### PR TITLE
Fix inverted flip-faces attribute parsing in CameraComponentElement

### DIFF
--- a/src/components/camera-component.ts
+++ b/src/components/camera-component.ts
@@ -513,7 +513,7 @@ class CameraComponentElement extends ComponentElement {
                 this.farClip = parseFloat(newValue);
                 break;
             case 'flip-faces':
-                this.flipFaces = newValue !== 'true';
+                this.flipFaces = newValue !== 'false';
                 break;
             case 'fov':
                 this.fov = parseFloat(newValue);


### PR DESCRIPTION
## What changed

Fixed the `flip-faces` case in `attributeChangedCallback` of `src/components/camera-component.ts`, which parsed the attribute with `newValue !== 'true'` — the inverse of the intended behavior. It now uses `newValue !== 'false'`.

## Why

The parse was inverted: `flip-faces="true"` set `flipFaces` to `false`, and `flip-faces="false"` set it to `true`. Every other string-parsed boolean attribute in the file (`clear-color-buffer`, `clear-depth-buffer`, `clear-stencil-buffer`, `cull-faces`, `frustum-culling`) uses `newValue !== 'false'`, so presence/any value enables and only an explicit `"false"` disables. This includes `clear-stencil-buffer`, which like `flipFaces` defaults to `false`.

## Notes for reviewers

- A sweep of `src/` for `!== 'true'` (and `=== 'true'` / `=== 'false'` variants) confirmed this was the only occurrence of the inverted pattern.
- Verified with `npm run lint` (clean) and `npm run build` (succeeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)