### PR TITLE
Add exports map, clean dist on build, and run type-check/publint in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Check package
+        run: npm run publint
+
   lint:
     runs-on: ubuntu-latest
 
@@ -40,3 +43,6 @@ jobs:
 
       - name: Run lint
         run: npm run lint
+
+      - name: Type check
+        run: npm run type-check

--- a/package.json
+++ b/package.json
@@ -27,12 +27,22 @@
   "module": "dist/pwc.mjs",
   "browser": "dist/pwc.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/pwc.mjs",
+      "require": "./dist/pwc.cjs"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "type": "module",
   "files": [
     "dist",
     "src"
   ],
   "scripts": {
+    "prebuild": "node -e \"fs.rmSync('dist', { recursive: true, force: true })\"",
     "build": "rollup -c",
     "dev": "concurrently \"npm run watch\" \"npm run serve\"",
     "docs": "typedoc",


### PR DESCRIPTION
## What

Package hygiene, first item from a repo-wide enhancement audit. No runtime or API changes.

- **`exports` map** in package.json: `types`/`import`/`require` conditions for `.`, a `./dist/*` passthrough so existing deep imports (import maps, pinned bundle paths) keep resolving, and `./package.json`. Legacy `main`/`module`/`browser`/`types` fields are unchanged for older tooling.
- **`prebuild` clean step** (dependency-free `node -e "fs.rmSync(...)"`): `dist/` is now regenerated from scratch on every `npm run build`.
- **CI**: the lint job now also runs `npm run type-check`; the build job runs `npm run publint` after building.

## Why

- The published npm package currently ships a stale `dist/components/splat-component.d.ts`, left over from the `pc-splat` → `pc-gsplat` rename (#247) — there was no clean step and `files` includes all of `dist`. The prebuild step eliminates it from the next release.
- Without an `exports` map, modern Node/bundler resolution falls back to legacy fields — a latent footgun for exactly the Next.js/Vite audience the library targets.
- `type-check` and `publint` both pass today but only ran at release time (or never); moving them to CI catches regressions on PRs.

## Notes for review

- Deliberately **no `browser` condition** in `exports`: it would hand modern bundlers the UMD build instead of ESM. CDN `<script src>` usage doesn't consult `exports`, so UMD consumers are unaffected.
- Deliberately **no `sideEffects` field**: element registration at import time is a genuine side effect; declaring `false` would let bundlers drop it.
- publint emits one advisory (exit 0) about the shared `types` file under the `require` condition — only relevant to CJS + TypeScript `nodenext` consumers of a browser-only package; a `.d.cts` split can address it later if desired.

## Verification

- `npm run build`: stale d.ts gone; all four bundles + maps + declarations regenerate.
- `npm run type-check`, `npm run lint`, `npm run publint` all pass (publint exit 0).
- `npm pack` + install in a scratch project: ESM resolves to `dist/pwc.mjs`, CJS to `dist/pwc.cjs`, deep path `dist/pwc.min.js` resolves via the passthrough.
- Loaded `examples/spinning-cube.html` against the rebuilt `dist`: renders correctly, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)