### PR TITLE
Remove GSplatComponent unified property support

### DIFF
--- a/examples/splat-flipbook.html
+++ b/examples/splat-flipbook.html
@@ -55,7 +55,7 @@
                 </pc-entity>
                 <!-- Animated Splat (Flipbook) -->
                 <pc-entity name="animated-splat" rotation="0 -90 180">
-                    <pc-splat unified cast-shadows></pc-splat>
+                    <pc-splat cast-shadows></pc-splat>
                     <pc-scripts>
                         <pc-script name="gsplatFlipbook" attributes='{
                             "fps": 30,
@@ -97,7 +97,7 @@
         <script type="module" src="js/example.mjs"></script>
         <script type="module">
             const appElement = await document.querySelector('pc-app').ready();
-            appElement.app.scene.gsplat.material.setParameter('alphaClip', 0.1);
+            appElement.app.scene.gsplat.alphaClip = 0.1;
         </script>
     </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "watch": "rollup -c -w"
   },
   "peerDependencies": {
-    "playcanvas": "^2.17.2"
+    "playcanvas": "^2.19.0"
   },
   "devDependencies": {
     "@mediapipe/tasks-vision": "0.10.35",

--- a/src/components/splat-component.ts
+++ b/src/components/splat-component.ts
@@ -16,8 +16,6 @@ class SplatComponentElement extends ComponentElement {
 
     private _castShadows = false;
 
-    private _unified = false;
-
     /** @ignore */
     constructor() {
         super('gsplat');
@@ -26,8 +24,7 @@ class SplatComponentElement extends ComponentElement {
     getInitialComponentData() {
         return {
             asset: AssetElement.get(this._asset),
-            castShadows: this._castShadows,
-            unified: this._unified
+            castShadows: this._castShadows
         };
     }
 
@@ -78,36 +75,11 @@ class SplatComponentElement extends ComponentElement {
         return this._castShadows;
     }
 
-    /**
-     * Sets whether the splat supports global sorting and LOD streaming. This property can only be
-     * changed when the component is disabled.
-     * @param value - Whether the splat supports global sorting and LOD streaming.
-     */
-    set unified(value: boolean) {
-        if (this.component && this.component.enabled) {
-            console.warn('The "unified" property can only be changed when the component is disabled.');
-            return;
-        }
-        this._unified = value;
-        if (this.component) {
-            this.component.unified = value;
-        }
-    }
-
-    /**
-     * Gets whether the splat supports global sorting and LOD streaming.
-     * @returns Whether the splat supports global sorting and LOD streaming.
-     */
-    get unified() {
-        return this._unified;
-    }
-
     static get observedAttributes() {
         return [
             ...super.observedAttributes,
             'asset',
-            'cast-shadows',
-            'unified'
+            'cast-shadows'
         ];
     }
 
@@ -120,9 +92,6 @@ class SplatComponentElement extends ComponentElement {
                 break;
             case 'cast-shadows':
                 this.castShadows = this.hasAttribute('cast-shadows');
-                break;
-            case 'unified':
-                this.unified = this.hasAttribute('unified');
                 break;
         }
     }


### PR DESCRIPTION
## What

Removes all support for and references to the `unified` property of `GSplatComponent` from web-components.

- **`src/components/splat-component.ts`** — drop the `_unified` field, the `getInitialComponentData` entry, the `set`/`get unified` accessors, the `'unified'` observed attribute, and its `attributeChangedCallback` case.
- **`examples/splat-flipbook.html`** — remove the now-redundant `unified` attribute from `<pc-splat>`, and replace `scene.gsplat.material.setParameter('alphaClip', 0.1)` with `scene.gsplat.alphaClip = 0.1`.

## Why

The engine deprecated `GSplatComponent.unified` and made unified rendering the default (`true`) as of playcanvas **v2.19.0** ([#8802](https://github.com/playcanvas/engine/pull/8802)). Now that web-components is on `2.19.1`, the `<pc-splat>` element no longer needs to expose the property.

In unified mode the component `material` getter returns `null`, so the flipbook example's old `material.setParameter(...)` call no longer works — it's been swapped for the new `scene.gsplat.alphaClip` setter, matching the engine's `flipbook.example.mjs`.

## Reviewer notes

- Requires playcanvas >= 2.19.0 (already pinned at 2.19.1 on `main`). On older versions the flipbook would render non-unified and fail to update between frames.
- Verified with `npm run lint` and `npm run build` (clean; the pre-existing TS5107 moduleResolution deprecation warning is unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
