### PR TITLE
Rename <pc-splat> to <pc-gsplat> [BREAKING]

### DIFF
--- a/examples/first-person-teleport.html
+++ b/examples/first-person-teleport.html
@@ -64,25 +64,25 @@
                 <!-- Statues -->
                 <pc-entity name="statues">
                     <pc-entity name="angel" position="-5 0.7 0" rotation="180 0 0">
-                        <pc-splat asset="angel"></pc-splat>
+                        <pc-gsplat asset="angel"></pc-gsplat>
                     </pc-entity>
                     <pc-entity name="angel-kneeling" position="5 0.7 0" rotation="0 0 180">
-                        <pc-splat asset="angel-kneeling"></pc-splat>
+                        <pc-gsplat asset="angel-kneeling"></pc-gsplat>
                     </pc-entity>
                     <pc-entity name="angel-with-candlestick" position="-5 0.7 5" rotation="180 0 0">
-                        <pc-splat asset="angel-with-candlestick"></pc-splat>
+                        <pc-gsplat asset="angel-with-candlestick"></pc-gsplat>
                     </pc-entity>
                     <pc-entity name="massa" position="0 0.7 -5" rotation="0 0 180">
-                        <pc-splat asset="massa"></pc-splat>
+                        <pc-gsplat asset="massa"></pc-gsplat>
                     </pc-entity>
                     <pc-entity name="narcissus" position="5 0.7 5" rotation="180 0 0">
-                        <pc-splat asset="narcissus"></pc-splat>
+                        <pc-gsplat asset="narcissus"></pc-gsplat>
                     </pc-entity>
                     <pc-entity name="st-peter" position="5 0.7 -5" rotation="0 0 180">
-                        <pc-splat asset="st-peter"></pc-splat>
+                        <pc-gsplat asset="st-peter"></pc-gsplat>
                     </pc-entity>
                     <pc-entity name="trumpet" position="-5 0.7 -5" rotation="0 0 180">
-                        <pc-splat asset="trumpet"></pc-splat>
+                        <pc-gsplat asset="trumpet"></pc-gsplat>
                     </pc-entity>
                 </pc-entity>
             </pc-scene>

--- a/examples/splat-annotations.html
+++ b/examples/splat-annotations.html
@@ -63,7 +63,7 @@
                 </pc-entity>
                 <!-- Bicycle -->
                 <pc-entity name="bicycle" rotation="0 0 180">
-                    <pc-splat asset="bicycle"></pc-splat>
+                    <pc-gsplat asset="bicycle"></pc-gsplat>
                     <pc-scripts>
                         <pc-script name="annotationManager"></pc-script>
                     </pc-scripts>

--- a/examples/splat-flipbook.html
+++ b/examples/splat-flipbook.html
@@ -55,7 +55,7 @@
                 </pc-entity>
                 <!-- Animated Splat (Flipbook) -->
                 <pc-entity name="animated-splat" rotation="0 -90 180">
-                    <pc-splat cast-shadows></pc-splat>
+                    <pc-gsplat cast-shadows></pc-gsplat>
                     <pc-scripts>
                         <pc-script name="gsplatFlipbook" attributes='{
                             "fps": 30,

--- a/examples/splat-simple.html
+++ b/examples/splat-simple.html
@@ -56,7 +56,7 @@
                 </pc-entity>
                 <!-- Statue -->
                 <pc-entity name="statue" position="0 1 0" rotation="0 -45 180">
-                    <pc-splat asset="angel"></pc-splat>
+                    <pc-gsplat asset="angel"></pc-gsplat>
                 </pc-entity>
             </pc-scene>
         </pc-app>

--- a/examples/video-recorder.html
+++ b/examples/video-recorder.html
@@ -69,7 +69,7 @@
                 </pc-entity>
                 <!-- Biker -->
                 <pc-entity name="biker" rotation="180 0 0">
-                    <pc-splat asset="biker"></pc-splat>
+                    <pc-gsplat asset="biker"></pc-gsplat>
                 </pc-entity>
                 <!-- Video Recorder -->
                 <pc-entity name="recorder">

