### PR TITLE
Preserve video recorder example aspect ratio

### DIFF
--- a/examples/assets/scripts/video-recorder.mjs
+++ b/examples/assets/scripts/video-recorder.mjs
@@ -140,9 +140,8 @@ export class VideoRecorder extends Script {
         });
 
         // Set canvas to video frame resolution
-        this.app.setCanvasFillMode(FILLMODE_KEEP_ASPECT);
         this.app.setCanvasResolution(RESOLUTION_FIXED, width, height);
-        this.app.resizeCanvas(width, height);
+        this.app.setCanvasFillMode(FILLMODE_KEEP_ASPECT);
 
         // Start capturing frames
         this.app.on('frameend', this.captureFrame, this);
@@ -167,8 +166,8 @@ export class VideoRecorder extends Script {
         this.app.off('frameend', this.captureFrame, this);
 
         // Restore canvas fill mode and resolution
-        this.app.setCanvasFillMode(FILLMODE_FILL_WINDOW);
         this.app.setCanvasResolution(RESOLUTION_AUTO);
+        this.app.setCanvasFillMode(FILLMODE_FILL_WINDOW);
 
         // Flush and finalize muxer
         await this.encoder.flush();

--- a/examples/assets/scripts/video-recorder.mjs
+++ b/examples/assets/scripts/video-recorder.mjs
@@ -142,6 +142,7 @@ export class VideoRecorder extends Script {
         // Set canvas to video frame resolution
         this.app.setCanvasFillMode(FILLMODE_KEEP_ASPECT);
         this.app.setCanvasResolution(RESOLUTION_FIXED, width, height);
+        this.app.resizeCanvas(width, height);
 
         // Start capturing frames
         this.app.on('frameend', this.captureFrame, this);

--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -6,10 +6,11 @@ body {
     -webkit-user-select: none;
     user-select: none;
     box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 canvas {
     touch-action: none;
-    width: 100%;
-    height: 100%;
 }


### PR DESCRIPTION
Ensure that the video recorder example resizes the canvas correctly and centers it in the client area.