### PR TITLE
Add support for pointer events to pc-entity

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,7 +18,10 @@ export default [
         languageOptions: {
             parser: tsParser,
             globals: {
-                ...globals.browser
+                ...globals.browser,
+                AddEventListenerOptions: true,
+                EventListener: true,
+                EventListenerOptions: true
             }
         },
         plugins: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,9 +19,9 @@ export default [
             parser: tsParser,
             globals: {
                 ...globals.browser,
-                AddEventListenerOptions: true,
-                EventListener: true,
-                EventListenerOptions: true
+                AddEventListenerOptions: "readonly",
+                EventListener: "readonly",
+                EventListenerOptions: "readonly"
             }
         },
         plugins: {

--- a/examples/shapes.html
+++ b/examples/shapes.html
@@ -46,27 +46,45 @@
                     <pc-light></pc-light>
                 </pc-entity>
                 <!-- Box-->
-                <pc-entity name="box" position="-1.2 1 0">
+                <pc-entity name="box" position="-1.2 1 0"
+                    onpointerenter="this.setAttribute('scale', '1.2 1.2 1.2')"
+                    onpointerleave="this.setAttribute('scale', '1 1 1')"
+                    onpointerdown="this.setAttribute('position', '-1.2 2 0')">
                     <pc-render type="box" material="metal"></pc-render>
                 </pc-entity>
                 <!-- Capsule -->
-                <pc-entity name="capsule" position="0 1 0">
+                <pc-entity name="capsule" position="0 1 0"
+                    onpointerenter="this.setAttribute('scale', '1.2 1.2 1.2')"
+                    onpointerleave="this.setAttribute('scale', '1 1 1')"
+                    onpointerdown="this.setAttribute('position', '0 2 0')">
                     <pc-render type="capsule" material="metal"></pc-render>
                 </pc-entity>
                 <!-- Cone -->
-                <pc-entity name="cone" position="1.2 1 0">
+                <pc-entity name="cone" position="1.2 1 0"
+                    onpointerenter="this.setAttribute('scale', '1.2 1.2 1.2')"
+                    onpointerleave="this.setAttribute('scale', '1 1 1')"
+                    onpointerdown="this.setAttribute('position', '1.2 2 0')">
                     <pc-render type="cone" material="metal"></pc-render>
                 </pc-entity>
                 <!-- Cylinder -->
-                <pc-entity name="cylinder" position="-1.2 -1 0">
+                <pc-entity name="cylinder" position="-1.2 -1 0"
+                    onpointerenter="this.setAttribute('scale', '1.2 1.2 1.2')"
+                    onpointerleave="this.setAttribute('scale', '1 1 1')"
+                    onpointerdown="this.setAttribute('position', '-1.2 -2 0')">
                     <pc-render type="cylinder" material="metal"></pc-render>
                 </pc-entity>
                 <!-- Plane -->
-                <pc-entity name="plane" position="0 -1 0">
+                <pc-entity name="plane" position="0 -1 0"
+                    onpointerenter="this.setAttribute('scale', '1.2 1.2 1.2')"
+                    onpointerleave="this.setAttribute('scale', '1 1 1')"
+                    onpointerdown="this.setAttribute('position', '0 -2 0')">
                     <pc-render type="plane" material="metal"></pc-render>
                 </pc-entity>
                 <!-- Sphere -->
-                <pc-entity name="sphere" position="1.2 -1 0">
+                <pc-entity name="sphere" position="1.2 -1 0"
+                    onpointerenter="this.setAttribute('scale', '1.2 1.2 1.2')"
+                    onpointerleave="this.setAttribute('scale', '1 1 1')"
+                    onpointerdown="this.setAttribute('position', '1.2 -2 0')">
                     <pc-render type="sphere" material="metal"></pc-render>
                 </pc-entity>
             </pc-scene>

--- a/examples/shapes.html
+++ b/examples/shapes.html
@@ -46,45 +46,27 @@
                     <pc-light></pc-light>
                 </pc-entity>
                 <!-- Box-->
-                <pc-entity name="box" position="-1.2 1 0"
-                    onpointerenter="this.setAttribute('scale', '1.2 1.2 1.2')"
-                    onpointerleave="this.setAttribute('scale', '1 1 1')"
-                    onpointerdown="this.setAttribute('position', '-1.2 2 0')">
+                <pc-entity name="box" position="-1.2 1 0">
                     <pc-render type="box" material="metal"></pc-render>
                 </pc-entity>
                 <!-- Capsule -->
-                <pc-entity name="capsule" position="0 1 0"
-                    onpointerenter="this.setAttribute('scale', '1.2 1.2 1.2')"
-                    onpointerleave="this.setAttribute('scale', '1 1 1')"
-                    onpointerdown="this.setAttribute('position', '0 2 0')">
+                <pc-entity name="capsule" position="0 1 0">
                     <pc-render type="capsule" material="metal"></pc-render>
                 </pc-entity>
                 <!-- Cone -->
-                <pc-entity name="cone" position="1.2 1 0"
-                    onpointerenter="this.setAttribute('scale', '1.2 1.2 1.2')"
-                    onpointerleave="this.setAttribute('scale', '1 1 1')"
-                    onpointerdown="this.setAttribute('position', '1.2 2 0')">
+                <pc-entity name="cone" position="1.2 1 0">
                     <pc-render type="cone" material="metal"></pc-render>
                 </pc-entity>
                 <!-- Cylinder -->
-                <pc-entity name="cylinder" position="-1.2 -1 0"
-                    onpointerenter="this.setAttribute('scale', '1.2 1.2 1.2')"
-                    onpointerleave="this.setAttribute('scale', '1 1 1')"
-                    onpointerdown="this.setAttribute('position', '-1.2 -2 0')">
+                <pc-entity name="cylinder" position="-1.2 -1 0">
                     <pc-render type="cylinder" material="metal"></pc-render>
                 </pc-entity>
                 <!-- Plane -->
-                <pc-entity name="plane" position="0 -1 0"
-                    onpointerenter="this.setAttribute('scale', '1.2 1.2 1.2')"
-                    onpointerleave="this.setAttribute('scale', '1 1 1')"
-                    onpointerdown="this.setAttribute('position', '0 -2 0')">
+                <pc-entity name="plane" position="0 -1 0">
                     <pc-render type="plane" material="metal"></pc-render>
                 </pc-entity>
                 <!-- Sphere -->
-                <pc-entity name="sphere" position="1.2 -1 0"
-                    onpointerenter="this.setAttribute('scale', '1.2 1.2 1.2')"
-                    onpointerleave="this.setAttribute('scale', '1 1 1')"
-                    onpointerdown="this.setAttribute('position', '1.2 -2 0')">
+                <pc-entity name="sphere" position="1.2 -1 0">
                     <pc-render type="sphere" material="metal"></pc-render>
                 </pc-entity>
             </pc-scene>

--- a/src/app.ts
+++ b/src/app.ts
@@ -160,14 +160,14 @@ class AppElement extends AsyncElement {
     _pickerCreate() {
         const { width, height } = this.app!.graphicsDevice;
         this._picker = new Picker(this.app!, width, height);
-        
+
         // Create bound handlers but don't attach them yet
         this._pointerHandlers.pointermove = this._onPointerMove.bind(this) as EventListener;
         this._pointerHandlers.pointerdown = this._onPointerDown.bind(this) as EventListener;
         this._pointerHandlers.pointerup = this._onPointerUp.bind(this) as EventListener;
 
         // Listen for pointer listeners being added/removed
-        ['pointermove', 'pointerdown', 'pointerup', 'pointerenter', 'pointerleave'].forEach(type => {
+        ['pointermove', 'pointerdown', 'pointerup', 'pointerenter', 'pointerleave'].forEach((type) => {
             this.addEventListener(`${type}:connect`, () => this._onPointerListenerAdded(type));
             this.addEventListener(`${type}:disconnect`, () => this._onPointerListenerRemoved(type));
         });
@@ -204,9 +204,9 @@ class AppElement extends AsyncElement {
         const selection = this._picker.getSelection(x, y);
 
         // Get the currently hovered entity (if any)
-        const newHoverEntity = selection.length > 0 
-            ? this.querySelector(`pc-entity[name="${selection[0].node.name}"]`) as EntityElement
-            : null;
+        const newHoverEntity = selection.length > 0 ?
+            this.querySelector(`pc-entity[name="${selection[0].node.name}"]`) as EntityElement :
+            null;
 
         // Handle enter/leave events
         if (this._hoveredEntity !== newHoverEntity) {
@@ -272,11 +272,11 @@ class AppElement extends AsyncElement {
     _onPointerListenerAdded(type: string) {
         if (!this._hasPointerListeners[type] && this._canvas) {
             this._hasPointerListeners[type] = true;
-            
+
             // For enter/leave events, we need the move handler
-            const handler = (type === 'pointerenter' || type === 'pointerleave') 
-                ? this._pointerHandlers.pointermove 
-                : this._pointerHandlers[type];
+            const handler = (type === 'pointerenter' || type === 'pointerleave') ?
+                this._pointerHandlers.pointermove :
+                this._pointerHandlers[type];
 
             if (handler) {
                 this._canvas.addEventListener(type === 'pointerenter' || type === 'pointerleave' ? 'pointermove' : type, handler);
@@ -286,14 +286,14 @@ class AppElement extends AsyncElement {
 
     _onPointerListenerRemoved(type: string) {
         const hasListeners = Array.from(this.querySelectorAll<EntityElement>('pc-entity'))
-            .some(entity => entity.hasListeners(type));
+        .some(entity => entity.hasListeners(type));
 
         if (!hasListeners && this._canvas) {
             this._hasPointerListeners[type] = false;
-            
-            const handler = (type === 'pointerenter' || type === 'pointerleave') 
-                ? this._pointerHandlers.pointermove 
-                : this._pointerHandlers[type];
+
+            const handler = (type === 'pointerenter' || type === 'pointerleave') ?
+                this._pointerHandlers.pointermove :
+                this._pointerHandlers[type];
 
             if (handler) {
                 this._canvas.removeEventListener(type === 'pointerenter' || type === 'pointerleave' ? 'pointermove' : type, handler);

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -40,11 +40,14 @@ class EntityElement extends AsyncElement {
     private _tags: string[] = [];
 
     /**
+     * The pointer event listeners for the entity.
+     */
+    private _listeners: { [key: string]: EventListener[] } = {};
+
+    /**
      * The PlayCanvas entity instance.
      */
     entity: Entity | null = null;
-
-    private _listeners: { [key: string]: EventListener[] } = {};
 
     createEntity(app: Application) {
         // Create a new entity
@@ -87,7 +90,16 @@ class EntityElement extends AsyncElement {
         pointerEvents.forEach((eventName) => {
             const handler = this.getAttribute(eventName);
             if (handler) {
-                this.addEventListener(eventName.substring(2), new Function('event', handler) as EventListener);
+                const eventType = eventName.substring(2); // remove 'on' prefix
+                const eventHandler = (event: Event) => {
+                    try {
+                        /* eslint-disable-next-line no-new-func */
+                        new Function('event', 'this', handler).call(this, event);
+                    } catch (e) {
+                        console.error('Error in event handler:', e);
+                    }
+                };
+                this.addEventListener(eventType, eventHandler);
             }
         });
     }
@@ -303,6 +315,7 @@ class EntityElement extends AsyncElement {
                     // Use Function.prototype.bind to avoid new Function
                     const handler = (event: Event) => {
                         try {
+                            /* eslint-disable-next-line no-new-func */
                             new Function('event', 'this', newValue).call(this, event);
                         } catch (e) {
                             console.error('Error in event handler:', e);

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -299,8 +299,16 @@ class EntityElement extends AsyncElement {
             case 'onpointerup':
             case 'onpointermove':
                 if (newValue) {
-                    const eventName = name.substring(2); // remove 'on' prefix
-                    this.addEventListener(eventName, new Function('event', newValue) as EventListener);
+                    const eventName = name.substring(2);
+                    // Use Function.prototype.bind to avoid new Function
+                    const handler = (event: Event) => {
+                        try {
+                            new Function('event', 'this', newValue).call(this, event);
+                        } catch (e) {
+                            console.error('Error in event handler:', e);
+                        }
+                    };
+                    this.addEventListener(eventName, handler);
                 }
                 break;
         }

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -84,7 +84,7 @@ class EntityElement extends AsyncElement {
             'onpointermove'
         ];
 
-        pointerEvents.forEach(eventName => {
+        pointerEvents.forEach((eventName) => {
             const handler = this.getAttribute(eventName);
             if (handler) {
                 this.addEventListener(eventName.substring(2), new Function('event', handler) as EventListener);


### PR DESCRIPTION
Add support for the following pointer events to the `pc-entity` element:

* `pointerdown`
* `pointerup`
* `pointermove`
* `pointerenter`
* `pointerleave`

You can do:

```html
<pc-entity onpointerdown="console.log('clicked!')"></pc-entity>
```

Or:

```js
const entity = document.getElementById('my-entity');
entity.addEventListener('pointerdown', (e) => {
    console.log('clicked!');
});
```