### PR TITLE
Refactor element ids in examples

### DIFF
--- a/examples/animation.html
+++ b/examples/animation.html
@@ -17,12 +17,12 @@
     <body>
         <pc-app antialias="false">
             <!-- Assets -->
-            <pc-asset id="camera-controls" src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
-            <pc-asset id="shadow-catcher" src="scripts/shadow-catcher.mjs"></pc-asset>
-            <pc-asset id="xr-controllers" src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
-            <pc-asset id="xr-navigation" src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
-            <pc-asset id="lake-bed" src="assets/skies/dry-lake-bed-2k.hdr"></pc-asset>
-            <pc-asset id="t-rex" src="assets/models/t-rex.glb"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
+            <pc-asset src="scripts/shadow-catcher.mjs"></pc-asset>
+            <pc-asset src="assets/skies/dry-lake-bed-2k.hdr" id="lake-bed"></pc-asset>
+            <pc-asset src="assets/models/t-rex.glb" id="t-rex"></pc-asset>
             <!-- Scene -->
             <pc-scene>
                 <!-- Sky -->

--- a/examples/car-configurator.html
+++ b/examples/car-configurator.html
@@ -19,13 +19,13 @@
             <!-- Modules -->
             <pc-module name="DracoDecoderModule" glue="modules/draco/draco.wasm.js" wasm="modules/draco/draco.wasm.wasm" fallback="modules/draco/draco.js"></pc-module>
             <!-- Assets -->
-            <pc-asset id="camera-controls" src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
-            <pc-asset id="camera-frame" src="../node_modules/playcanvas/scripts/esm/camera-frame.mjs"></pc-asset>
-            <pc-asset id="choose-color" src="scripts/choose-color.mjs"></pc-asset>
-            <pc-asset id="xr-controllers" src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
-            <pc-asset id="xr-navigation" src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
-            <pc-asset id="studio" src="assets/skies/octagon-lamps-photo-studio-2k.hdr"></pc-asset>
-            <pc-asset id="car" src="assets/models/porsche-911-carrera-4s.glb"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-frame.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
+            <pc-asset src="scripts/choose-color.mjs"></pc-asset>
+            <pc-asset src="assets/skies/octagon-lamps-photo-studio-2k.hdr" id="studio"></pc-asset>
+            <pc-asset src="assets/models/porsche-911-carrera-4s.glb" id="car"></pc-asset>
             <!-- Scene -->
             <pc-scene>
                 <!-- Sky -->

--- a/examples/fps-controller.html
+++ b/examples/fps-controller.html
@@ -20,10 +20,10 @@
             <pc-module name="Ammo" glue="modules/ammo/ammo.wasm.js" wasm="modules/ammo/ammo.wasm.wasm" fallback="modules/ammo/ammo.js"></pc-module>
             <pc-module name="Basis" glue="modules/basis/basis.wasm.js" wasm="modules/basis/basis.wasm.wasm" fallback="modules/basis/basis.js"></pc-module>
             <!-- Assets -->
-            <pc-asset id="first-person-camera" src="../node_modules/playcanvas/scripts/esm/first-person-controller.mjs"></pc-asset>
-            <pc-asset id="static-body" src="scripts/static-body.mjs"></pc-asset>
-            <pc-asset id="blue-sky" src="assets/skies/autumn-field-puresky.webp"></pc-asset>
-            <pc-asset id="map" src="assets/models/fps-map.glb"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/first-person-controller.mjs"></pc-asset>
+            <pc-asset src="scripts/static-body.mjs"></pc-asset>
+            <pc-asset src="assets/skies/autumn-field-puresky.webp" id="blue-sky"></pc-asset>
+            <pc-asset src="assets/models/fps-map.glb" id="map"></pc-asset>
             <!-- Scene -->
             <pc-scene>
                 <!-- Sky -->

--- a/examples/glb.html
+++ b/examples/glb.html
@@ -17,12 +17,12 @@
     <body>
         <pc-app>
             <!-- Assets -->
