### PR TITLE
Expose more attributes on pc-camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,21 @@ The `pc-camera` tag is used to define a camera component. It must be a direct ch
 
 | Attribute | Description |
 | --- | --- |
-| `clear-color` | The background color of the camera. Can be a comma-separated list of R, G, B, and A values or a hex color code. If not specified, `1,1,1,1` is used. |
-| `far-clip` | The far clipping plane of the camera. If not specified, `1000` is used. |
-| `fov` | The field of view of the camera. If not specified, `45` is used. |
-| `near-clip` | The near clipping plane of the camera. If not specified, `0.1` is used. |
-| `orthographic` | Valueless attribute. If present, the camera uses an orthographic projection. |
-| `ortho-height` | The height of the orthographic projection. If not specified, `10` is used. |
+| `clear-color` | The background color of the camera. Can be a comma-separated list of R, G, B, and A values or a hex color code. If unspecified, `0.75,0.75,0.75,1` is used. |
+| `clear-color-buffer` | Boolean attribute. Controls whether the camera clears the color buffer. If unspecified, the color buffer is cleared. |
+| `clear-depth-buffer` | Boolean attribute. Controls whether the camera clears the depth buffer. If unspecified, the depth buffer is cleared. |
+| `clear-stencil-buffer` | Boolean attribute. Controls whether the camera clears the stencil buffer. If unspecified, the stencil buffer is cleared. |
+| `cull-faces` | Boolean attribute. Controls whether the camera culls faces. If unspecified, faces are culled. |
+| `far-clip` | The far clipping plane of the camera. If unspecified, `1000` is used. |
+| `flip-faces` | Boolean attribute. Controls whether the camera flips faces. If unspecified, faces are not flipped. |
+| `fov` | The field of view of the camera. If unspecified, `45` is used. |
+| `frustum-culling` | Boolean attribute. Controls whether the camera uses frustum culling. If unspecified, frustum culling is used. |
+| `near-clip` | The near clipping plane of the camera. If unspecified, `0.1` is used. |
+| `orthographic` | Valueless attribute. If present, the camera uses an orthographic projection. If unspecified, the camera uses a perspective projection. |
+| `ortho-height` | The height of the orthographic projection. If unspecified, `10` is used. |
+| `priority` | The priority of the camera. If unspecified, `0` is used. |
+| `rect` | The viewport rectangle of the camera. Specified as a comma-separated list of X, Y, Width, and Height values. If unspecified, `0,0,1,1` is used. |
+| `scissor-rect` | The scissor rectangle of the camera. Specified as a comma-separated list of X, Y, Width, and Height values. If not specified, `0,0,1,1` is used. |
 
 ### pc-collision
 