--- a/src/components/gsplat-component.ts
+++ b/src/components/gsplat-component.ts
@@ -4,14 +4,14 @@ import { ComponentElement } from './component';
 import { AssetElement } from '../asset';
 
 /**
- * The SplatComponentElement interface provides properties and methods for manipulating
- * {@link https://developer.playcanvas.com/user-manual/web-components/tags/pc-splat/ | `<pc-splat>`} elements.
- * The SplatComponentElement interface also inherits the properties and methods of the
+ * The GSplatComponentElement interface provides properties and methods for manipulating
+ * {@link https://developer.playcanvas.com/user-manual/web-components/tags/pc-gsplat/ | `<pc-gsplat>`} elements.
+ * The GSplatComponentElement interface also inherits the properties and methods of the
  * {@link HTMLElement} interface.
  *
  * @category Components
  */
-class SplatComponentElement extends ComponentElement {
+class GSplatComponentElement extends ComponentElement {
     private _asset = '';
 
     private _castShadows = false;
@@ -29,8 +29,8 @@ class SplatComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the underlying PlayCanvas splat component.
-     * @returns The splat component.
+     * Gets the underlying PlayCanvas gsplat component.
+     * @returns The gsplat component.
      */
     get component(): GSplatComponent | null {
         return super.component as GSplatComponent | null;
@@ -97,6 +97,6 @@ class SplatComponentElement extends ComponentElement {
     }
 }
 
-customElements.define('pc-splat', SplatComponentElement);
+customElements.define('pc-gsplat', GSplatComponentElement);
 
-export { SplatComponentElement };
+export { GSplatComponentElement };

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ import { ScriptComponentElement } from './components/script-component';
 import { ScriptElement } from './components/script';
 import { SoundComponentElement } from './components/sound-component';
 import { SoundSlotElement } from './components/sound-slot';
-import { SplatComponentElement } from './components/splat-component';
+import { GSplatComponentElement } from './components/gsplat-component';
 import { MaterialElement } from './material';
 import { ModelElement } from './model';
 import { SceneElement } from './scene';
@@ -55,7 +55,7 @@ export {
     ScriptElement,
     SoundComponentElement,
     SoundSlotElement,
-    SplatComponentElement,
+    GSplatComponentElement,
     MaterialElement,
     ModelElement,
     SceneElement,


### PR DESCRIPTION
## Summary

Renames the Gaussian splat web component from `<pc-splat>` / `SplatComponentElement` to `<pc-gsplat>` / `GSplatComponentElement`.

Every other element in this library mirrors its underlying engine component and tag (e.g. `CameraComponentElement` ↔ `CameraComponent` ↔ `<pc-camera>`). The splat element wraps the engine's **`GSplatComponent`** but was exposed as `<pc-splat>` — the lone exception. This change brings it in line with the convention and the engine naming.

## ⚠️ Breaking Changes

- **HTML tag:** `<pc-splat>` → `<pc-gsplat>`
- **Exported class:** `SplatComponentElement` → `GSplatComponentElement`

### Migration

HTML:
```html
<!-- before -->
<pc-splat asset="my-splat"></pc-splat>
<!-- after -->
<pc-gsplat asset="my-splat"></pc-gsplat>
```

JS / TS:
```ts
// before
import { SplatComponentElement } from '@playcanvas/web-components';
// after
import { GSplatComponentElement } from '@playcanvas/web-components';
```

## Changes

- Renamed `src/components/splat-component.ts` → `src/components/gsplat-component.ts` (class, `customElements.define`, export, and the `/tags/pc-gsplat/` doc link).
- Updated the barrel export in `src/index.ts`.
- Updated the 5 examples that use the element (`splat-simple`, `splat-annotations`, `splat-flipbook`, `first-person-teleport`, `video-recorder`). Example filenames are unchanged.

## Testing

- `npm run type-check`, `npm run lint`, and `npm run build` all pass.
- Ran the examples locally: `<pc-gsplat>` registers, upgrades to `GSplatComponentElement`, wires up the engine `GSplatComponent`, and the splat renders with no console errors.

## Note

The accompanying version bump (`0.5.0` → `0.6.0`) and the external docs-site page rename (`/tags/pc-gsplat/`) are handled separately, per this repo's release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)