-            <pc-asset id="camera-controls" src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
-            <pc-asset id="rotate" src="scripts/rotate.mjs"></pc-asset>
-            <pc-asset id="xr-controllers" src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
-            <pc-asset id="xr-navigation" src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
-            <pc-asset id="studio" src="assets/skies/octagon-lamps-photo-studio-2k.hdr"></pc-asset>
-            <pc-asset id="cube" src="assets/models/playcanvas-cube.glb"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
+            <pc-asset src="scripts/rotate.mjs"></pc-asset>
+            <pc-asset src="assets/skies/octagon-lamps-photo-studio-2k.hdr" id="studio"></pc-asset>
+            <pc-asset src="assets/models/playcanvas-cube.glb" id="cube"></pc-asset>
             <!-- Scene -->
             <pc-scene>
                 <!-- Sky -->

--- a/examples/physics.html
+++ b/examples/physics.html
@@ -19,12 +19,12 @@
             <!-- Modules -->
             <pc-module name="Ammo" glue="modules/ammo/ammo.wasm.js" wasm="modules/ammo/ammo.wasm.wasm" fallback="modules/ammo/ammo.js"></pc-module>
             <!-- Assets -->
-            <pc-asset id="camera-controls" src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
-            <pc-asset id="grid" src="../node_modules/playcanvas/scripts/esm/grid.mjs"></pc-asset>
-            <pc-asset id="xr-controllers" src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
-            <pc-asset id="xr-navigation" src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
-            <pc-asset id="studio" src="assets/skies/octagon-lamps-photo-studio-2k.hdr"></pc-asset>
-            <pc-asset id="cube" src="assets/models/playcanvas-cube.glb"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/grid.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
+            <pc-asset src="assets/skies/octagon-lamps-photo-studio-2k.hdr" id="studio"></pc-asset>
+            <pc-asset src="assets/models/playcanvas-cube.glb" id="cube"></pc-asset>
             <!-- Scene -->
             <pc-scene>
                 <!-- Sky -->

--- a/examples/positional-sound.html
+++ b/examples/positional-sound.html
@@ -17,12 +17,12 @@
     <body>
         <pc-app>
             <!-- Assets -->
-            <pc-asset id="orbit" src="scripts/orbit.mjs"></pc-asset>
-            <pc-asset id="xr-controllers" src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
-            <pc-asset id="xr-navigation" src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
-            <pc-asset id="lake-bed" src="assets/skies/dry-lake-bed-2k.hdr"></pc-asset>
-            <pc-asset id="robot" src="assets/models/walking-robot.glb"></pc-asset>
-            <pc-asset id="footsteps" src="assets/sounds/footsteps.mp3"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
+            <pc-asset src="scripts/orbit.mjs"></pc-asset>
+            <pc-asset src="assets/skies/dry-lake-bed-2k.hdr" id="lake-bed"></pc-asset>
+            <pc-asset src="assets/models/walking-robot.glb" id="robot"></pc-asset>
+            <pc-asset src="assets/sounds/footsteps.mp3" id="footsteps"></pc-asset>
             <!-- Scene -->
             <pc-scene>
                 <!-- Sky -->

--- a/examples/screen.html
+++ b/examples/screen.html
@@ -17,8 +17,8 @@
     <body>
         <pc-app>
             <!-- Assets -->
-            <pc-asset id="arial" src="assets/fonts/arial.json" type="font"></pc-asset>
-            <pc-asset id="courier" src="assets/fonts/courier.json" type="font"></pc-asset>
+            <pc-asset src="assets/fonts/arial.json" type="font" id="arial"></pc-asset>
+            <pc-asset src="assets/fonts/courier.json" type="font" id="courier"></pc-asset>
             <!-- Scene -->
             <pc-scene>
                 <!-- Camera -->

--- a/examples/shoe-configurator.html
+++ b/examples/shoe-configurator.html
@@ -17,12 +17,12 @@
     <body>
         <pc-app>
             <!-- Assets -->
-            <pc-asset id="camera-controls" src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
-            <pc-asset id="shadow-catcher" src="scripts/shadow-catcher.mjs"></pc-asset>
-            <pc-asset id="xr-controllers" src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
-            <pc-asset id="xr-navigation" src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
-            <pc-asset id="studio" src="assets/skies/octagon-lamps-photo-studio-2k.hdr"></pc-asset>
-            <pc-asset id="shoe" src="assets/models/shoe.glb"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
+            <pc-asset src="scripts/shadow-catcher.mjs"></pc-asset>
+            <pc-asset src="assets/skies/octagon-lamps-photo-studio-2k.hdr" id="studio"></pc-asset>
+            <pc-asset src="assets/models/shoe.glb" id="shoe"></pc-asset>
             <!-- Scene -->
             <pc-scene>
                 <!-- Sky -->

