### PR TITLE
Lead the examples browser with showcase content

### DIFF
--- a/examples/js/example-list.mjs
+++ b/examples/js/example-list.mjs
@@ -1,4 +1,18 @@
 export const examples = [
+    // Showcases
+    { name: 'Car Configurator', path: 'car-configurator.html', category: 'Showcases' },
+    { name: 'Annotations', path: 'annotations.html', category: 'Showcases' },
+    { name: 'Shoe Configurator', path: 'shoe-configurator.html', category: 'Showcases' },
+    { name: 'Solar System', path: 'solar-system.html', category: 'Showcases' },
+    { name: 'Falling Blocks', path: 'vibe-falling-blocks.html', category: 'Showcases' },
+    // Gaussian Splatting
+    { name: 'Basic Splat', path: 'splat-simple.html', category: 'Gaussian Splatting' },
+    { name: 'Splat Annotations', path: 'splat-annotations.html', category: 'Gaussian Splatting' },
+    { name: 'Splat Flipbook', path: 'splat-flipbook.html', category: 'Gaussian Splatting' },
+    // XR
+    { name: 'AR Avatar', path: 'ar-avatar.html', category: 'XR' },
+    { name: 'AR Hand Gestures', path: 'ar-hand-gestures.html', category: 'XR' },
+    { name: 'First Person Teleport', path: 'first-person-teleport.html', category: 'XR' },
     // Graphics
     { name: 'Basic Shapes', path: 'basic-shapes.html', category: 'Graphics' },
     { name: 'Basic Particles', path: 'basic-particles.html', category: 'Graphics' },
@@ -19,19 +33,5 @@ export const examples = [
     { name: '2D Screen', path: 'screen.html', category: 'UI & Text' },
     { name: 'Text', path: 'text.html', category: 'UI & Text' },
     { name: '3D Text', path: 'text3d.html', category: 'UI & Text' },
-    { name: 'Scroll View', path: 'ui-scroll-view.html', category: 'UI & Text' },
-    // Gaussian Splatting
-    { name: 'Basic Splat', path: 'splat-simple.html', category: 'Gaussian Splatting' },
-    { name: 'Splat Annotations', path: 'splat-annotations.html', category: 'Gaussian Splatting' },
-    { name: 'Splat Flipbook', path: 'splat-flipbook.html', category: 'Gaussian Splatting' },
-    // XR
-    { name: 'AR Avatar', path: 'ar-avatar.html', category: 'XR' },
-    { name: 'AR Hand Gestures', path: 'ar-hand-gestures.html', category: 'XR' },
-    { name: 'First Person Teleport', path: 'first-person-teleport.html', category: 'XR' },
-    // Showcases
-    { name: 'Annotations', path: 'annotations.html', category: 'Showcases' },
-    { name: 'Car Configurator', path: 'car-configurator.html', category: 'Showcases' },
-    { name: 'Shoe Configurator', path: 'shoe-configurator.html', category: 'Showcases' },
-    { name: 'Solar System', path: 'solar-system.html', category: 'Showcases' },
-    { name: 'Falling Blocks', path: 'vibe-falling-blocks.html', category: 'Showcases' }
+    { name: 'Scroll View', path: 'ui-scroll-view.html', category: 'UI & Text' }
 ];


### PR DESCRIPTION
## What

Reorders `examples/js/example-list.mjs` so the examples browser leads with its strongest content:

- Category order is now **Showcases → Gaussian Splatting → XR → Graphics → Animation → Physics → Sound → UI & Text** (the sidebar renders categories in array order).
- **Car Configurator** moves to the head of the list, making it the default example — `browser.mjs` loads `examples[0]` when there's no hash, so the first thing every visitor previously saw was Basic Shapes (untextured primitives).

Entries otherwise keep their relative order. No paths or names change, so search and hash deep-links are unaffected. One file, ordering only.

## Verification

- `npm run lint` passes.
- Loaded the examples browser locally: Car Configurator loads by default and is highlighted active in the sidebar; categories render in the new order; zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)