--- a/src/components/camera-component.ts
+++ b/src/components/camera-component.ts
@@ -1,7 +1,7 @@
-import { PROJECTION_ORTHOGRAPHIC, PROJECTION_PERSPECTIVE, CameraComponent, Color } from 'playcanvas';
+import { PROJECTION_ORTHOGRAPHIC, PROJECTION_PERSPECTIVE, CameraComponent, Color, Vec4 } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseColor } from '../utils';
+import { parseColor, parseVec4 } from '../utils';
 
 /**
  * Represents a camera component in the PlayCanvas engine.
@@ -9,17 +9,35 @@ import { parseColor } from '../utils';
  * @category Components
  */
 class CameraComponentElement extends ComponentElement {
-    private _clearColor = new Color(1, 1, 1, 1);
+    private _clearColor = new Color(0.75, 0.75, 0.75, 1);
+
+    private _clearColorBuffer = true;
+
+    private _clearDepthBuffer = true;
+
+    private _clearStencilBuffer = false;
+
+    private _cullFaces = true;
 
     private _farClip = 1000;
 
+    private _flipFaces = false;
+
     private _fov = 45;
+
+    private _frustumCulling = true;
 
     private _nearClip = 0.1;
 
     private _orthographic = false;
 
     private _orthoHeight = 10;
+
+    private _priority = 0;
+
+    private _rect = new Vec4(0, 0, 1, 1);
+
+    private _scissorRect = new Vec4(0, 0, 1, 1);
 
     /**
      * Creates a new CameraComponentElement.
@@ -31,11 +49,20 @@ class CameraComponentElement extends ComponentElement {
     getInitialComponentData() {
         return {
             clearColor: this._clearColor,
+            clearColorBuffer: this._clearColorBuffer,
+            clearDepthBuffer: this._clearDepthBuffer,
+            clearStencilBuffer: this._clearStencilBuffer,
+            cullFaces: this._cullFaces,
             farClip: this._farClip,
+            flipFaces: this._flipFaces,
             fov: this._fov,
+            frustumCulling: this._frustumCulling,
             nearClip: this._nearClip,
-            projection: this._orthographic ? PROJECTION_ORTHOGRAPHIC : PROJECTION_PERSPECTIVE,
-            orthoHeight: this._orthoHeight
+            orthographic: this._orthographic,
+            orthoHeight: this._orthoHeight,
+            priority: this._priority,
+            rect: this._rect,
+            scissorRect: this._scissorRect
         };
     }
 
@@ -67,6 +94,82 @@ class CameraComponentElement extends ComponentElement {
     }
 
     /**
+     * Sets the clear color buffer of the camera.
+     * @param value - The clear color buffer.
+     */
+    set clearColorBuffer(value: boolean) {
+        this._clearColorBuffer = value;
+        if (this.component) {
+            this.component.clearColorBuffer = value;
+        }
+    }
+
+    /**
+     * Gets the clear color buffer of the camera.
+     * @returns The clear color buffer.
+     */
+    get clearColorBuffer(): boolean {
+        return this._clearColorBuffer;
+    }
+
+    /**
+     * Sets the clear depth buffer of the camera.
+     * @param value - The clear depth buffer.
+     */
+    set clearDepthBuffer(value: boolean) {
+        this._clearDepthBuffer = value;
+        if (this.component) {
+            this.component.clearDepthBuffer = value;
+        }
+    }
+
+    /**
+     * Gets the clear depth buffer of the camera.
+     * @returns The clear depth buffer.
+     */
+    get clearDepthBuffer(): boolean {
+        return this._clearDepthBuffer;
+    }
+
+    /**
+     * Sets the clear stencil buffer of the camera.
+     * @param value - The clear stencil buffer.
+     */
+    set clearStencilBuffer(value: boolean) {
+        this._clearStencilBuffer = value;
+        if (this.component) {
+            this.component.clearStencilBuffer = value;
+        }
+    }
+
+    /**
+     * Gets the clear stencil buffer of the camera.
+     * @returns The clear stencil buffer.
+     */
+    get clearStencilBuffer(): boolean {
+        return this._clearStencilBuffer;
+    }
+
+    /** 
+     * Sets the cull faces of the camera.
+     * @param value - The cull faces.
+     */
+    set cullFaces(value: boolean) {
+        this._cullFaces = value;
+        if (this.component) {
+            this.component.cullFaces = value;
+        }
+    }
+
+    /**
+     * Gets the cull faces of the camera.
+     * @returns The cull faces.
+     */
+    get cullFaces(): boolean {
+        return this._cullFaces;
+    }
+
+    /**
      * Sets the far clip distance of the camera.
      * @param value - The far clip distance.
      */
@@ -86,6 +189,25 @@ class CameraComponentElement extends ComponentElement {
     }
 
     /**
+     * Sets the flip faces of the camera.
+     * @param value - The flip faces.
+     */
+    set flipFaces(value: boolean) {
+        this._flipFaces = value;
+        if (this.component) {
+            this.component.flipFaces = value;
+        }
+    }
+
+    /**
+     * Gets the flip faces of the camera.
+     * @returns The flip faces.
+     */
+    get flipFaces(): boolean {
+        return this._flipFaces;
+    }
+
+    /**
      * Sets the field of view of the camera.
      * @param value - The field of view.
      */
@@ -102,6 +224,25 @@ class CameraComponentElement extends ComponentElement {
      */
     get fov(): number {
         return this._fov;
+    }
+
+    /**
+     * Sets the frustum culling of the camera.
+     * @param value - The frustum culling.
+     */
+    set frustumCulling(value: boolean) {
+        this._frustumCulling = value;
+        if (this.component) {
+            this.component.frustumCulling = value;
+        }
+    }
+
+    /**
+     * Gets the frustum culling of the camera.
+     * @returns The frustum culling.
+     */
+    get frustumCulling(): boolean {
+        return this._frustumCulling;
     }
 
     /**
@@ -161,8 +302,82 @@ class CameraComponentElement extends ComponentElement {
         return this._orthoHeight;
     }
 
+    /**
+     * Sets the priority of the camera.
+     * @param value - The priority.
+     */
+    set priority(value: number) {
+        this._priority = value;
+        if (this.component) {
+            this.component.priority = value;
+        }
+    }
+
+    /**
+     * Gets the priority of the camera.
+     * @returns The priority.
+     */
+    get priority(): number {
+        return this._priority;
+    }
+
+    /**
+     * Sets the rect of the camera.
+     * @param value - The rect.
+     */
+    set rect(value: Vec4) {
+        this._rect = value;
+        if (this.component) {
+            this.component.rect = value;
+        }
+    }
+
+    /**
+     * Gets the rect of the camera.
+     * @returns The rect.
+     */
+    get rect(): Vec4 {
+        return this._rect;
+    }
+
+    /**
+     * Sets the scissor rect of the camera.
+     * @param value - The scissor rect.
+     */
+    set scissorRect(value: Vec4) {
+        this._scissorRect = value;
+        if (this.component) {
+            this.component.scissorRect = value;
+        }
+    }
+
+    /**
+     * Gets the scissor rect of the camera.
+     * @returns The scissor rect.
+     */
+    get scissorRect(): Vec4 {
+        return this._scissorRect;
+    }
+
     static get observedAttributes() {
-        return [...super.observedAttributes, 'clear-color', 'near-clip', 'far-clip', 'fov', 'orthographic', 'ortho-height'];
+        return [
+            ...super.observedAttributes,
+            'clear-color',
+            'clear-color-buffer',
+            'clear-depth-buffer',
+            'clear-stencil-buffer',
+            'cull-faces',
+            'far-clip',
+            'flip-faces',
+            'fov',
+            'frustum-culling',
+            'near-clip',
+            'orthographic',
+            'ortho-height',
+            'priority',
+            'rect',
+            'scissor-rect'
+        ];
     }
 
     attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
@@ -172,11 +387,29 @@ class CameraComponentElement extends ComponentElement {
             case 'clear-color':
                 this.clearColor = parseColor(newValue);
                 break;
+            case 'clear-color-buffer':
+                this.clearColorBuffer = newValue !== 'false';
+                break;
+            case 'clear-depth-buffer':
+                this.clearDepthBuffer = newValue !== 'false';
+                break;
+            case 'clear-stencil-buffer':
+                this.clearStencilBuffer = newValue !== 'false';
+                break;
+            case 'cull-faces':
+                this.cullFaces = newValue !== 'false';
+                break;
             case 'far-clip':
                 this.farClip = parseFloat(newValue);
                 break;
+            case 'flip-faces':
+                this.flipFaces = newValue !== 'true';
+                break;
             case 'fov':
                 this.fov = parseFloat(newValue);
+                break;
+            case 'frustum-culling':
+                this.frustumCulling = newValue !== 'false';
                 break;
             case 'near-clip':
                 this.nearClip = parseFloat(newValue);
@@ -186,6 +419,15 @@ class CameraComponentElement extends ComponentElement {
                 break;
             case 'ortho-height':
                 this.orthoHeight = parseFloat(newValue);
+                break;
+            case 'priority':
+                this.priority = parseFloat(newValue);
+                break;
+            case 'rect':
+                this.rect = parseVec4(newValue);
+                break;
+            case 'scissor-rect':
+                this.scissorRect = parseVec4(newValue);
                 break;
         }
     }


### PR DESCRIPTION
Adds support for:

* `clear-color-buffer`
* `clear-depth-buffer`
* `clear-stencil-buffer`
* `cull-faces`
* `flip-faces`
* `frustum-culling`
* `priority`
* `rect`
* `scissor-rect`