--- a/examples/solar-system.html
+++ b/examples/solar-system.html
@@ -58,18 +58,18 @@
                 <!-- Modules -->
                 <pc-module name="Basis" glue="modules/basis/basis.wasm.js" wasm="modules/basis/basis.wasm.wasm" fallback="modules/basis/basis.js"></pc-module>
                 <!-- Assets -->
-                <pc-asset id="camera-frame" src="../node_modules/playcanvas/scripts/esm/camera-frame.mjs"></pc-asset>
-                <pc-asset id="solar-system" src="scripts/solar-system.mjs"></pc-asset>
-                <pc-asset id="stars" src="assets/skies/stars.png"></pc-asset>
-                <pc-asset id="sun" src="assets/models/planets/sun.glb"></pc-asset>
-                <pc-asset id="mercury" src="assets/models/planets/mercury.glb" lazy></pc-asset>
-                <pc-asset id="venus" src="assets/models/planets/venus.glb" lazy></pc-asset>
-                <pc-asset id="earth" src="assets/models/planets/earth.glb" lazy></pc-asset>
-                <pc-asset id="mars" src="assets/models/planets/mars.glb" lazy></pc-asset>
-                <pc-asset id="jupiter" src="assets/models/planets/jupiter.glb" lazy></pc-asset>
-                <pc-asset id="saturn" src="assets/models/planets/saturn.glb" lazy></pc-asset>
-                <pc-asset id="uranus" src="assets/models/planets/uranus.glb" lazy></pc-asset>
-                <pc-asset id="neptune" src="assets/models/planets/neptune.glb" lazy></pc-asset>
+                <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-frame.mjs"></pc-asset>
+                <pc-asset src="scripts/solar-system.mjs"></pc-asset>
+                <pc-asset src="assets/skies/stars.png" id="stars"></pc-asset>
+                <pc-asset src="assets/models/planets/sun.glb" id="sun"></pc-asset>
+                <pc-asset src="assets/models/planets/mercury.glb" id="mercury" lazy></pc-asset>
+                <pc-asset src="assets/models/planets/venus.glb" id="venus" lazy></pc-asset>
+                <pc-asset src="assets/models/planets/earth.glb" id="earth" lazy></pc-asset>
+                <pc-asset src="assets/models/planets/mars.glb" id="mars" lazy></pc-asset>
+                <pc-asset src="assets/models/planets/jupiter.glb" id="jupiter" lazy></pc-asset>
+                <pc-asset src="assets/models/planets/saturn.glb" id="saturn" lazy></pc-asset>
+                <pc-asset src="assets/models/planets/uranus.glb" id="uranus" lazy></pc-asset>
+                <pc-asset src="assets/models/planets/neptune.glb" id="neptune" lazy></pc-asset>
                 <!-- Scene -->
                 <pc-scene>
                     <!-- Sky -->

--- a/examples/sound.html
+++ b/examples/sound.html
@@ -17,9 +17,9 @@
     <body>
         <pc-app>
             <!-- Assets -->
-            <pc-asset id="camera-controls" src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
-            <pc-asset id="nyan-cat" src="assets/models/nyan-cat.glb"></pc-asset>
-            <pc-asset id="music" src="assets/sounds/nyan-cat.mp3"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
+            <pc-asset src="assets/models/nyan-cat.glb" id="nyan-cat"></pc-asset>
+            <pc-asset src="assets/sounds/nyan-cat.mp3" id="music"></pc-asset>
             <!-- Scene -->
             <pc-scene>
                 <!-- Camera -->

--- a/examples/spinning-cube.html
+++ b/examples/spinning-cube.html
@@ -16,7 +16,7 @@
     </head>
     <body>
         <pc-app>
-            <pc-asset id="rotate" src="scripts/rotate.mjs"></pc-asset>
+            <pc-asset src="scripts/rotate.mjs"></pc-asset>
             <!-- Scene -->
             <pc-scene>
                 <!-- Camera -->

