### PR TITLE
Migrate from mp4-muxer to mediabunny

### DIFF
--- a/examples/assets/scripts/video-recorder.mjs
+++ b/examples/assets/scripts/video-recorder.mjs
@@ -129,7 +129,7 @@ export class VideoRecorder extends Script {
             format: new Mp4OutputFormat({
                 fastStart: 'in-memory'
             }),
-            target: new BufferTarget(),
+            target: new BufferTarget()
         });
 
         const videoSource = new EncodedVideoPacketSource('avc');

--- a/examples/assets/scripts/video-recorder.mjs
+++ b/examples/assets/scripts/video-recorder.mjs
@@ -1,4 +1,4 @@
-import { Muxer, ArrayBufferTarget } from 'mp4-muxer';
+import { BufferTarget, EncodedPacket, EncodedVideoPacketSource, Mp4OutputFormat, Output } from 'mediabunny';
 import { FILLMODE_KEEP_ASPECT, FILLMODE_FILL_WINDOW, RESOLUTION_AUTO, RESOLUTION_FIXED, Script } from 'playcanvas';
 
 /** @enum {number} */
@@ -48,10 +48,10 @@ export class VideoRecorder extends Script {
     encoder = null;
 
     /**
-     * @type {Muxer|null}
+     * @type {Output|null}
      * @private
      */
-    muxer = null;
+    output = null;
 
     /** @private */
     totalFrames = 0;
@@ -115,7 +115,7 @@ export class VideoRecorder extends Script {
     /**
      * Start recording.
      */
-    record() {
+    async record() {
         if (this.recording) return;
         this.recording = true;
         this.totalFrames = 0;
@@ -124,23 +124,28 @@ export class VideoRecorder extends Script {
 
         const { width, height, bitrate } = this.getVideoSettings();
 
-        // Create video frame muxer
-        this.muxer = new Muxer({
-            target: new ArrayBufferTarget(),
-            video: {
-                codec: 'avc',
-                width,
-                height
-            },
-            fastStart: 'in-memory',
-            firstTimestampBehavior: 'offset'
+        // Create video frame output
+        this.output = new Output({
+            format: new Mp4OutputFormat({
+                fastStart: 'in-memory'
+            }),
+            target: new BufferTarget(),
         });
+
+        const videoSource = new EncodedVideoPacketSource('avc');
+        this.output.addVideoTrack(videoSource, {
+            rotation: 0,
+            frameRate: this.frameRate
+        });
+
+        await this.output.start();
 
         // Create video frame encoder
         this.encoder = new VideoEncoder({
-            output: (chunk, meta) => {
+            output: async (chunk, meta) => {
                 this.framesEncoded++;
-                this.muxer.addVideoChunk(chunk, meta);
+                const encodedPacket = EncodedPacket.fromEncodedChunk(chunk);
+                await videoSource.add(encodedPacket, meta);
                 if (!this.recording) {
                     this.app.fire('encode:progress', (this.framesEncoded - this.framesEncodedAtFlush) / (this.totalFrames - this.framesEncodedAtFlush));
                 }
@@ -195,10 +200,10 @@ export class VideoRecorder extends Script {
 
         // Flush and finalize muxer
         await this.encoder.flush();
-        this.muxer.finalize();
+        await this.output.finalize();
 
         // Download video
-        const { buffer } = this.muxer.target;
+        const { buffer } = this.output.target;
         this.app.fire('encode:end', buffer);
 
         // Free resources

--- a/examples/video-recorder.html
+++ b/examples/video-recorder.html
@@ -7,7 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
-                    "mp4-muxer": "../node_modules/mp4-muxer/build/mp4-muxer.mjs",
+                    "mediabunny": "../node_modules/mediabunny/dist/bundles/mediabunny.min.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs",
                     "@tweenjs/tween.js": "../node_modules/@tweenjs/tween.js/dist/tween.esm.js"
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "eslint": "9.31.0",
         "eslint-import-resolver-typescript": "4.4.4",
         "globals": "16.3.0",
-        "mp4-muxer": "5.2.2",
+        "mediabunny": "^1.1.1",
         "opentype.js": "1.3.4",
         "playcanvas": "2.9.2",
         "rollup": "4.45.1",
@@ -949,10 +949,19 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/dom-mediacapture-transform": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.11.tgz",
+      "integrity": "sha512-Y2p+nGf1bF2XMttBnsVPHUWzRRZzqUoJAKmiP10b5umnO6DDrWI0BrGDJy1pOHoOULVmGSfFNkQrAlC5dcj6nQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/dom-webcodecs": "*"
+      }
+    },
     "node_modules/@types/dom-webcodecs": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.13.tgz",
-      "integrity": "sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==",
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.15.tgz",
+      "integrity": "sha512-omOlCPvTWyPm4ZE5bZUhlSvnHM2ZWM2U+1cPiYFL/e8aV5O9MouELp+L4dMKNTON0nTeHqEg+KWDfFQMY5Wkaw==",
       "dev": true
     },
     "node_modules/@types/estree": {
@@ -1003,12 +1012,6 @@
       "integrity": "sha512-Vr6Stjv5jPRqH690f5I5GLjVk8GSsoQSYJ2FVd/3jJF7KaqfwPi3ehfBS96mlQ2kPCwZaX6U0rG2+NGHBKkA/A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/wicg-file-system-access": {
-      "version": "2020.9.8",
-      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.8.tgz",
-      "integrity": "sha512-ggMz8nOygG7d/stpH40WVaNvBwuyYLnrg5Mbyf6bmsj/8+gb6Ei4ZZ9/4PNpcPNTT8th9Q8sM8wYmWGjMWLX/A==",
-      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.37.0",
@@ -4257,6 +4260,20 @@
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true
     },
+    "node_modules/mediabunny": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.1.1.tgz",
+      "integrity": "sha512-eEz4A2ZzTYauzbOHP37JfcwP2zgB+t7DqjDsrNRttpZRIeDJnLFe7O+AugvozbCBN2G6MQ1IP7EIsPwyX1KMmg==",
+      "dev": true,
+      "dependencies": {
+        "@types/dom-mediacapture-transform": "^0.1.11",
+        "@types/dom-webcodecs": "^0.1.15"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -4385,18 +4402,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/mp4-muxer": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/mp4-muxer/-/mp4-muxer-5.2.2.tgz",
-      "integrity": "sha512-dhozjTywI0h2qFzeShagt8YYw811fh1XlwiDCE2f6Aeqf6xG2CyuShoSa5E0AZDO8pPF0JOZ3wOmWBNWIGdSpQ==",
-      "deprecated": "This library is superseded by Mediabunny. Please migrate to it.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/dom-webcodecs": "^0.1.6",
-        "@types/wicg-file-system-access": "^2020.9.5"
-      }
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint": "9.31.0",
     "eslint-import-resolver-typescript": "4.4.4",
     "globals": "16.3.0",
-    "mp4-muxer": "5.2.2",
+    "mediabunny": "^1.1.1",
     "opentype.js": "1.3.4",
     "playcanvas": "2.9.2",
     "rollup": "4.45.1",


### PR DESCRIPTION
Since `mp4-muxer` is now deprecated, this PR migrates the video recorder script to [mediabunny](https://mediabunny.dev/).