### PR TITLE
Create all entities before creating components

### DIFF
--- a/examples/scripts/material-variants.mjs
+++ b/examples/scripts/material-variants.mjs
@@ -1,5 +1,7 @@
 document.addEventListener('DOMContentLoaded', async () => {
-    const entityElement = await document.querySelector('pc-entity[name="shoe"]').ready();
+    await document.querySelector('pc-app').ready();
+
+    const entityElement = document.querySelector('pc-entity[name="shoe"]');
     const assetElement = document.querySelector('pc-asset#shoe');
 
     if (entityElement && assetElement) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,9 +2,9 @@ import { Application, FILLMODE_FILL_WINDOW, Keyboard, Mouse, RESOLUTION_AUTO } f
 
 import { AssetElement } from './asset';
 import { AsyncElement } from './async-element';
+import { EntityElement } from './entity';
 import { MaterialElement } from './material';
 import { ModuleElement } from './module';
-import { EntityElement } from './entity';
 
 /**
  * The main application element.

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import { AssetElement } from './asset';
 import { AsyncElement } from './async-element';
 import { MaterialElement } from './material';
 import { ModuleElement } from './module';
+import { EntityElement } from './entity';
 
 /**
  * The main application element.
@@ -23,6 +24,8 @@ class AppElement extends AsyncElement {
     private _stencil = true;
 
     private _highResolution = false;
+
+    private _hierarchyReady = false;
 
     /**
      * The PlayCanvas application instance.
@@ -83,6 +86,19 @@ class AppElement extends AsyncElement {
         Array.from(materialElements).forEach((materialElement) => {
             materialElement.createMaterial();
         });
+
+        // Create all entities
+        const entityElements = this.querySelectorAll<EntityElement>('pc-entity');
+        Array.from(entityElements).forEach((entityElement) => {
+            entityElement.createEntity(this.app!);
+        });
+
+        // Build hierarchy
+        entityElements.forEach((entityElement) => {
+            entityElement.buildHierarchy(this.app!);
+        });
+
+        this._hierarchyReady = true;
 
         // Load assets before starting the application
         this.app.preload(() => {
@@ -165,6 +181,15 @@ class AppElement extends AsyncElement {
      */
     get depth() {
         return this._depth;
+    }
+
+    /**
+     * Gets the hierarchy ready flag.
+     * @returns The hierarchy ready flag.
+     * @ignore
+     */
+    get hierarchyReady() {
+        return this._hierarchyReady;
     }
 
     /**

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Vec3 } from 'playcanvas';
+import { Application, Entity, Vec3 } from 'playcanvas';
 
 import { AsyncElement } from './async-element';
 import { parseVec3 } from './utils';
@@ -44,53 +44,65 @@ class EntityElement extends AsyncElement {
      */
     entity: Entity | null = null;
 
-    async connectedCallback() {
-        const closestApp = this.closestApp;
-        if (!closestApp) return;
-
-        // Wait for the app to complete initialization
-        await closestApp.ready();
-
-        const app = closestApp.app!;
-
+    // Add new method to create entity
+    createEntity(app: Application) {
         // Create a new entity
         this.entity = new Entity(this._name, app);
 
         // Initialize from attributes
-        const enabledAttr = this.getAttribute('enabled');
-        const nameAttr = this.getAttribute('name');
-        const positionAttr = this.getAttribute('position');
-        const rotationAttr = this.getAttribute('rotation');
-        const scaleAttr = this.getAttribute('scale');
-        const tagsAttr = this.getAttribute('tags');
+        if (this._enabled !== true) this.entity.enabled = this._enabled;
+        this.entity.setLocalPosition(this._position);
+        this.entity.setLocalEulerAngles(this._rotation);
+        this.entity.setLocalScale(this._scale);
+        if (this._tags.length > 0) {
+            this.entity.tags.add(this._tags);
+        }
+    }
 
-        if (enabledAttr) this.enabled = enabledAttr !== 'false';
-        if (nameAttr) this.name = nameAttr;
-        if (positionAttr) this.position = parseVec3(positionAttr);
-        if (rotationAttr) this.rotation = parseVec3(rotationAttr);
-        if (scaleAttr) this.scale = parseVec3(scaleAttr);
-        if (tagsAttr) this.tags = tagsAttr.split(',').map(tag => tag.trim());
+    buildHierarchy(app: Application) {
+        if (!this.entity) return;
 
         const closestEntity = this.closestEntity;
-        if (closestEntity) {
-            closestEntity.ready().then(() => {
-                closestEntity.entity!.addChild(this.entity!);
-                this._onReady();
-            });
+        if (closestEntity?.entity) {
+            closestEntity.entity.addChild(this.entity);
         } else {
             app.root.addChild(this.entity);
-            this._onReady();
+        }
+
+        this._onReady();
+    }
+
+    connectedCallback() {
+        // Wait for app to be ready
+        const closestApp = this.closestApp;
+        if (!closestApp) return;
+
+        // If app is already running, create entity immediately
+        if (closestApp.hierarchyReady) {
+            const app = closestApp.app!;
+
+            this.createEntity(app);
+            this.buildHierarchy(app);
+
+            // Handle any child entities that might exist
+            const childEntities = this.querySelectorAll<EntityElement>('pc-entity');
+            childEntities.forEach(child => {
+                child.createEntity(app);
+            });
+            childEntities.forEach(child => {
+                child.buildHierarchy(app);
+            });
         }
     }
 
     disconnectedCallback() {
         if (this.entity) {
-            // Notify all children that their entities are about to become invalid
-            const children = this.querySelectorAll('pc-entity');
-            children.forEach((child) => {
-                (child as EntityElement).entity = null;
-            });
+            // Remove from hierarchy
+            if (this.entity.parent) {
+                this.entity.parent.removeChild(this.entity);
+            }
 
+            // Destroy the entity
             this.entity.destroy();
             this.entity = null;
         }

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -46,23 +46,27 @@ class EntityElement extends AsyncElement {
 
     createEntity(app: Application) {
         // Create a new entity
-        this.entity = new Entity(
-            this.getAttribute('name') || this._name,
-            app
-        );
+        this.entity = new Entity(this.getAttribute('name') || this._name, app);
 
-        // Initialize from attributes first, falling back to member variable defaults
         const enabled = this.getAttribute('enabled');
-        this.entity.enabled = enabled !== null ? enabled !== 'false' : this._enabled;
+        if (enabled) {
+            this.entity.enabled = enabled !== 'false';
+        }
 
         const position = this.getAttribute('position');
-        this.entity.setLocalPosition(position ? parseVec3(position) : this._position);
+        if (position) {
+            this.entity.setLocalPosition(parseVec3(position));
+        }
 
         const rotation = this.getAttribute('rotation');
-        this.entity.setLocalEulerAngles(rotation ? parseVec3(rotation) : this._rotation);
+        if (rotation) {
+            this.entity.setLocalEulerAngles(parseVec3(rotation));
+        }
 
         const scale = this.getAttribute('scale');
-        this.entity.setLocalScale(scale ? parseVec3(scale) : this._scale);
+        if (scale) {
+            this.entity.setLocalScale(parseVec3(scale));
+        }
 
         const tags = this.getAttribute('tags');
         if (tags) {

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -86,10 +86,10 @@ class EntityElement extends AsyncElement {
 
             // Handle any child entities that might exist
             const childEntities = this.querySelectorAll<EntityElement>('pc-entity');
-            childEntities.forEach(child => {
+            childEntities.forEach((child) => {
                 child.createEntity(app);
             });
-            childEntities.forEach(child => {
+            childEntities.forEach((child) => {
                 child.buildHierarchy(app);
             });
         }

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -97,10 +97,11 @@ class EntityElement extends AsyncElement {
 
     disconnectedCallback() {
         if (this.entity) {
-            // Remove from hierarchy
-            if (this.entity.parent) {
-                this.entity.parent.removeChild(this.entity);
-            }
+            // Notify all children that their entities are about to become invalid
+            const children = this.querySelectorAll('pc-entity');
+            children.forEach((child) => {
+                (child as EntityElement).entity = null;
+            });
 
             // Destroy the entity
             this.entity.destroy();

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -44,18 +44,29 @@ class EntityElement extends AsyncElement {
      */
     entity: Entity | null = null;
 
-    // Add new method to create entity
     createEntity(app: Application) {
         // Create a new entity
-        this.entity = new Entity(this._name, app);
+        this.entity = new Entity(
+            this.getAttribute('name') || this._name,
+            app
+        );
 
-        // Initialize from attributes
-        if (this._enabled !== true) this.entity.enabled = this._enabled;
-        this.entity.setLocalPosition(this._position);
-        this.entity.setLocalEulerAngles(this._rotation);
-        this.entity.setLocalScale(this._scale);
-        if (this._tags.length > 0) {
-            this.entity.tags.add(this._tags);
+        // Initialize from attributes first, falling back to member variable defaults
+        const enabled = this.getAttribute('enabled');
+        this.entity.enabled = enabled !== null ? enabled !== 'false' : this._enabled;
+
+        const position = this.getAttribute('position');
+        this.entity.setLocalPosition(position ? parseVec3(position) : this._position);
+
+        const rotation = this.getAttribute('rotation');
+        this.entity.setLocalEulerAngles(rotation ? parseVec3(rotation) : this._rotation);
+
+        const scale = this.getAttribute('scale');
+        this.entity.setLocalScale(scale ? parseVec3(scale) : this._scale);
+
+        const tags = this.getAttribute('tags');
+        if (tags) {
+            this.entity.tags.add(tags.split(',').map(tag => tag.trim()));
         }
     }
 


### PR DESCRIPTION
This ensures that scripts do no initialize before the hierarchy is constructed (which can result in `Entity#findByName` failing, for example).