### PR TITLE
Add progress bar for video encoding

### DIFF
--- a/examples/assets/scripts/video-recorder-ui.mjs
+++ b/examples/assets/scripts/video-recorder-ui.mjs
@@ -3,6 +3,10 @@ import { Script } from 'playcanvas';
 export class VideoRecorderUI extends Script {
     initialize() {
         this.createUI();
+        // Listen to video recording progress events
+        this.app.on('encode:begin', this.onEncodeBegin, this);
+        this.app.on('encode:progress', this.onEncodeProgress, this);
+        this.app.on('encode:end', this.onEncodeEnd, this);
     }
 
     createUI() {
@@ -40,8 +44,8 @@ export class VideoRecorderUI extends Script {
 
             const label = document.createElement('label');
             label.textContent = labelText;
-            label.style.width = '100px';  // Fixed width for alignment
-            label.style.color = '#fff';   // Very light grey
+            label.style.width = '100px';
+            label.style.color = '#fff';
 
             const select = document.createElement('select');
             select.style.width = '75px';
@@ -135,8 +139,54 @@ export class VideoRecorderUI extends Script {
             }
         });
 
+        // Create a simple progress indicator (could be a div styled as a progress bar)
+        this.progressBar = document.createElement('div');
+        this.progressBar.style.height = '10px';
+        this.progressBar.style.background = '#ccc';
+        this.progressBar.style.width = '0%';
+        this.progressBar.style.transition = 'width 0.2s';
+        container.appendChild(this.progressBar);
+
         container.appendChild(optionsContainer);
         container.appendChild(button);
         document.body.appendChild(container);
+    }
+
+    onEncodeBegin() {
+        // Show the progress bar once encoding is complete.
+        this.progressBar.style.display = 'block';
+    }
+
+    onEncodeProgress(progress) {
+        // progress is a value between 0 and 1
+        // Update our progress bar width accordingly.
+        const percent = Math.min(Math.max(progress * 100, 0), 100);
+        this.progressBar.style.width = percent + '%';
+    }
+
+    onEncodeEnd(buffer) {
+        // Hide the progress bar once encoding is complete.
+        this.progressBar.style.display = 'none';
+
+        // Download the recorded video.
+        const blob = new Blob([buffer], { type: 'video/mp4' });
+        this.downloadBlob(blob);
+    }
+
+    /**
+     * Download the recorded video.
+     *
+     * @param {Blob} blob - The recorded video blob.
+     * @private
+     */
+    downloadBlob(blob) {
+        const url = URL.createObjectURL(blob);
+
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'recording.mp4';
+        a.click();
+
+        URL.revokeObjectURL(url);
     }
 }

--- a/examples/assets/scripts/video-recorder-ui.mjs
+++ b/examples/assets/scripts/video-recorder-ui.mjs
@@ -105,6 +105,9 @@ export class VideoRecorderUI extends Script {
         button.style.width = '100%';  // Make button same width as rows
         button.style.fontSize = 'inherit';
 
+        // Store the button reference on the instance for later access.
+        this.recordButton = button;
+
         button.addEventListener('click', () => {
             const videoRecorder = this.entity.script.videoRecorder;
             if (videoRecorder.recording) {
@@ -153,20 +156,22 @@ export class VideoRecorderUI extends Script {
     }
 
     onEncodeBegin() {
-        // Show the progress bar once encoding is complete.
+        // Show the progress bar and disable the Record/Stop button once encoding begins.
         this.progressBar.style.display = 'block';
+        this.recordButton.disabled = true;
     }
 
     onEncodeProgress(progress) {
         // progress is a value between 0 and 1
         // Update our progress bar width accordingly.
         const percent = Math.min(Math.max(progress * 100, 0), 100);
-        this.progressBar.style.width = percent + '%';
+        this.progressBar.style.width = `${percent}%`;
     }
 
     onEncodeEnd(buffer) {
-        // Hide the progress bar once encoding is complete.
+        // Hide the progress bar and re-enable the Record/Stop button once encoding is complete.
         this.progressBar.style.display = 'none';
+        this.recordButton.disabled = false;
 
         // Download the recorded video.
         const blob = new Blob([buffer], { type: 'video/mp4' });

--- a/examples/assets/scripts/video-recorder.mjs
+++ b/examples/assets/scripts/video-recorder.mjs
@@ -189,13 +189,10 @@ export class VideoRecorder extends Script {
         // Restore canvas fill mode and resolution
         this.app.setCanvasResolution(RESOLUTION_AUTO);
         this.app.setCanvasFillMode(FILLMODE_FILL_WINDOW);
-        console.log('Restored canvas resolution and fill mode');
 
         // Flush and finalize muxer
         await this.encoder.flush();
-        console.log('Flushed encoder');
         this.muxer.finalize();
-        console.log('Finalized muxer');
 
         // Download video
         const { buffer } = this.muxer.target;


### PR DESCRIPTION
Video Recorder example updates:

* Add a progress bar to show progress of processing of remaining frames after stopping of recording.
* Move blob download code out of core video encoder script.
* Disable autorendering while encoding to allow it to finish faster.