--- a/examples/splat.html
+++ b/examples/splat.html
@@ -17,11 +17,11 @@
     <body>
         <pc-app antialias="false" depth="false" high-resolution="false" stencil="false">
             <!-- Assets -->
-            <pc-asset id="camera-controls" src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
-            <pc-asset id="xr-controllers" src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
-            <pc-asset id="xr-navigation" src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
-            <pc-asset id="angel" src="assets/splats/angel.compressed.ply"></pc-asset>
-            <pc-asset id="rotunda" src="assets/skies/sepulchral-chapel-rotunda-4k.webp"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
+            <pc-asset src="assets/splats/angel.compressed.ply" id="angel"></pc-asset>
+            <pc-asset src="assets/skies/sepulchral-chapel-rotunda-4k.webp" id="rotunda"></pc-asset>
             <!-- Scene -->
             <pc-scene>
                 <!-- Sky -->

--- a/examples/text.html
+++ b/examples/text.html
@@ -16,8 +16,8 @@
     </head>
     <body>
         <pc-app>
-            <pc-asset id="scroll" src="scripts/scroll.mjs"></pc-asset>
-            <pc-asset id="trade-gothic" src="assets/fonts/trade gothic lt bold no. 2.json" type="font"></pc-asset>
+            <pc-asset src="scripts/scroll.mjs"></pc-asset>
+            <pc-asset src="assets/fonts/trade gothic lt bold no. 2.json" type="font" id="trade-gothic"></pc-asset>
             <pc-scene fog="linear" fog-start="0" fog-end="8" fog-color="black">
                 <!-- Camera -->
                 <pc-entity name="camera">

--- a/examples/tween.html
+++ b/examples/tween.html
@@ -17,9 +17,9 @@
     </head>
     <body>
         <pc-app>
-            <pc-asset id="tweener" src="scripts/tweener.mjs"></pc-asset>
-            <pc-asset id="studio" src="assets/skies/octagon-lamps-photo-studio-2k.hdr"></pc-asset>
-            <pc-asset id="star" src="assets/models/star.glb"></pc-asset>
+            <pc-asset src="scripts/tweener.mjs"></pc-asset>
+            <pc-asset src="assets/skies/octagon-lamps-photo-studio-2k.hdr" id="studio"></pc-asset>
+            <pc-asset src="assets/models/star.glb" id="star"></pc-asset>
             <!-- Scene -->
             <pc-scene></pc-scene>
                 <!-- Sky -->

--- a/examples/video-texture.html
+++ b/examples/video-texture.html
@@ -20,13 +20,13 @@
             <pc-module name="Basis" glue="modules/basis/basis.wasm.js" wasm="modules/basis/basis.wasm.wasm" fallback="modules/basis/basis.js"></pc-module>
             <pc-module name="DracoDecoderModule" glue="modules/draco/draco.wasm.js" wasm="modules/draco/draco.wasm.wasm" fallback="modules/draco/draco.js"></pc-module>
             <!-- Assets -->
-            <pc-asset id="camera-controls" src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
-            <pc-asset id="shadow-catcher" src="scripts/shadow-catcher.mjs"></pc-asset>
-            <pc-asset id="video-texture" src="scripts/video-texture.mjs"></pc-asset>
-            <pc-asset id="xr-controllers" src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
-            <pc-asset id="xr-navigation" src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
-            <pc-asset id="studio" src="assets/skies/octagon-lamps-photo-studio-2k.hdr"></pc-asset>
-            <pc-asset id="vintage-pc" src="assets/models/vintage-pc.glb"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
+            <pc-asset src="scripts/shadow-catcher.mjs"></pc-asset>
+            <pc-asset src="scripts/video-texture.mjs"></pc-asset>
+            <pc-asset src="assets/skies/octagon-lamps-photo-studio-2k.hdr" id="studio"></pc-asset>
+            <pc-asset src="assets/models/vintage-pc.glb" id="vintage-pc"></pc-asset>
             <!-- Scene -->
             <pc-scene>
                 <!-- Sky -->


### PR DESCRIPTION
* Remove `id` attributes from elements that don't need them.
* Put `src` attribute first for `pc-asset` elements.