### PR TITLE
Fix TS5107 by switching moduleResolution to "bundler"

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Problem

TypeScript 6.0 (pinned as `typescript: 6.0.3`) promotes the deprecated `moduleResolution: "node"` (node10) from a warning to a **hard error** (`TS5107`). This breaks `npm run docs` (typedoc) and `tsc`:

```
error TS5107: Option 'moduleResolution=node10' is deprecated and will stop functioning
in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

This is currently failing the [api-reference](https://github.com/playcanvas/api-reference) GitHub Actions build, which clones `main` and runs `npm run docs`.

## Fix

Switch `moduleResolution` from `"node"` to `"bundler"`. Since `module` is already `ESNext` and the package is built with rollup, `"bundler"` is the correct modern replacement — cleaner than silencing with `ignoreDeprecations`, which would only defer the problem until TS 7.0 removes the option entirely.

## Verification

Both pass cleanly with the change:
- `npm run docs` — typedoc generates HTML with no errors
- `npm run type-check` (`tsc --noEmit`) — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
