### PR TITLE
Refactor how script attributes are handled

### DIFF
--- a/examples/animation.html
+++ b/examples/animation.html
@@ -33,8 +33,8 @@
                         <pc-camera></pc-camera>
                         <pc-scripts>
                             <pc-script name="cameraControls" attributes='{
-                                "focusPoint": [0, 1.75, 2],
-                                "pitchRange": [-90, 0],
+                                "focusPoint": "vec3:0,1.75,2",
+                                "pitchRange": "vec2:-90,0",
                                 "sceneSize": 15,
                                 "zoomMin": 0.5,
                                 "zoomMax": 15
@@ -51,7 +51,7 @@
                     <pc-model asset="t-rex"></pc-model>
                     <pc-scripts>
                         <pc-script name="shadowCatcher" attributes='{
-                            "size": [14, 14]
+                            "size": "vec2:14,14"
                         }'></pc-script>
                     </pc-scripts>
                 </pc-entity>

--- a/examples/annotations.html
+++ b/examples/annotations.html
@@ -37,8 +37,8 @@
                         <pc-camera clear-color="black"></pc-camera>
                         <pc-scripts>
                             <pc-script name="cameraControls" attributes='{
-                                "focusPoint": [0, 1.75, 0],
-                                "pitchRange": [-90, 0],
+                                "focusPoint": "vec3:0,1.75,0",
+                                "pitchRange": "vec2:-90,0",
                                 "sceneSize": 2
                             }'></pc-script>
                         </pc-scripts>
@@ -53,7 +53,7 @@
                     <pc-model asset="jet-fighter"></pc-model>
                     <pc-scripts>
                         <pc-script name="shadowCatcher" attributes='{
-                            "size": [14, 14]
+                            "size": "vec2:14,14"
                         }'></pc-script>
                     </pc-scripts>
                     <pc-entity name="annotation1" position="5.5 1.2 0">

--- a/examples/basic-shapes.html
+++ b/examples/basic-shapes.html
@@ -37,8 +37,8 @@
                             <pc-script name="cameraControls" attributes='{
                                 "enableFly": false,
                                 "enablePan": false,
-                                "focusPoint": [0, 0.5, 0],
-                                "pitchRange": [-90, 0]
+                                "focusPoint": "vec3:0,0.5,0",
+                                "pitchRange": "vec2:-90,0"
                             }'></pc-script>
                         </pc-scripts>
                     </pc-entity>

--- a/examples/car-configurator.html
+++ b/examples/car-configurator.html
@@ -38,8 +38,8 @@
                             <pc-script name="cameraControls" attributes='{
                                 "enableFly": false,
                                 "enablePan": false,
-                                "focusPoint": [0, 0.5, 0],
-                                "pitchRange": [-90, 0],
+                                "focusPoint": "vec3:0,0.5,0",
+                                "pitchRange": "vec2:-90,0",
                                 "sceneSize": 10,
                                 "zoomMin": 0.25,
                                 "zoomMax": 1

--- a/examples/shoe-configurator.html
+++ b/examples/shoe-configurator.html
@@ -35,7 +35,7 @@
                             <pc-script name="cameraControls" attributes='{
                                 "enableFly": false,
                                 "enablePan": false,
-                                "focusPoint": [0, 0.05, 0],
+                                "focusPoint": "vec3:0,0.05,0",
                                 "sceneSize": 0.5,
                                 "zoomMin": 0.25,
                                 "zoomMax": 1
@@ -52,7 +52,7 @@
                     <pc-model asset="shoe"></pc-model>
                     <pc-scripts>
                         <pc-script name="shadowCatcher" attributes='{
-                            "size": [0.5, 0.5],
+                            "size": "vec2:0.5,0.5",
                             "shadowDistance": 1
                         }'></pc-script>
                     </pc-scripts>

--- a/examples/splat.html
+++ b/examples/splat.html
@@ -34,8 +34,8 @@
                             <pc-script name="cameraControls" attributes='{
                                 "enableFly": false,
                                 "enablePan": false,
-                                "focusPoint": [0, 2, 0],
-                                "pitchRange": [-90, 0],
+                                "focusPoint": "vec3:0,2,0",
+                                "pitchRange": "vec2:-90,0",
                                 "sceneSize": 3,
                                 "zoomMin": 0.5,
                                 "zoomMax": 3

--- a/examples/text3d.html
+++ b/examples/text3d.html
@@ -33,7 +33,7 @@
                         <pc-camera clear-color="black"></pc-camera>
                         <pc-scripts>
                             <pc-script name="cameraControls" attributes='{
-                                "focusPoint": [0, 0.5, 0],
+                                "focusPoint": "vec3:0,0.5,0",
                                 "sceneSize": 10,
                                 "zoomMin": 0.1,
                                 "zoomMax": 10

