### PR TITLE
Add lod-base-distance and lod-multiplier attributes to <pc-gsplat>

### DIFF
--- a/src/components/gsplat-component.ts
+++ b/src/components/gsplat-component.ts
@@ -16,6 +16,10 @@ class GSplatComponentElement extends ComponentElement {
 
     private _castShadows = false;
 
+    private _lodBaseDistance = 5;
+
+    private _lodMultiplier = 3;
+
     /** @ignore */
     constructor() {
         super('gsplat');
@@ -24,7 +28,9 @@ class GSplatComponentElement extends ComponentElement {
     getInitialComponentData() {
         return {
             asset: AssetElement.get(this._asset),
-            castShadows: this._castShadows
+            castShadows: this._castShadows,
+            lodBaseDistance: this._lodBaseDistance,
+            lodMultiplier: this._lodMultiplier
         };
     }
 
@@ -75,11 +81,58 @@ class GSplatComponentElement extends ComponentElement {
         return this._castShadows;
     }
 
+    /**
+     * Sets the base distance for the first LOD transition (LOD 0 to LOD 1). Splats closer than
+     * this distance use the highest quality LOD. Each subsequent LOD level transitions at a
+     * progressively larger distance, controlled by {@link lodMultiplier}. Clamped to a minimum of
+     * 0.1. Defaults to 5. Only affects assets that contain LOD levels (e.g. `.lod-meta.json`).
+     * @param value - The LOD base distance.
+     */
+    set lodBaseDistance(value: number) {
+        this._lodBaseDistance = value;
+        if (this.component) {
+            this.component.lodBaseDistance = value;
+        }
+    }
+
+    /**
+     * Gets the base distance for the first LOD transition.
+     * @returns The LOD base distance.
+     */
+    get lodBaseDistance() {
+        return this._lodBaseDistance;
+    }
+
+    /**
+     * Sets the multiplier between successive LOD distance thresholds. Each LOD level transitions
+     * at this factor times the previous level's distance, creating a geometric progression. Lower
+     * values keep higher quality at distance; higher values switch to coarser LODs sooner. Clamped
+     * to a minimum of 1.2. Defaults to 3. Only affects assets that contain LOD levels (e.g.
+     * `.lod-meta.json`).
+     * @param value - The LOD multiplier.
+     */
+    set lodMultiplier(value: number) {
+        this._lodMultiplier = value;
+        if (this.component) {
+            this.component.lodMultiplier = value;
+        }
+    }
+
+    /**
+     * Gets the multiplier between successive LOD distance thresholds.
+     * @returns The LOD multiplier.
+     */
+    get lodMultiplier() {
+        return this._lodMultiplier;
+    }
+
     static get observedAttributes() {
         return [
             ...super.observedAttributes,
             'asset',
-            'cast-shadows'
+            'cast-shadows',
+            'lod-base-distance',
+            'lod-multiplier'
         ];
     }
 
@@ -92,6 +145,12 @@ class GSplatComponentElement extends ComponentElement {
                 break;
             case 'cast-shadows':
                 this.castShadows = this.hasAttribute('cast-shadows');
+                break;
+            case 'lod-base-distance':
+                this.lodBaseDistance = Number(newValue);
+                break;
+            case 'lod-multiplier':
+                this.lodMultiplier = Number(newValue);
                 break;
         }
     }


### PR DESCRIPTION
## Summary

Exposes the two `GSplatComponent` level-of-detail (LOD) tuning properties as declarative attributes on `<pc-gsplat>`. These let authors control how streaming-LOD splats (e.g. `.lod-meta.json` assets) transition between detail levels directly from HTML, rather than only via script.

Before this change, `<pc-gsplat>` exposed only `asset` and `cast-shadows` (plus inherited `enabled`).

## New attributes

| Attribute | Property | Type | Default | Description |
|---|---|---|---|---|
| `lod-base-distance` | `lodBaseDistance` | number | `5` | Distance of the first LOD transition (LOD 0 → LOD 1). Splats closer than this use the highest-quality LOD. Engine-clamped to a minimum of `0.1`. |
| `lod-multiplier` | `lodMultiplier` | number | `3` | Geometric multiplier between successive LOD distance thresholds. Engine-clamped to a minimum of `1.2`. |

```html
<pc-gsplat asset="city" lod-base-distance="10" lod-multiplier="2"></pc-gsplat>
```

Both attributes are no-ops for assets without LOD levels (e.g. plain `.ply`/`.sog`).

## Implementation

Mirrors the existing numeric-attribute pattern used by sibling elements (`light-component.ts`, `camera-component.ts`): private backing field → included in `getInitialComponentData()` → guarded getter/setter that syncs to the engine component → registered in `observedAttributes` → parsed with `Number()` in `attributeChangedCallback`. This covers both values present at load (applied at component creation) and runtime attribute changes.

Scope was intentionally limited to these two properties. Other public `GSplatComponent` members were left out as not attribute-friendly or not appropriate for declarative use: `highQualitySH`, `layers`, `customAabb`, and the deprecated/object-typed/read-only `unified`, `instance`, `material`, `resource`, `id`, `lodDistances`, `splatBudget`, `workBufferUpdate`.

## Verification

- `npm run type-check` — clean (confirms the new property access resolves against the pinned `playcanvas` types)
- `npm run lint` — clean
- `npm run build` — succeeds; new members appear in the generated bundles and in `dist/components/gsplat-component.d.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
