### PR TITLE
Enable MiniStats in examples

### DIFF
--- a/examples/annotations.html
+++ b/examples/annotations.html
@@ -34,7 +34,7 @@
                 <!-- Camera (with XR support) -->
                 <pc-entity name="camera root">
                     <pc-entity name="camera" position="0 1.75 8">
-                        <pc-camera clear-color="black"></pc-camera>
+                        <pc-camera></pc-camera>
                         <pc-scripts>
                             <pc-script name="cameraControls" attributes='{
                                 "focusPoint": "vec3:0,1.75,0",

--- a/examples/assets/scripts/annotation.mjs
+++ b/examples/assets/scripts/annotation.mjs
@@ -446,10 +446,19 @@ export class Annotation extends Script {
      * @private
      */
     _calculateScreenSpaceScale() {
+        const DESIRED_PIXEL_SIZE = 25; // Match this to your hotspot DOM element size
+
         const cameraPos = this.camera.entity.getPosition();
-        const cameraForward = this.camera.entity.forward;
         const toAnnotation = this.entity.getPosition().sub(cameraPos);
-        const distanceToNearPlane = toAnnotation.dot(cameraForward);
-        return distanceToNearPlane * Math.tan(this.camera.fov * Math.PI / 180) * 0.025;
+        const distance = toAnnotation.length();
+
+        // Get the camera's projection matrix vertical scale factor
+        const projMatrix = this.camera.projectionMatrix;
+        const screenHeight = this.app.graphicsDevice.height;
+
+        // Calculate world size needed for desired pixel size
+        const worldSize = (DESIRED_PIXEL_SIZE / screenHeight) * (2 * distance / projMatrix.data[5]);
+
+        return worldSize;
     }
 }

--- a/examples/assets/scripts/annotation.mjs
+++ b/examples/assets/scripts/annotation.mjs
@@ -446,7 +446,7 @@ export class Annotation extends Script {
      * @private
      */
     _calculateScreenSpaceScale() {
-        const DESIRED_PIXEL_SIZE = 25; // Match this to your hotspot DOM element size
+        const DESIRED_PIXEL_SIZE = 25;
 
         const cameraPos = this.camera.entity.getPosition();
         const toAnnotation = this.entity.getPosition().sub(cameraPos);

--- a/examples/js/example-ui.mjs
+++ b/examples/js/example-ui.mjs
@@ -1,8 +1,14 @@
-import { Color, Quat, Vec3 } from 'playcanvas';
+import { Color, MiniStats, Quat, Vec3 } from 'playcanvas';
 
 document.addEventListener('DOMContentLoaded', async () => {
     const appElement = await document.querySelector('pc-app').ready();
     const app = appElement.app;
+
+    // Add MiniStats if query parameter is present
+    if (new URLSearchParams(window.location.search).has('ministats')) {
+        /* eslint-disable-next-line no-unused-vars */
+        const stats = new MiniStats(app);
+    }
 
     // Create container for buttons
     const container = document.createElement('div');


### PR DESCRIPTION
Add `?ministats` to an example URL. The example needs to be running outside of the examples browser for this to work. So, for example:

https://playcanvas.github.io/web-components/examples/animation?ministats