--- a/examples/tween.html
+++ b/examples/tween.html
@@ -39,24 +39,24 @@
                             "tweens": [
                                 {
                                     "path": "localScale",
-                                    "start": [1, 1, 1, 0],
-                                    "end": [1.2, 1.2, 1.2, 0],
+                                    "start": "vec4:1,1,1,0",
+                                    "end": "vec4:1.2,1.2,1.2,0",
                                     "duration": 500,
                                     "easingFunction": "Elastic",
                                     "easingType": "Out"
                                 },
                                 {
                                     "path": "localScale",
-                                    "start": [1.2, 1.2, 1.2, 0],
-                                    "end": [1, 1, 1, 0],
+                                    "start": "vec4:1.2,1.2,1.2,0",
+                                    "end": "vec4:1,1,1,0",
                                     "duration": 500,
                                     "easingFunction": "Elastic",
                                     "easingType": "Out"
                                 },
                                 {
                                     "path": "localEulerAngles",
-                                    "start": [0, 0, 0, 0],
-                                    "end": [0, 360, 0, 0],
+                                    "start": "vec4:0,0,0,0",
+                                    "end": "vec4:0,360,0,0",
                                     "duration": 2000,
                                     "easingFunction": "Elastic",
                                     "easingType": "Out"

--- a/examples/video-texture.html
+++ b/examples/video-texture.html
@@ -39,8 +39,8 @@
                             <pc-script name="cameraControls" attributes='{
                                 "enableFly": false,
                                 "enablePan": false,
-                                "focusPoint": [0, 0.225, 0],
-                                "pitchRange": [-90, 0],
+                                "focusPoint": "vec3:0,0.225,0",
+                                "pitchRange": "vec2:-90,0",
                                 "sceneSize": 1,
                                 "zoomMin": 0.5,
                                 "zoomMax": 3
@@ -61,7 +61,7 @@
                     <pc-model asset="vintage-pc"></pc-model>
                     <pc-scripts>
                         <pc-script name="shadowCatcher" attributes='{
-                            "size": [3, 3],
+                            "size": "vec2:3,3",
                             "shadowDistance": 4,
                             "blurSize": 16
                         }'></pc-script>

--- a/src/components/script-component.ts
+++ b/src/components/script-component.ts
@@ -66,6 +66,8 @@ class ScriptComponentElement extends ComponentElement {
      * - "vec3:1,2,3" → new Vec3(1,2,3)
      * - "vec4:1,2,3,4" → new Vec4(1,2,3,4)
      * - "color:1,0.5,0.5,1" → new Color(1,0.5,0.5,1)
+     * @param item - The item to convert.
+     * @returns The converted item.
      */
     private convertAttributes(item: any): any {
         if (typeof item === 'string') {
@@ -132,6 +134,8 @@ class ScriptComponentElement extends ComponentElement {
 
     /**
      * Preprocess the attributes object by converting its values.
+     * @param attrs - The attributes object to preprocess.
+     * @returns The preprocessed attributes object.
      */
     private preprocessAttributes(attrs: any): any {
         return this.convertAttributes(attrs);
@@ -139,6 +143,9 @@ class ScriptComponentElement extends ComponentElement {
 
     /**
      * Recursively merge properties from source into target.
+     * @param target - The target object to merge into.
+     * @param source - The source object to merge from.
+     * @returns The merged object.
      */
     private mergeDeep(target: any, source: any): any {
         for (const key in source) {
@@ -160,6 +167,8 @@ class ScriptComponentElement extends ComponentElement {
 
     /**
      * Update script attributes by merging preprocessed values into the script.
+     * @param script - The script to update.
+     * @param attributes - The attributes to merge into the script.
      */
     private applyAttributes(script: any, attributes: string | null) {
         try {

--- a/src/components/script-component.ts
+++ b/src/components/script-component.ts
@@ -1,8 +1,9 @@
 import { Color, ScriptComponent, Script, Vec2, Vec3, Vec4 } from 'playcanvas';
 
-import { ComponentElement } from './component';
-import { ScriptElement } from './script';
 import { AssetElement } from '../asset';
+import { ComponentElement } from './component';
+import { EntityElement } from '../entity';
+import { ScriptElement } from './script';
 
 // Add these interfaces at the top of the file, after the imports
 interface ScriptAttributesChangeEvent extends CustomEvent {
@@ -73,14 +74,14 @@ class ScriptComponentElement extends ComponentElement {
         if (typeof item === 'string') {
             if (item.startsWith('asset:')) {
                 const assetId = item.slice(6);
-                const assetElement = document.querySelector(`pc-asset#${assetId}`) as any;
+                const assetElement = document.querySelector(`pc-asset#${assetId}`) as AssetElement;
                 if (assetElement) {
                     return assetElement.asset;
                 }
             }
             if (item.startsWith('entity:')) {
                 const entityId = item.slice(7);
-                const entityElement = document.querySelector(`pc-entity[name="${entityId}"]`) as any;
+                const entityElement = document.querySelector(`pc-entity[name="${entityId}"]`) as EntityElement;
                 if (entityElement) {
                     return entityElement.entity;
                 }


### PR DESCRIPTION
Now, script attributes that are PlayCanvas types (`Asset`, `Color`, `Entity`, `Vec2`, `Vec3`, `Vec4`) are specified as strings with prefixes:

* `"asset:id"` is converted to the Asset instance associated with `<pc-asset id="id">`.
* `"entity:id"` is converted to the Entity instance associated with `<pc-entity id="id">`.
* `"color:1,2,3,4"` is converted to `Color(1, 2, 3, 4)`.
* `"vec2:1,2"` is converted to `Vec2(1, 2)`.
* `"vec3:1,2,3"` is converted to `Vec3(1, 2, 3)`.
* `"vec4:1,2,3,4"` is converted to `Vec4(1, 2, 3, 4)`.