### PR TITLE
Update XR script paths for relocated playcanvas scripts

### DIFF
--- a/examples/animation.html
+++ b/examples/animation.html
@@ -19,10 +19,10 @@
             <!-- Assets -->
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/shadow-catcher.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-menu.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-session.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-controllers.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-menu.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-navigation.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-session.mjs"></pc-asset>
             <pc-asset src="assets/fonts/arial.json" type="font" id="arial-font"></pc-asset>
             <pc-asset src="assets/skies/dry-lake-bed-2k.hdr" id="lake-bed"></pc-asset>
             <pc-asset src="assets/models/t-rex.glb" id="t-rex"></pc-asset>

--- a/examples/annotations.html
+++ b/examples/annotations.html
@@ -23,10 +23,10 @@
             <pc-asset src="../node_modules/playcanvas/scripts/esm/annotations.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/shadow-catcher.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-menu.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-session.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-controllers.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-menu.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-navigation.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-session.mjs"></pc-asset>
             <pc-asset src="assets/fonts/arial.json" type="font" id="arial-font"></pc-asset>
             <pc-asset src="assets/skies/shanghai-riverside-4k.hdr" id="shanghai"></pc-asset>
             <pc-asset src="assets/models/jet-fighter.glb" id="jet-fighter"></pc-asset>

--- a/examples/basic-shapes.html
+++ b/examples/basic-shapes.html
@@ -18,10 +18,10 @@
         <pc-app>
             <!-- Assets -->
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-menu.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-session.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-controllers.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-menu.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-navigation.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-session.mjs"></pc-asset>
             <pc-asset src="assets/fonts/arial.json" type="font" id="arial-font"></pc-asset>
             <!-- Materials -->
             <pc-material id="crimson" diffuse="crimson"></pc-material>

--- a/examples/car-configurator.html
+++ b/examples/car-configurator.html
@@ -21,10 +21,10 @@
             <!-- Assets -->
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-frame.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-menu.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-session.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-controllers.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-menu.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-navigation.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-session.mjs"></pc-asset>
             <pc-asset src="assets/fonts/arial.json" type="font" id="arial-font"></pc-asset>
             <pc-asset src="assets/scripts/choose-color.mjs"></pc-asset>
             <pc-asset src="assets/skies/octagon-lamps-photo-studio-2k.hdr" id="studio"></pc-asset>

--- a/examples/first-person-teleport.html
+++ b/examples/first-person-teleport.html
@@ -17,10 +17,10 @@
     <body>
         <pc-app antialias="false" stencil="false">
             <!-- Assets -->
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-menu.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-session.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-controllers.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-menu.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-navigation.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-session.mjs"></pc-asset>
             <pc-asset src="assets/fonts/arial.json" type="font" id="arial-font"></pc-asset>
             <pc-asset src="assets/scripts/first-person-teleport.mjs"></pc-asset>
             <pc-asset src="assets/splats/statues/angel.sog" id="angel"></pc-asset>

--- a/examples/glb.html
+++ b/examples/glb.html
@@ -18,10 +18,10 @@
         <pc-app>
             <!-- Assets -->
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-menu.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-session.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-controllers.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-menu.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-navigation.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-session.mjs"></pc-asset>
             <pc-asset src="assets/fonts/arial.json" type="font" id="arial-font"></pc-asset>
             <pc-asset src="assets/scripts/rotate.mjs"></pc-asset>
             <pc-asset src="assets/skies/octagon-lamps-photo-studio-2k.hdr" id="studio"></pc-asset>

--- a/examples/physics.html
+++ b/examples/physics.html
@@ -21,10 +21,10 @@
             <!-- Assets -->
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/grid.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-menu.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-session.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-controllers.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-menu.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-navigation.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-session.mjs"></pc-asset>
             <pc-asset src="assets/fonts/arial.json" type="font" id="arial-font"></pc-asset>
             <pc-asset src="assets/skies/octagon-lamps-photo-studio-2k.hdr" id="studio"></pc-asset>
             <pc-asset src="assets/models/playcanvas-cube.glb" id="cube"></pc-asset>

--- a/examples/positional-sound.html
+++ b/examples/positional-sound.html
@@ -17,10 +17,10 @@
     <body>
         <pc-app>
             <!-- Assets -->
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-menu.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-session.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-controllers.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-menu.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-navigation.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-session.mjs"></pc-asset>
             <pc-asset src="assets/fonts/arial.json" type="font" id="arial-font"></pc-asset>
             <pc-asset src="assets/scripts/orbit.mjs"></pc-asset>
             <pc-asset src="assets/skies/dry-lake-bed-2k.hdr" id="lake-bed"></pc-asset>

