### PR TITLE
Support lighting-only skies

### DIFF
--- a/examples/physics.html
+++ b/examples/physics.html
@@ -28,7 +28,10 @@
                 registerScript(OrbitCamera, 'orbitCamera');
                 registerScript(OrbitCameraInputMouse, 'orbitCameraInputMouse');
             </script>
+            <pc-asset id="helipad" src="assets/helipad-env-atlas.png" preload></pc-asset>
+            <pc-asset id="cube" src="assets/playcanvas-cube.glb" preload></pc-asset>
             <pc-scene>
+                <pc-sky asset="helipad" solid-color></pc-sky>
                 <!-- Camera -->
                 <pc-entity name="camera" position="0,1,5">
                     <pc-camera clear-color="#222222"></pc-camera>
@@ -47,17 +50,22 @@
                         <pc-script name="grid"></pc-script>
                     </pc-scripts>
                 </pc-entity>
-                <!-- Ball -->
-                <pc-entity name="ball" position="0,3,0">
-                    <pc-render type="sphere" cast-shadows></pc-render>
+                <!-- Box 1 -->
+                <pc-entity name="box1" position="0,4,0">
+                    <pc-model asset="cube"></pc-model>
                     <pc-rigidbody type="dynamic" restitution="0.9"></pc-rigidbody>
-                    <pc-collision type="sphere"></pc-collision>
-                </pc-entity>
-                <!-- Ground -->
-                <pc-entity name="ground" position="0,0.5,0">
-                    <pc-render type="box"></pc-render>
-                    <pc-rigidbody restitution="0.9"></pc-rigidbody>
                     <pc-collision></pc-collision>
+                </pc-entity>
+                <!-- Box 2 -->
+                <pc-entity name="box2" position="0,2,0">
+                    <pc-model asset="cube"></pc-model>
+                    <pc-rigidbody type="dynamic" restitution="0.9"></pc-rigidbody>
+                    <pc-collision></pc-collision>
+                </pc-entity>
+                <!-- Plane -->
+                <pc-entity name="plane" position="0,-0.5,0">
+                    <pc-rigidbody></pc-rigidbody>
+                    <pc-collision half-extents="100,0.5,100"></pc-collision>
                 </pc-entity>
             </pc-scene>
         </pc-app>

--- a/src/components/collision-component.ts
+++ b/src/components/collision-component.ts
@@ -1,6 +1,7 @@
-import { CollisionComponent } from 'playcanvas';
+import { CollisionComponent, Vec3 } from 'playcanvas';
 
 import { ComponentElement } from './component';
+import { parseVec3 } from '../utils';
 
 /**
  * Represents a collision component in the PlayCanvas engine.
@@ -11,6 +12,8 @@ class CollisionComponentElement extends ComponentElement {
     private _axis: number = 1;
 
     private _convexHull: boolean = false;
+
+    private _halfExtents: Vec3 = new Vec3(0.5, 0.5, 0.5);
 
     private _height: number = 2;
 
@@ -29,6 +32,7 @@ class CollisionComponentElement extends ComponentElement {
         return {
             axis: this._axis,
             convexHull: this._convexHull,
+            halfExtents: this._halfExtents,
             height: this._height,
             radius: this._radius,
             type: this._type
@@ -65,6 +69,17 @@ class CollisionComponentElement extends ComponentElement {
         return this._convexHull;
     }
 
+    set halfExtents(value: Vec3) {
+        this._halfExtents = value;
+        if (this.component) {
+            this.component.halfExtents = value;
+        }
+    }
+
+    get halfExtents() {
+        return this._halfExtents;
+    }
+
     set height(value: number) {
         this._height = value;
         if (this.component) {
@@ -99,7 +114,7 @@ class CollisionComponentElement extends ComponentElement {
     }
 
     static get observedAttributes() {
-        return [...super.observedAttributes, 'axis', 'convex-hull', 'height', 'radius', 'type'];
+        return [...super.observedAttributes, 'axis', 'convex-hull', 'half-extents', 'height', 'radius', 'type'];
     }
 
     attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
@@ -111,6 +126,9 @@ class CollisionComponentElement extends ComponentElement {
                 break;
             case 'convex-hull':
                 this.convexHull = this.hasAttribute('convex-hull');
+                break;
+            case 'half-extents':
+                this.halfExtents = parseVec3(newValue);
                 break;
             case 'height':
                 this.height = parseFloat(newValue);

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -1,4 +1,4 @@
-import { Quat } from 'playcanvas';
+import { LAYERID_SKYBOX, Quat } from 'playcanvas';
 
 import { AppElement } from './app';
 import { AssetElement } from './asset';
@@ -15,6 +15,8 @@ class SkyElement extends HTMLElement {
 
     private _level = 0;
 
+    private _solidColor = false;
+
     async connectedCallback() {
         // Get the application
         const appElement = this.closest('pc-app') as AppElement;
@@ -26,6 +28,7 @@ class SkyElement extends HTMLElement {
         await appElement.getApplication();
 
         this.asset = this.getAttribute('asset') || '';
+        this.solidColor = this.hasAttribute('solid-color');
     }
 
     getAsset() {
@@ -90,6 +93,21 @@ class SkyElement extends HTMLElement {
         return this._rotation;
     }
 
+    set solidColor(value: boolean) {
+        this._solidColor = value;
+        const scene = this.getScene();
+        if (scene) {
+            const layer = scene.layers.getLayerById(LAYERID_SKYBOX);
+            if (layer) {
+                layer.enabled = !this._solidColor;
+            }
+        }
+    }
+
+    get solidColor() {
+        return this._solidColor;
+    }
+
     set level(value: number) {
         this._level = value;
         const scene = this.getScene();
@@ -103,7 +121,7 @@ class SkyElement extends HTMLElement {
     }
 
     static get observedAttributes() {
-        return ['asset', 'intensity', 'level', 'rotation'];
+        return ['asset', 'intensity', 'level', 'rotation', 'solid-color'];
     }
 
     attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
@@ -119,6 +137,9 @@ class SkyElement extends HTMLElement {
                 break;
             case 'level':
                 this.level = parseInt(newValue, 10);
+                break;
+            case 'solid-color':
+                this.solidColor = this.hasAttribute('solid-color');
                 break;
         }
     }


### PR DESCRIPTION
Allow for the disabling of the rendering of the sky envAtlas and just use it for scene lighting.