### PR TITLE
Allow model elements to be streamed

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,6 +31,7 @@ export default [
         },
         rules: {
             ...tsPlugin.configs['recommended'].rules,
+            '@typescript-eslint/ban-ts-comment': 'off',
             '@typescript-eslint/no-explicit-any': 'off',
             '@typescript-eslint/no-unused-vars': 'off',
             'jsdoc/require-param-type': 'off',

--- a/examples/scripts/planetary-camera.mjs
+++ b/examples/scripts/planetary-camera.mjs
@@ -9,8 +9,8 @@ export class PlanetaryCamera extends Script {
             ['venus', new Vec3(-20, 10, 10)],     
             ['earth', new Vec3(-20, 10, 10)],     
             ['mars', new Vec3(-12, 6, 6)],        
-            ['jupiter', new Vec3(-90, 60, 60)],   
-            ['saturn', new Vec3(-80, 55, 55)],    
+            ['jupiter', new Vec3(-90, 30, 60)],   
+            ['saturn', new Vec3(-80, 35, 55)],    
             ['uranus', new Vec3(-40, 30, 30)],    
             ['neptune', new Vec3(-40, 30, 30)]    
         ]);

--- a/examples/scripts/planetary-motion.mjs
+++ b/examples/scripts/planetary-motion.mjs
@@ -1,4 +1,4 @@
-import { Script, Vec3 } from 'playcanvas';
+import { Script } from 'playcanvas';
 
 export class PlanetaryMotion extends Script {
     initialize() {
@@ -76,8 +76,10 @@ export class PlanetaryMotion extends Script {
     update(dt) {
         const sun = this.planets.get('sun');
         const render = sun.findComponent('render');
-        const material = render.meshInstances[0].material;
-        material.emissiveIntensity = 100;
+        if (render) {
+            const material = render.meshInstances[0].material;
+            material.emissiveIntensity = 100;
+        }
 
         // Update each planet's position and rotation
         for (const [planet, entity] of this.planets) {
@@ -101,7 +103,20 @@ export class PlanetaryMotion extends Script {
             const z = Math.sin(angle) * distance;
             
             entity.setLocalPosition(x, 0, z);
-            entity.rotate(0, this.rotationSpeeds.get(planet) * dt * 30, 0);
+
+            // Special case for Saturn to keep rings tilted correctly
+            if (planet === 'saturn') {
+                // Set rotation so rings always tilt up relative to the sun
+                const tiltAngle = Math.PI / 12; // 30-degree tilt
+                entity.setLocalEulerAngles(
+                    tiltAngle * 180 / Math.PI,  // Convert to degrees
+                    (this.rotationSpeeds.get(planet) * dt * 30) + (angle * 180 / Math.PI),
+                    0
+                );
+            } else {
+                // Normal rotation for other planets
+                entity.rotate(0, this.rotationSpeeds.get(planet) * dt * 30, 0);
+            }
         }
     }
 }

--- a/examples/solar-system.html
+++ b/examples/solar-system.html
@@ -13,7 +13,10 @@
         </script>
         <script type="module" src="../dist/pwc.mjs"></script>
         <style>
-            body { margin: 0; }
+            body { 
+                margin: 0; 
+                background-color: black;
+            }
             
             #canvas-container {
                 position: fixed;
@@ -60,14 +63,14 @@
                 <pc-asset id="planetary-motion" src="scripts/planetary-motion.mjs" preload></pc-asset>
                 <pc-asset id="stars" src="assets/sky/stars.png" preload></pc-asset>
                 <pc-asset id="sun" src="assets/models/planets/sun.glb" preload></pc-asset>
-                <pc-asset id="mercury" src="assets/models/planets/mercury.glb" preload></pc-asset>
-                <pc-asset id="venus" src="assets/models/planets/venus.glb" preload></pc-asset>
-                <pc-asset id="earth" src="assets/models/planets/earth.glb" preload></pc-asset>
-                <pc-asset id="mars" src="assets/models/planets/mars.glb" preload></pc-asset>
-                <pc-asset id="jupiter" src="assets/models/planets/jupiter.glb" preload></pc-asset>
-                <pc-asset id="saturn" src="assets/models/planets/saturn.glb" preload></pc-asset>
-                <pc-asset id="uranus" src="assets/models/planets/uranus.glb" preload></pc-asset>
-                <pc-asset id="neptune" src="assets/models/planets/neptune.glb" preload></pc-asset>
+                <pc-asset id="mercury" src="assets/models/planets/mercury.glb"></pc-asset>
+                <pc-asset id="venus" src="assets/models/planets/venus.glb"></pc-asset>
+                <pc-asset id="earth" src="assets/models/planets/earth.glb"></pc-asset>
+                <pc-asset id="mars" src="assets/models/planets/mars.glb"></pc-asset>
+                <pc-asset id="jupiter" src="assets/models/planets/jupiter.glb"></pc-asset>
+                <pc-asset id="saturn" src="assets/models/planets/saturn.glb"></pc-asset>
+                <pc-asset id="uranus" src="assets/models/planets/uranus.glb"></pc-asset>
+                <pc-asset id="neptune" src="assets/models/planets/neptune.glb"></pc-asset>
                 <!-- Scene -->
                 <pc-scene>
                     <!-- Sky -->


### PR DESCRIPTION
You can now safely remove `preload` from container assets.