--- a/examples/shoe-configurator.html
+++ b/examples/shoe-configurator.html
@@ -19,10 +19,10 @@
             <!-- Assets -->
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/shadow-catcher.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-menu.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-session.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-controllers.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-menu.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-navigation.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-session.mjs"></pc-asset>
             <pc-asset src="assets/fonts/arial.json" type="font" id="arial-font"></pc-asset>
             <pc-asset src="assets/skies/octagon-lamps-photo-studio-2k.hdr" id="studio"></pc-asset>
             <pc-asset src="assets/models/shoe.glb" id="shoe"></pc-asset>

--- a/examples/splat-annotations.html
+++ b/examples/splat-annotations.html
@@ -20,10 +20,10 @@
             <pc-asset src="../node_modules/playcanvas/scripts/esm/annotations.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-frame.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-menu.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-session.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-controllers.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-menu.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-navigation.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-session.mjs"></pc-asset>
             <pc-asset src="assets/fonts/arial.json" type="font" id="arial-font"></pc-asset>
             <pc-asset src="assets/splats/bicycle.sog" id="bicycle"></pc-asset>
             <!-- Scene -->

--- a/examples/splat-flipbook.html
+++ b/examples/splat-flipbook.html
@@ -20,10 +20,10 @@
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/gsplat/gsplat-flipbook.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/shadow-catcher.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-menu.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-session.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-controllers.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-menu.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-navigation.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-session.mjs"></pc-asset>
             <pc-asset src="assets/fonts/arial.json" type="font" id="arial-font"></pc-asset>
             <pc-asset src="assets/skies/octagon-lamps-photo-studio-2k.hdr" id="studio"></pc-asset>
             <!-- Scene -->

--- a/examples/splat-simple.html
+++ b/examples/splat-simple.html
@@ -18,10 +18,10 @@
         <pc-app antialias="false" depth="false" high-resolution="false" stencil="false">
             <!-- Assets -->
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-menu.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-session.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-controllers.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-menu.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-navigation.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-session.mjs"></pc-asset>
             <pc-asset src="assets/fonts/arial.json" type="font" id="arial-font"></pc-asset>
             <pc-asset src="assets/splats/statues/angel.sog" id="angel"></pc-asset>
             <pc-asset src="assets/skies/sepulchral-chapel-rotunda-4k.webp" id="rotunda"></pc-asset>

--- a/examples/text3d.html
+++ b/examples/text3d.html
@@ -21,10 +21,10 @@
             <!-- Assets -->
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/grid.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-menu.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-session.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-controllers.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-menu.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-navigation.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-session.mjs"></pc-asset>
             <pc-asset src="assets/fonts/arial.json" type="font" id="arial-font"></pc-asset>
             <pc-asset src="assets/scripts/text3d.mjs"></pc-asset>
             <pc-asset id="arial" src="assets/fonts/arial.ttf" type="binary"></pc-asset>

--- a/examples/video-texture.html
+++ b/examples/video-texture.html
@@ -21,10 +21,10 @@
             <pc-module name="DracoDecoderModule" glue="modules/draco/draco.wasm.js" wasm="modules/draco/draco.wasm.wasm" fallback="modules/draco/draco.js"></pc-module>
             <!-- Assets -->
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-controllers.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-menu.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-navigation.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr-session.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-controllers.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-menu.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-navigation.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-session.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/shadow-catcher.mjs"></pc-asset>
             <pc-asset src="assets/fonts/arial.json" type="font" id="arial-font"></pc-asset>
             <pc-asset src="assets/scripts/video-texture.mjs"></pc-asset>


### PR DESCRIPTION
## What changed

The `playcanvas` npm module reorganized its bundled XR scripts, moving them from `scripts/esm/xr-*.mjs` into a new `scripts/esm/xr/` subdirectory. This broke every example that loads the XR scripts — the `<pc-asset>` `src` paths 404'd, so the XR controller, menu, navigation, and session scripts failed to load.

This updates the `<pc-asset src="...">` paths in all 14 affected example HTML files:

- `scripts/esm/xr-controllers.mjs` → `scripts/esm/xr/xr-controllers.mjs`
- `scripts/esm/xr-menu.mjs` → `scripts/esm/xr/xr-menu.mjs`
- `scripts/esm/xr-navigation.mjs` → `scripts/esm/xr/xr-navigation.mjs`
- `scripts/esm/xr-session.mjs` → `scripts/esm/xr/xr-session.mjs`

## Why

Keeps the examples working against the updated `playcanvas` dependency.

## Notes for reviewers

- The script names (`xrControllers`, `xrMenu`, `xrNavigation`, `xrSession`) and their attributes are unchanged in the new module, so the `<pc-script>` elements needed no edits — only the asset paths.
- Verified by loading `examples/animation.html` against the dev server: the scene renders and there are no console errors (XR assets resolve at their new paths).
- Confirmed all other `scripts/esm/*` references in the examples still point to files that exist in the updated module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)