### PR TITLE
Declare playcanvas as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,9 @@
         "typedoc": "0.28.16",
         "typedoc-plugin-mdn-links": "5.1.1",
         "typescript": "5.9.3"
+      },
+      "peerDependencies": {
+        "playcanvas": "^2.17.2"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "type-check:watch": "npm run type-check -- --watch",
     "watch": "rollup -c -w"
   },
+  "peerDependencies": {
+    "playcanvas": "^2.17.2"
+  },
   "devDependencies": {
     "@mediapipe/tasks-vision": "0.10.32",
     "@playcanvas/eslint-config": "2.1.0",


### PR DESCRIPTION
## Summary

- Declares `playcanvas` as a `peerDependency` (`^2.17.2`)
- The rollup config already externalizes playcanvas (`external: ['playcanvas']`), meaning consumers must provide the engine. This change makes that requirement explicit to package managers and consumers.

## Test plan

- Verify `npm install` still works without warnings
- Verify `npm run build` produces the same output
