### PR TITLE
Add generic whenReady() readiness API and typed tag names

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,31 +38,6 @@ See PlayCanvas Web Components in action here: https://playcanvas.github.io/web-c
 
 Please see the [Getting Started Guide](https://developer.playcanvas.com/user-manual/web-components/getting-started/) for installation and usage instructions.
 
-### Scripting elements
-
-PlayCanvas Web Components initialize asynchronously. To script against an element's underlying engine object, import `whenReady` and await it:
-
-```html
-<script type="module">
-    import { whenReady } from '@playcanvas/web-components';
-
-    const { app } = await whenReady('pc-app'); // app is the AppBase instance
-    app.scene.exposure = 0.5;
-</script>
-```
-
-`whenReady` accepts a tag name, any CSS selector or an element reference, and resolves with the element once its engine object has been created — so it works just as well for scenes, entities, cameras and so on:
-
-```js
-const { scene } = await whenReady('pc-scene');
-const camera = (await whenReady('pc-camera')).component;
-const { entity } = await whenReady('pc-entity[name="player"]');
-```
-
-Pages with multiple `<pc-app>` elements can disambiguate with a selector (e.g. `whenReady('#left')`). And if you already hold a reference to an element, you can await its `ready()` method directly — the primitive that `whenReady` builds on.
-
-For anything more substantial than page-level glue, prefer writing an engine script and attaching it with `<pc-script>` — scripts receive a fully initialized entity, so no readiness check is ever needed.
-
 ## Development 
 
 ### Setting Up Local Development

--- a/README.md
+++ b/README.md
@@ -38,6 +38,31 @@ See PlayCanvas Web Components in action here: https://playcanvas.github.io/web-c
 
 Please see the [Getting Started Guide](https://developer.playcanvas.com/user-manual/web-components/getting-started/) for installation and usage instructions.
 
+### Scripting elements
+
+PlayCanvas Web Components initialize asynchronously. To script against an element's underlying engine object, import `whenReady` and await it:
+
+```html
+<script type="module">
+    import { whenReady } from '@playcanvas/web-components';
+
+    const { app } = await whenReady('pc-app'); // app is the AppBase instance
+    app.scene.exposure = 0.5;
+</script>
+```
+
+`whenReady` accepts a tag name, any CSS selector or an element reference, and resolves with the element once its engine object has been created — so it works just as well for scenes, entities, cameras and so on:
+
+```js
+const { scene } = await whenReady('pc-scene');
+const camera = (await whenReady('pc-camera')).component;
+const { entity } = await whenReady('pc-entity[name="player"]');
+```
+
+Pages with multiple `<pc-app>` elements can disambiguate with a selector (e.g. `whenReady('#left')`). And if you already hold a reference to an element, you can await its `ready()` method directly — the primitive that `whenReady` builds on.
+
+For anything more substantial than page-level glue, prefer writing an engine script and attaching it with `<pc-script>` — scripts receive a fully initialized entity, so no readiness check is ever needed.
+
 ## Development 
 
 ### Setting Up Local Development

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,11 +22,7 @@ export default [
         languageOptions: {
             parser: tsParser,
             globals: {
-                ...globals.browser,
-                AddEventListenerOptions: "readonly",
-                EventListener: "readonly",
-                EventListenerOptions: "readonly",
-                HTMLElementTagNameMap: "readonly"
+                ...globals.browser
             }
         },
         plugins: {
@@ -38,9 +34,9 @@ export default [
             }
         },
         rules: {
+            // Disable the base rules that the TypeScript compiler already enforces
+            ...tsPlugin.configs['eslint-recommended'].overrides[0].rules,
             ...tsPlugin.configs['recommended'].rules,
-            // TypeScript function overloads are not redeclarations (tsc catches real ones)
-            'no-redeclare': 'off',
             '@typescript-eslint/ban-ts-comment': 'off',
             '@typescript-eslint/no-explicit-any': 'off',
             '@typescript-eslint/no-unused-vars': 'off',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,10 @@ export default [
             globals: {
                 ...globals.browser
             }
+        },
+        rules: {
+            // dist/pwc.mjs is a build output, so it is absent when linting an unbuilt checkout
+            'import/no-unresolved': ['error', { ignore: ['/dist/pwc\\.mjs$'] }]
         }
     },
     {
@@ -21,7 +25,8 @@ export default [
                 ...globals.browser,
                 AddEventListenerOptions: "readonly",
                 EventListener: "readonly",
-                EventListenerOptions: "readonly"
+                EventListenerOptions: "readonly",
+                HTMLElementTagNameMap: "readonly"
             }
         },
         plugins: {
@@ -34,6 +39,8 @@ export default [
         },
         rules: {
             ...tsPlugin.configs['recommended'].rules,
+            // TypeScript function overloads are not redeclarations (tsc catches real ones)
+            'no-redeclare': 'off',
             '@typescript-eslint/ban-ts-comment': 'off',
             '@typescript-eslint/no-explicit-any': 'off',
             '@typescript-eslint/no-unused-vars': 'off',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,7 +35,7 @@ export default [
         },
         rules: {
             // Disable the base rules that the TypeScript compiler already enforces
-            ...tsPlugin.configs['eslint-recommended'].overrides[0].rules,
+            ...tsPlugin.configs['flat/eslint-recommended'].rules,
             ...tsPlugin.configs['recommended'].rules,
             '@typescript-eslint/ban-ts-comment': 'off',
             '@typescript-eslint/no-explicit-any': 'off',

--- a/examples/ar-hand-gestures.html
+++ b/examples/ar-hand-gestures.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs",
                     "@mediapipe/tasks-vision": "../node_modules/@mediapipe/tasks-vision/vision_bundle.mjs"
                 }
@@ -37,16 +38,16 @@
             </pc-scene>
         </pc-app>
         <script type="module">
-            document.addEventListener('DOMContentLoaded', async () => {
-                const app = await document.querySelector('pc-app').ready();
+            import { whenReady } from '@playcanvas/web-components';
 
-                app.app.on('hand:gesture', (handIndex, gesture, score) => {
-                    console.log(`Hand ${handIndex} detected gesture: ${gesture} (score: ${score})`);
-                });
+            const { app } = await whenReady('pc-app');
 
-                app.app.on('hand:position', (handIndex, position) => {
-                    console.log(`Hand ${handIndex} position: ${position}`);
-                });
+            app.on('hand:gesture', (handIndex, gesture, score) => {
+                console.log(`Hand ${handIndex} detected gesture: ${gesture} (score: ${score})`);
+            });
+
+            app.on('hand:position', (handIndex, position) => {
+                console.log(`Hand ${handIndex} position: ${position}`);
             });
         </script>
         <script type="module" src="js/example.mjs"></script>

--- a/examples/assets/scripts/material-variants.mjs
+++ b/examples/assets/scripts/material-variants.mjs
@@ -1,5 +1,7 @@
+import { whenReady } from '../../../dist/pwc.mjs';
+
 document.addEventListener('DOMContentLoaded', async () => {
-    await document.querySelector('pc-app').ready();
+    await whenReady('pc-app');
 
     const entityElement = document.querySelector('pc-entity[name="shoe"]');
     const assetElement = document.querySelector('pc-asset#shoe');

--- a/examples/assets/scripts/material-variants.mjs
+++ b/examples/assets/scripts/material-variants.mjs
@@ -1,43 +1,41 @@
 import { whenReady } from '../../../dist/pwc.mjs';
 
-document.addEventListener('DOMContentLoaded', async () => {
-    await whenReady('pc-app');
+await whenReady('pc-app');
 
-    const entityElement = document.querySelector('pc-entity[name="shoe"]');
-    const assetElement = document.querySelector('pc-asset#shoe');
+const entityElement = document.querySelector('pc-entity[name="shoe"]');
+const assetElement = document.querySelector('pc-asset#shoe');
 
-    if (entityElement && assetElement) {
-        const resource = assetElement.asset.resource;
-        const variants = resource.getMaterialVariants();
+if (entityElement && assetElement) {
+    const resource = assetElement.asset.resource;
+    const variants = resource.getMaterialVariants();
 
-        // create container for buttons
-        const buttonContainer = document.createElement('div');
-        buttonContainer.classList.add('example-button-container', 'top-right');
+    // create container for buttons
+    const buttonContainer = document.createElement('div');
+    buttonContainer.classList.add('example-button-container', 'top-right');
 
-        // create a button for each variant
-        variants.forEach((variant) => {
-            const button = document.createElement('button');
-            button.textContent = variant.split('-')
-            .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-            .join(' ');
+    // create a button for each variant
+    variants.forEach((variant) => {
+        const button = document.createElement('button');
+        button.textContent = variant.split('-')
+        .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ');
 
-            button.classList.add('example-button');
+        button.classList.add('example-button');
 
-            button.onmouseenter = () => {
-                button.style.background = 'rgba(255, 255, 255, 1)';
-            };
+        button.onmouseenter = () => {
+            button.style.background = 'rgba(255, 255, 255, 1)';
+        };
 
-            button.onmouseleave = () => {
-                button.style.background = 'rgba(255, 255, 255, 0.9)';
-            };
+        button.onmouseleave = () => {
+            button.style.background = 'rgba(255, 255, 255, 0.9)';
+        };
 
-            button.addEventListener('click', () => {
-                resource.applyMaterialVariant(entityElement.entity, variant);
-            });
-
-            buttonContainer.appendChild(button);
+        button.addEventListener('click', () => {
+            resource.applyMaterialVariant(entityElement.entity, variant);
         });
 
-        document.body.appendChild(buttonContainer);
-    }
-});
+        buttonContainer.appendChild(button);
+    });
+
+    document.body.appendChild(buttonContainer);
+}

--- a/examples/js/example.mjs
+++ b/examples/js/example.mjs
@@ -2,101 +2,99 @@ import { MiniStats, XRTYPE_AR, XRTYPE_VR } from 'playcanvas';
 
 import { whenReady } from '../../dist/pwc.mjs';
 
-document.addEventListener('DOMContentLoaded', async () => {
-    const { app } = await whenReady('pc-app');
+const { app } = await whenReady('pc-app');
 
-    // Add MiniStats if query parameter is present
-    if (new URLSearchParams(window.location.search).has('ministats')) {
-        /* eslint-disable-next-line no-unused-vars */
-        const stats = new MiniStats(app);
+// Add MiniStats if query parameter is present
+if (new URLSearchParams(window.location.search).has('ministats')) {
+    /* eslint-disable-next-line no-unused-vars */
+    const stats = new MiniStats(app);
+}
+
+// Check if this example supports XR
+function isXRCapable() {
+    // Check for XR-related scripts
+    const xrScripts = document.querySelectorAll('pc-script[name="xrSession"], pc-script[name="xrControllers"], pc-script[name="xrNavigation"]');
+    return xrScripts.length > 0;
+}
+
+// Create container for buttons
+const container = document.createElement('div');
+container.classList.add('example-button-container', 'bottom-right');
+
+function createButton({ iconClass, title, onClick }) {
+    const button = document.createElement('button');
+    if (iconClass) button.classList.add(iconClass);
+    button.title = title;
+    button.classList.add('example-button', 'icon');
+
+    if (onClick) {
+        button.onclick = onClick;
     }
 
-    // Check if this example supports XR
-    function isXRCapable() {
-        // Check for XR-related scripts
-        const xrScripts = document.querySelectorAll('pc-script[name="xrSession"], pc-script[name="xrControllers"], pc-script[name="xrNavigation"]');
-        return xrScripts.length > 0;
-    }
+    return button;
+}
 
-    // Create container for buttons
-    const container = document.createElement('div');
-    container.classList.add('example-button-container', 'bottom-right');
-
-    function createButton({ iconClass, title, onClick }) {
-        const button = document.createElement('button');
-        if (iconClass) button.classList.add(iconClass);
-        button.title = title;
-        button.classList.add('example-button', 'icon');
-
-        if (onClick) {
-            button.onclick = onClick;
-        }
-
-        return button;
-    }
-
-    // Only create AR/VR buttons for XR-capable examples
-    if (app.xr && isXRCapable()) {
-        const arButton = createButton({
-            iconClass: 'icon-ar',
-            title: 'Enter AR',
-            onClick: () => app.fire('ar:start')
-        });
-        arButton.style.display = app.xr.isAvailable(XRTYPE_AR) ? 'flex' : 'none';
-        container.appendChild(arButton);
-
-        const vrButton = createButton({
-            iconClass: 'icon-vr',
-            title: 'Enter VR',
-            onClick: () => app.fire('vr:start')
-        });
-        vrButton.style.display = app.xr.isAvailable(XRTYPE_VR) ? 'flex' : 'none';
-        container.appendChild(vrButton);
-
-        app.xr.on('available', (type, available) => {
-            switch (type) {
-                case XRTYPE_AR:
-                    arButton.style.display = available ? 'flex' : 'none';
-                    break;
-                case XRTYPE_VR:
-                    vrButton.style.display = available ? 'flex' : 'none';
-                    break;
-            }
-        });
-    }
-
-    // Add fullscreen button if supported
-    if (document.documentElement.requestFullscreen && document.exitFullscreen) {
-        const fullscreenButton = createButton({
-            iconClass: 'icon-fs-enter',
-            title: 'Enter Fullscreen',
-            onClick: () => {
-                if (!document.fullscreenElement) {
-                    document.documentElement.requestFullscreen();
-                } else {
-                    document.exitFullscreen();
-                }
-            }
-        });
-
-        // Update icon when fullscreen state changes
-        document.addEventListener('fullscreenchange', () => {
-            fullscreenButton.classList.toggle('icon-fs-enter', !document.fullscreenElement);
-            fullscreenButton.classList.toggle('icon-fs-exit', !!document.fullscreenElement);
-            fullscreenButton.title = document.fullscreenElement ? 'Exit Fullscreen' : 'Enter Fullscreen';
-        });
-
-        container.appendChild(fullscreenButton);
-    }
-
-    // Add source button
-    const filename = window.location.pathname.split('/').pop();
-    const sourceButton = createButton({
-        iconClass: 'icon-source',
-        title: 'View Source',
-        onClick: () => window.open(`https://github.com/playcanvas/web-components/tree/main/examples/${filename}`, '_blank')
+// Only create AR/VR buttons for XR-capable examples
+if (app.xr && isXRCapable()) {
+    const arButton = createButton({
+        iconClass: 'icon-ar',
+        title: 'Enter AR',
+        onClick: () => app.fire('ar:start')
     });
-    container.appendChild(sourceButton);
+    arButton.style.display = app.xr.isAvailable(XRTYPE_AR) ? 'flex' : 'none';
+    container.appendChild(arButton);
 
-    document.body.appendChild(container);
+    const vrButton = createButton({
+        iconClass: 'icon-vr',
+        title: 'Enter VR',
+        onClick: () => app.fire('vr:start')
+    });
+    vrButton.style.display = app.xr.isAvailable(XRTYPE_VR) ? 'flex' : 'none';
+    container.appendChild(vrButton);
+
+    app.xr.on('available', (type, available) => {
+        switch (type) {
+            case XRTYPE_AR:
+                arButton.style.display = available ? 'flex' : 'none';
+                break;
+            case XRTYPE_VR:
+                vrButton.style.display = available ? 'flex' : 'none';
+                break;
+        }
+    });
+}
+
+// Add fullscreen button if supported
+if (document.documentElement.requestFullscreen && document.exitFullscreen) {
+    const fullscreenButton = createButton({
+        iconClass: 'icon-fs-enter',
+        title: 'Enter Fullscreen',
+        onClick: () => {
+            if (!document.fullscreenElement) {
+                document.documentElement.requestFullscreen();
+            } else {
+                document.exitFullscreen();
+            }
+        }
+    });
+
+    // Update icon when fullscreen state changes
+    document.addEventListener('fullscreenchange', () => {
+        fullscreenButton.classList.toggle('icon-fs-enter', !document.fullscreenElement);
+        fullscreenButton.classList.toggle('icon-fs-exit', !!document.fullscreenElement);
+        fullscreenButton.title = document.fullscreenElement ? 'Exit Fullscreen' : 'Enter Fullscreen';
+    });
+
+    container.appendChild(fullscreenButton);
+}
+
+// Add source button
+const filename = window.location.pathname.split('/').pop();
+const sourceButton = createButton({
+    iconClass: 'icon-source',
+    title: 'View Source',
+    onClick: () => window.open(`https://github.com/playcanvas/web-components/tree/main/examples/${filename}`, '_blank')
 });
+container.appendChild(sourceButton);
+
+document.body.appendChild(container);

--- a/examples/js/example.mjs
+++ b/examples/js/example.mjs
@@ -2,7 +2,9 @@ import { MiniStats, XRTYPE_AR, XRTYPE_VR } from 'playcanvas';
 
 import { whenReady } from '../../dist/pwc.mjs';
 
-const { app } = await whenReady('pc-app');
+const appElement = await whenReady('pc-app');
+/** @type {import('playcanvas').AppBase} */
+const app = appElement.app;
 
 // Add MiniStats if query parameter is present
 if (new URLSearchParams(window.location.search).has('ministats')) {

--- a/examples/js/example.mjs
+++ b/examples/js/example.mjs
@@ -1,9 +1,9 @@
 import { MiniStats, XRTYPE_AR, XRTYPE_VR } from 'playcanvas';
 
+import { whenReady } from '../../dist/pwc.mjs';
+
 document.addEventListener('DOMContentLoaded', async () => {
-    const appElement = await document.querySelector('pc-app').ready();
-    /** @type {import('playcanvas').AppBase} */
-    const app = appElement.app;
+    const { app } = await whenReady('pc-app');
 
     // Add MiniStats if query parameter is present
     if (new URLSearchParams(window.location.search).has('ministats')) {

--- a/examples/solar-system.html
+++ b/examples/solar-system.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }
@@ -579,21 +580,21 @@
         </div>
 
         <script type="module">
-            document.addEventListener('DOMContentLoaded', async () => {
-                const app = await document.querySelector('pc-app').ready();
-                const planets = ['sun', 'mercury', 'venus', 'earth', 'mars', 'jupiter', 'saturn', 'uranus', 'neptune'];
-                let currentPlanetIndex = -1;
+            import { whenReady } from '@playcanvas/web-components';
 
-                window.addEventListener('scroll', () => {
-                    const scrollPercent = window.scrollY / (document.documentElement.scrollHeight - window.innerHeight);
-                    const newPlanetIndex = Math.floor(scrollPercent * planets.length);
-                    
-                    // Only fire event when we change sections
-                    if (newPlanetIndex !== currentPlanetIndex) {
-                        currentPlanetIndex = newPlanetIndex;
-                        app.app.fire('zoom', planets[currentPlanetIndex]);
-                    }
-                });
+            const { app } = await whenReady('pc-app');
+            const planets = ['sun', 'mercury', 'venus', 'earth', 'mars', 'jupiter', 'saturn', 'uranus', 'neptune'];
+            let currentPlanetIndex = -1;
+
+            window.addEventListener('scroll', () => {
+                const scrollPercent = window.scrollY / (document.documentElement.scrollHeight - window.innerHeight);
+                const newPlanetIndex = Math.floor(scrollPercent * planets.length);
+
+                // Only fire event when we change sections
+                if (newPlanetIndex !== currentPlanetIndex) {
+                    currentPlanetIndex = newPlanetIndex;
+                    app.fire('zoom', planets[currentPlanetIndex]);
+                }
             });
         </script>
     </body>

--- a/examples/spinning-cube-api.html
+++ b/examples/spinning-cube-api.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }
@@ -18,11 +19,13 @@
         <script type="module">
             import { registerScript, Script } from 'playcanvas';
 
+            import { whenReady } from '@playcanvas/web-components';
+
             // Use the DOM API to programmatically create the scene
             const app = document.createElement('pc-app');
             document.body.appendChild(app);
 
-            await app.ready();
+            await whenReady(app);
 
             class Rotate extends Script { 
                 update(dt) {

--- a/examples/splat-flipbook.html
+++ b/examples/splat-flipbook.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }
@@ -96,8 +97,10 @@
         </pc-app>
         <script type="module" src="js/example.mjs"></script>
         <script type="module">
-            const appElement = await document.querySelector('pc-app').ready();
-            appElement.app.scene.gsplat.alphaClip = 0.1;
+            import { whenReady } from '@playcanvas/web-components';
+
+            const { app } = await whenReady('pc-app');
+            app.scene.gsplat.alphaClip = 0.1;
         </script>
     </body>
 </html>

--- a/src/app.ts
+++ b/src/app.ts
@@ -614,4 +614,10 @@ class AppElement extends AsyncElement {
 
 customElements.define('pc-app', AppElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-app': AppElement;
+    }
+}
+
 export { AppElement };

--- a/src/app.ts
+++ b/src/app.ts
@@ -116,10 +116,16 @@ class AppElement extends AsyncElement {
         pointerup: null
     };
 
+    private _app: AppBase | null = null;
+
     /**
-     * The PlayCanvas application instance.
+     * The PlayCanvas application instance. Available once the element is ready — await
+     * {@link whenReady} or the element's `ready()` promise before accessing it.
+     * @returns The application instance.
      */
-    app: AppBase | null = null;
+    get app(): AppBase {
+        return this._app!;
+    }
 
     /**
      * Creates a new AppElement instance.
@@ -227,7 +233,7 @@ class AppElement extends AsyncElement {
         createOptions.batchManager = BatchManager;
         createOptions.xr = XrManager;
 
-        this.app = new AppBase(this._canvas);
+        this._app = new AppBase(this._canvas);
         this.app.init(createOptions);
 
         this.app.setCanvasFillMode(FILLMODE_FILL_WINDOW);
@@ -282,7 +288,7 @@ class AppElement extends AsyncElement {
         // Clean up the application
         if (this.app) {
             this.app.destroy();
-            this.app = null;
+            this._app = null;
         }
 
         // Remove event listeners

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -229,4 +229,10 @@ class AssetElement extends HTMLElement {
 
 customElements.define('pc-asset', AssetElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-asset': AssetElement;
+    }
+}
+
 export { AssetElement };

--- a/src/async-element.ts
+++ b/src/async-element.ts
@@ -52,14 +52,9 @@ type AsyncElementTagName = {
 }[keyof HTMLElementTagNameMap];
 
 /**
- * A union of the tag names of all elements that do not initialize asynchronously. Used to reject
- * `whenReady('pc-asset')` and the like at compile time, while still accepting arbitrary CSS
- * selectors.
- */
-type NonAsyncElementTagName = Exclude<keyof HTMLElementTagNameMap, AsyncElementTagName>;
-
-/**
- * Waits for the first element matching the given tag name to be fully initialized.
+ * Waits for the first element matching the given tag name to be fully initialized. Note that the
+ * promise never settles if the element cannot finish initializing (for example, a component
+ * element that is not inside a `<pc-app>`).
  * @param target - The tag name of the element to wait for (e.g. `'pc-app'`).
  * @returns A promise that resolves with the element once it's ready.
  * @example
@@ -67,7 +62,9 @@ type NonAsyncElementTagName = Exclude<keyof HTMLElementTagNameMap, AsyncElementT
  */
 function whenReady<K extends AsyncElementTagName>(target: K): Promise<HTMLElementTagNameMap[K]>;
 /**
- * Waits for the given element to be fully initialized.
+ * Waits for the given element to be fully initialized. Note that the promise never settles if
+ * the element cannot finish initializing (for example, an element that is never added to the
+ * document).
  * @param target - The element to wait for.
  * @returns A promise that resolves with the element once it's ready.
  * @example
@@ -77,26 +74,42 @@ function whenReady<K extends AsyncElementTagName>(target: K): Promise<HTMLElemen
  */
 function whenReady<T extends AsyncElement>(target: T): Promise<T>;
 /**
- * Waits for the first element matching the given CSS selector to be fully initialized.
+ * Waits for the first element matching the given CSS selector to be fully initialized. Note that
+ * the promise never settles if the element cannot finish initializing (for example, a component
+ * element that is not inside a `<pc-app>`).
  * @param target - A CSS selector matching the element to wait for (e.g. `'#my-app'`).
  * @returns A promise that resolves with the element once it's ready.
  * @example
- * const { entity } = await whenReady('pc-entity[name="camera"]');
+ * // In TypeScript, supply the element type when using an arbitrary selector
+ * const { entity } = await whenReady<EntityElement>('pc-entity[name="camera"]');
  */
-function whenReady<T extends AsyncElement = AsyncElement, S extends string = string>(target: S extends NonAsyncElementTagName ? never : S): Promise<T>;
+function whenReady<T extends AsyncElement = AsyncElement, S extends string = string>(
+    target: S extends Exclude<keyof HTMLElementTagNameMap, AsyncElementTagName> ? never : S
+): Promise<T>;
 async function whenReady(target: string | AsyncElement): Promise<AsyncElement> {
-    if (document.readyState === 'loading') {
-        await new Promise((resolve) => {
-            document.addEventListener('DOMContentLoaded', resolve, { once: true });
-        });
+    let element: Element | null;
+    if (typeof target === 'string') {
+        if (document.readyState === 'loading') {
+            await new Promise((resolve) => {
+                document.addEventListener('DOMContentLoaded', resolve, { once: true });
+            });
+        }
+
+        try {
+            element = document.querySelector(target);
+        } catch {
+            throw new Error(`whenReady: '${target}' is not a valid CSS selector`);
+        }
+        if (!element) {
+            throw new Error(`whenReady: no element found matching '${target}'`);
+        }
+    } else {
+        element = target;
     }
 
-    const element = typeof target === 'string' ? document.querySelector(target) : target;
-    if (!element) {
-        throw new Error(`whenReady: no element found matching '${target}'`);
-    }
     if (!(element instanceof AsyncElement)) {
-        throw new Error(`whenReady: element matching '${target}' does not initialize asynchronously`);
+        const description = element instanceof Element ? `<${element.tagName.toLowerCase()}>` : String(target);
+        throw new Error(`whenReady: ${description} does not initialize asynchronously`);
     }
 
     await element.ready();
@@ -105,4 +118,4 @@ async function whenReady(target: string | AsyncElement): Promise<AsyncElement> {
 }
 
 export { AsyncElement, whenReady };
-export type { AsyncElementTagName, NonAsyncElementTagName };
+export type { AsyncElementTagName };

--- a/src/async-element.ts
+++ b/src/async-element.ts
@@ -43,4 +43,66 @@ class AsyncElement extends HTMLElement {
     }
 }
 
-export { AsyncElement };
+/**
+ * A union of the tag names of all elements that initialize asynchronously (i.e. elements whose
+ * classes extend {@link AsyncElement}).
+ */
+type AsyncElementTagName = {
+    [K in keyof HTMLElementTagNameMap]: HTMLElementTagNameMap[K] extends AsyncElement ? K : never
+}[keyof HTMLElementTagNameMap];
+
+/**
+ * A union of the tag names of all elements that do not initialize asynchronously. Used to reject
+ * `whenReady('pc-asset')` and the like at compile time, while still accepting arbitrary CSS
+ * selectors.
+ */
+type NonAsyncElementTagName = Exclude<keyof HTMLElementTagNameMap, AsyncElementTagName>;
+
+/**
+ * Waits for the first element matching the given tag name to be fully initialized.
+ * @param target - The tag name of the element to wait for (e.g. `'pc-app'`).
+ * @returns A promise that resolves with the element once it's ready.
+ * @example
+ * const { app } = await whenReady('pc-app');
+ */
+function whenReady<K extends AsyncElementTagName>(target: K): Promise<HTMLElementTagNameMap[K]>;
+/**
+ * Waits for the given element to be fully initialized.
+ * @param target - The element to wait for.
+ * @returns A promise that resolves with the element once it's ready.
+ * @example
+ * const appElement = document.createElement('pc-app');
+ * document.body.appendChild(appElement);
+ * const { app } = await whenReady(appElement);
+ */
+function whenReady<T extends AsyncElement>(target: T): Promise<T>;
+/**
+ * Waits for the first element matching the given CSS selector to be fully initialized.
+ * @param target - A CSS selector matching the element to wait for (e.g. `'#my-app'`).
+ * @returns A promise that resolves with the element once it's ready.
+ * @example
+ * const { entity } = await whenReady('pc-entity[name="camera"]');
+ */
+function whenReady<T extends AsyncElement = AsyncElement, S extends string = string>(target: S extends NonAsyncElementTagName ? never : S): Promise<T>;
+async function whenReady(target: string | AsyncElement): Promise<AsyncElement> {
+    if (document.readyState === 'loading') {
+        await new Promise((resolve) => {
+            document.addEventListener('DOMContentLoaded', resolve, { once: true });
+        });
+    }
+
+    const element = typeof target === 'string' ? document.querySelector(target) : target;
+    if (!element) {
+        throw new Error(`whenReady: no element found matching '${target}'`);
+    }
+    if (!(element instanceof AsyncElement)) {
+        throw new Error(`whenReady: element matching '${target}' does not initialize asynchronously`);
+    }
+
+    await element.ready();
+
+    return element;
+}
+
+export { AsyncElement, whenReady };
+export type { AsyncElementTagName, NonAsyncElementTagName };

--- a/src/async-element.ts
+++ b/src/async-element.ts
@@ -26,16 +26,18 @@ class AsyncElement extends HTMLElement {
     }
 
     /**
-     * Called when the element is fully initialized and ready.
-     * Subclasses should call this when they're ready.
+     * Called when the element is fully initialized and ready. Subclasses should call this when
+     * they're ready. Resolves the ready promise and dispatches a bubbling, composed `ready`
+     * event.
      */
     protected _onReady() {
         this._readyResolve();
-        this.dispatchEvent(new CustomEvent('ready'));
+        this.dispatchEvent(new CustomEvent('ready', { bubbles: true, composed: true }));
     }
 
     /**
-     * Returns a promise that resolves with this element when it's ready.
+     * Returns a promise that resolves with this element when it's ready. This is the low-level
+     * primitive underlying {@link whenReady}, which is the recommended way to wait for elements.
      * @returns A promise that resolves with this element when it's ready.
      */
     ready(): Promise<this> {

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -447,4 +447,10 @@ class ButtonComponentElement extends ComponentElement {
 
 customElements.define('pc-button', ButtonComponentElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-button': ButtonComponentElement;
+    }
+}
+
 export { ButtonComponentElement };

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -94,8 +94,8 @@ class ButtonComponentElement extends ComponentElement {
      * Gets the underlying PlayCanvas button component.
      * @returns The button component.
      */
-    get component(): ButtonComponent | null {
-        return super.component as ButtonComponent | null;
+    get component(): ButtonComponent {
+        return super.component as ButtonComponent;
     }
 
     /**

--- a/src/components/camera-component.ts
+++ b/src/components/camera-component.ts
@@ -554,4 +554,10 @@ class CameraComponentElement extends ComponentElement {
 
 customElements.define('pc-camera', CameraComponentElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-camera': CameraComponentElement;
+    }
+}
+
 export { CameraComponentElement };

--- a/src/components/camera-component.ts
+++ b/src/components/camera-component.ts
@@ -119,8 +119,8 @@ class CameraComponentElement extends ComponentElement {
      * Gets the underlying PlayCanvas camera component.
      * @returns The camera component.
      */
-    get component(): CameraComponent | null {
-        return super.component as CameraComponent | null;
+    get component(): CameraComponent {
+        return super.component as CameraComponent;
     }
 
     /**

--- a/src/components/collision-component.ts
+++ b/src/components/collision-component.ts
@@ -50,8 +50,8 @@ class CollisionComponentElement extends ComponentElement {
      * Gets the underlying PlayCanvas collision component.
      * @returns The collision component.
      */
-    get component(): CollisionComponent | null {
-        return super.component as CollisionComponent | null;
+    get component(): CollisionComponent {
+        return super.component as CollisionComponent;
     }
 
     set angularOffset(value: Quat) {

--- a/src/components/collision-component.ts
+++ b/src/components/collision-component.ts
@@ -180,4 +180,10 @@ class CollisionComponentElement extends ComponentElement {
 
 customElements.define('pc-collision', CollisionComponentElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-collision': CollisionComponentElement;
+    }
+}
+
 export { CollisionComponentElement };

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -58,8 +58,13 @@ class ComponentElement extends AsyncElement {
         }
     }
 
-    get component(): Component | null {
-        return this._component;
+    /**
+     * The PlayCanvas component instance. Available once the element is ready — await
+     * {@link whenReady} or the element's `ready()` promise before accessing it.
+     * @returns The component instance.
+     */
+    get component(): Component {
+        return this._component!;
     }
 
     /**

--- a/src/components/element-component.ts
+++ b/src/components/element-component.ts
@@ -148,8 +148,8 @@ class ElementComponentElement extends ComponentElement {
      * Gets the underlying PlayCanvas element component.
      * @returns The element component.
      */
-    get component(): ElementComponent | null {
-        return super.component as ElementComponent | null;
+    get component(): ElementComponent {
+        return super.component as ElementComponent;
     }
 
     /**

--- a/src/components/element-component.ts
+++ b/src/components/element-component.ts
@@ -774,4 +774,10 @@ class ElementComponentElement extends ComponentElement {
 
 customElements.define('pc-element', ElementComponentElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-element': ElementComponentElement;
+    }
+}
+
 export { ElementComponentElement };

--- a/src/components/gsplat-component.ts
+++ b/src/components/gsplat-component.ts
@@ -44,8 +44,8 @@ class GSplatComponentElement extends ComponentElement {
      * Gets the underlying PlayCanvas gsplat component.
      * @returns The gsplat component.
      */
-    get component(): GSplatComponent | null {
-        return super.component as GSplatComponent | null;
+    get component(): GSplatComponent {
+        return super.component as GSplatComponent;
     }
 
     /**

--- a/src/components/gsplat-component.ts
+++ b/src/components/gsplat-component.ts
@@ -215,4 +215,10 @@ class GSplatComponentElement extends ComponentElement {
 
 customElements.define('pc-gsplat', GSplatComponentElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-gsplat': GSplatComponentElement;
+    }
+}
+
 export { GSplatComponentElement };

--- a/src/components/layoutchild-component.ts
+++ b/src/components/layoutchild-component.ts
@@ -46,8 +46,8 @@ class LayoutChildComponentElement extends ComponentElement {
      * Gets the underlying PlayCanvas layout child component.
      * @returns The layout child component.
      */
-    get component(): LayoutChildComponent | null {
-        return super.component as LayoutChildComponent | null;
+    get component(): LayoutChildComponent {
+        return super.component as LayoutChildComponent;
     }
 
     /**

--- a/src/components/layoutchild-component.ts
+++ b/src/components/layoutchild-component.ts
@@ -229,4 +229,10 @@ class LayoutChildComponentElement extends ComponentElement {
 
 customElements.define('pc-layoutchild', LayoutChildComponentElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-layoutchild': LayoutChildComponentElement;
+    }
+}
+
 export { LayoutChildComponentElement };

--- a/src/components/layoutgroup-component.ts
+++ b/src/components/layoutgroup-component.ts
@@ -65,8 +65,8 @@ class LayoutGroupComponentElement extends ComponentElement {
      * Gets the underlying PlayCanvas layout group component.
      * @returns The layout group component.
      */
-    get component(): LayoutGroupComponent | null {
-        return super.component as LayoutGroupComponent | null;
+    get component(): LayoutGroupComponent {
+        return super.component as LayoutGroupComponent;
     }
 
     /**

--- a/src/components/layoutgroup-component.ts
+++ b/src/components/layoutgroup-component.ts
@@ -294,4 +294,10 @@ class LayoutGroupComponentElement extends ComponentElement {
 
 customElements.define('pc-layoutgroup', LayoutGroupComponentElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-layoutgroup': LayoutGroupComponentElement;
+    }
+}
+
 export { LayoutGroupComponentElement };

--- a/src/components/light-component.ts
+++ b/src/components/light-component.ts
@@ -567,4 +567,10 @@ class LightComponentElement extends ComponentElement {
 
 customElements.define('pc-light', LightComponentElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-light': LightComponentElement;
+    }
+}
+
 export { LightComponentElement };

--- a/src/components/light-component.ts
+++ b/src/components/light-component.ts
@@ -95,8 +95,8 @@ class LightComponentElement extends ComponentElement {
      * Gets the underlying PlayCanvas light component.
      * @returns The light component.
      */
-    get component(): LightComponent | null {
-        return super.component as LightComponent | null;
+    get component(): LightComponent {
+        return super.component as LightComponent;
     }
 
     /**

--- a/src/components/listener-component.ts
+++ b/src/components/listener-component.ts
@@ -27,4 +27,10 @@ class ListenerComponentElement extends ComponentElement {
 
 customElements.define('pc-listener', ListenerComponentElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-listener': ListenerComponentElement;
+    }
+}
+
 export { ListenerComponentElement };

--- a/src/components/listener-component.ts
+++ b/src/components/listener-component.ts
@@ -20,8 +20,8 @@ class ListenerComponentElement extends ComponentElement {
      * Gets the underlying PlayCanvas audio listener component.
      * @returns The audio listener component.
      */
-    get component(): AudioListenerComponent | null {
-        return super.component as AudioListenerComponent | null;
+    get component(): AudioListenerComponent {
+        return super.component as AudioListenerComponent;
     }
 }
 

--- a/src/components/particlesystem-component.ts
+++ b/src/components/particlesystem-component.ts
@@ -152,4 +152,10 @@ class ParticleSystemComponentElement extends ComponentElement {
 
 customElements.define('pc-particles', ParticleSystemComponentElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-particles': ParticleSystemComponentElement;
+    }
+}
+
 export { ParticleSystemComponentElement };

--- a/src/components/particlesystem-component.ts
+++ b/src/components/particlesystem-component.ts
@@ -40,8 +40,8 @@ class ParticleSystemComponentElement extends ComponentElement {
      * Gets the underlying PlayCanvas particle system component.
      * @returns The particle system component.
      */
-    get component(): ParticleSystemComponent | null {
-        return super.component as ParticleSystemComponent | null;
+    get component(): ParticleSystemComponent {
+        return super.component as ParticleSystemComponent;
     }
 
     private applyConfig(resource: any) {

--- a/src/components/render-component.ts
+++ b/src/components/render-component.ts
@@ -38,8 +38,8 @@ class RenderComponentElement extends ComponentElement {
      * Gets the underlying PlayCanvas render component.
      * @returns The render component.
      */
-    get component(): RenderComponent | null {
-        return super.component as RenderComponent | null;
+    get component(): RenderComponent {
+        return super.component as RenderComponent;
     }
 
     /**

--- a/src/components/render-component.ts
+++ b/src/components/render-component.ts
@@ -144,4 +144,10 @@ class RenderComponentElement extends ComponentElement {
 
 customElements.define('pc-render', RenderComponentElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-render': RenderComponentElement;
+    }
+}
+
 export { RenderComponentElement };

--- a/src/components/rigidbody-component.ts
+++ b/src/components/rigidbody-component.ts
@@ -224,4 +224,10 @@ class RigidBodyComponentElement extends ComponentElement {
 
 customElements.define('pc-rigidbody', RigidBodyComponentElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-rigidbody': RigidBodyComponentElement;
+    }
+}
+
 export { RigidBodyComponentElement };

--- a/src/components/rigidbody-component.ts
+++ b/src/components/rigidbody-component.ts
@@ -80,8 +80,8 @@ class RigidBodyComponentElement extends ComponentElement {
      * Gets the underlying PlayCanvas rigidbody component.
      * @returns The rigidbody component.
      */
-    get component(): RigidBodyComponent | null {
-        return super.component as RigidBodyComponent | null;
+    get component(): RigidBodyComponent {
+        return super.component as RigidBodyComponent;
     }
 
     set angularDamping(value: number) {

--- a/src/components/screen-component.ts
+++ b/src/components/screen-component.ts
@@ -44,8 +44,8 @@ class ScreenComponentElement extends ComponentElement {
      * Gets the underlying PlayCanvas screen component.
      * @returns The screen component.
      */
-    get component(): ScreenComponent | null {
-        return super.component as ScreenComponent | null;
+    get component(): ScreenComponent {
+        return super.component as ScreenComponent;
     }
 
     set priority(value: number) {

--- a/src/components/screen-component.ts
+++ b/src/components/screen-component.ts
@@ -154,4 +154,10 @@ class ScreenComponentElement extends ComponentElement {
 
 customElements.define('pc-screen', ScreenComponentElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-screen': ScreenComponentElement;
+    }
+}
+
 export { ScreenComponentElement };

--- a/src/components/script-component.ts
+++ b/src/components/script-component.ts
@@ -267,4 +267,10 @@ class ScriptComponentElement extends ComponentElement {
 
 customElements.define('pc-scripts', ScriptComponentElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-scripts': ScriptComponentElement;
+    }
+}
+
 export { ScriptComponentElement };

--- a/src/components/script-component.ts
+++ b/src/components/script-component.ts
@@ -260,8 +260,8 @@ class ScriptComponentElement extends ComponentElement {
      * Gets the underlying PlayCanvas script component.
      * @returns The script component.
      */
-    get component(): ScriptComponent | null {
-        return super.component as ScriptComponent | null;
+    get component(): ScriptComponent {
+        return super.component as ScriptComponent;
     }
 }
 

--- a/src/components/script.ts
+++ b/src/components/script.ts
@@ -87,4 +87,10 @@ class ScriptElement extends HTMLElement {
 
 customElements.define('pc-script', ScriptElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-script': ScriptElement;
+    }
+}
+
 export { ScriptElement };

--- a/src/components/scrollbar-component.ts
+++ b/src/components/scrollbar-component.ts
@@ -163,4 +163,10 @@ class ScrollbarComponentElement extends ComponentElement {
 
 customElements.define('pc-scrollbar', ScrollbarComponentElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-scrollbar': ScrollbarComponentElement;
+    }
+}
+
 export { ScrollbarComponentElement };

--- a/src/components/scrollbar-component.ts
+++ b/src/components/scrollbar-component.ts
@@ -49,8 +49,8 @@ class ScrollbarComponentElement extends ComponentElement {
      * Gets the underlying PlayCanvas scrollbar component.
      * @returns The scrollbar component.
      */
-    get component(): ScrollbarComponent | null {
-        return super.component as ScrollbarComponent | null;
+    get component(): ScrollbarComponent {
+        return super.component as ScrollbarComponent;
     }
 
     /**

--- a/src/components/scrollview-component.ts
+++ b/src/components/scrollview-component.ts
@@ -424,4 +424,10 @@ class ScrollViewComponentElement extends ComponentElement {
 
 customElements.define('pc-scrollview', ScrollViewComponentElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-scrollview': ScrollViewComponentElement;
+    }
+}
+
 export { ScrollViewComponentElement };

--- a/src/components/scrollview-component.ts
+++ b/src/components/scrollview-component.ts
@@ -94,8 +94,8 @@ class ScrollViewComponentElement extends ComponentElement {
      * Gets the underlying PlayCanvas scroll view component.
      * @returns The scroll view component.
      */
-    get component(): ScrollViewComponent | null {
-        return super.component as ScrollViewComponent | null;
+    get component(): ScrollViewComponent {
+        return super.component as ScrollViewComponent;
     }
 
     /**

--- a/src/components/sound-component.ts
+++ b/src/components/sound-component.ts
@@ -46,8 +46,8 @@ class SoundComponentElement extends ComponentElement {
      * Gets the underlying PlayCanvas sound component.
      * @returns The sound component.
      */
-    get component(): SoundComponent | null {
-        return super.component as SoundComponent | null;
+    get component(): SoundComponent {
+        return super.component as SoundComponent;
     }
 
     /**

--- a/src/components/sound-component.ts
+++ b/src/components/sound-component.ts
@@ -227,4 +227,10 @@ class SoundComponentElement extends ComponentElement {
 
 customElements.define('pc-sounds', SoundComponentElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-sounds': SoundComponentElement;
+    }
+}
+
 export { SoundComponentElement };

--- a/src/components/sound-slot.ts
+++ b/src/components/sound-slot.ts
@@ -285,4 +285,10 @@ class SoundSlotElement extends AsyncElement {
 
 customElements.define('pc-sound', SoundSlotElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-sound': SoundSlotElement;
+    }
+}
+
 export { SoundSlotElement };

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -50,45 +50,52 @@ class EntityElement extends AsyncElement {
      */
     private _built = false;
 
+    private _entity: Entity | null = null;
+
     /**
-     * The PlayCanvas entity instance.
+     * The PlayCanvas entity instance. Available once the element is ready — await
+     * {@link whenReady} or the element's `ready()` promise before accessing it.
+     * @returns The entity instance.
      */
-    entity: Entity | null = null;
+    get entity(): Entity {
+        return this._entity!;
+    }
 
     createEntity(app: AppBase) {
         // Guard against double creation. When a subtree is inserted at runtime (e.g. cloning a
         // `<template>`), an ancestor's connectedCallback eagerly creates descendant entities; the
         // descendants' own connectedCallbacks would otherwise create them a second time.
-        if (this.entity) {
+        if (this._entity) {
             return;
         }
 
         // Create a new entity
-        this.entity = new Entity(this.getAttribute('name') || this._name, app);
+        const entity = new Entity(this.getAttribute('name') || this._name, app);
+        this._entity = entity;
 
         const enabled = this.getAttribute('enabled');
         if (enabled) {
-            this.entity.enabled = enabled !== 'false';
+            entity.enabled = enabled !== 'false';
         }
 
         const position = this.getAttribute('position');
         if (position) {
-            this.entity.setLocalPosition(parseVec3(position));
+            entity.setLocalPosition(parseVec3(position));
         }
 
         const rotation = this.getAttribute('rotation');
         if (rotation) {
-            this.entity.setLocalEulerAngles(parseVec3(rotation));
+            entity.setLocalEulerAngles(parseVec3(rotation));
         }
 
         const scale = this.getAttribute('scale');
         if (scale) {
-            this.entity.setLocalScale(parseVec3(scale));
+            entity.setLocalScale(parseVec3(scale));
         }
 
         const tags = this.getAttribute('tags');
         if (tags) {
-            this.entity.tags.add(tags.split(',').map(tag => tag.trim()));
+            entity.tags.add(tags.split(',').map(tag => tag.trim()));
         }
 
         // Handle pointer events
@@ -159,12 +166,12 @@ class EntityElement extends AsyncElement {
             // Notify all children that their entities are about to become invalid
             const children = this.querySelectorAll('pc-entity');
             children.forEach((child) => {
-                (child as EntityElement).entity = null;
+                (child as EntityElement)._entity = null;
             });
 
             // Destroy the entity
             this.entity.destroy();
-            this.entity = null;
+            this._entity = null;
             this._built = false;
         }
     }

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -371,4 +371,10 @@ class EntityElement extends AsyncElement {
 
 customElements.define('pc-entity', EntityElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-entity': EntityElement;
+    }
+}
+
 export { EntityElement };

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,4 +73,4 @@ export {
     whenReady
 };
 
-export type { AsyncElementTagName, NonAsyncElementTagName } from './async-element';
+export type { AsyncElementTagName } from './async-element';

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@
 /* eslint-disable import/order */
 
 // Note that order matters here (e.g. pc-entity must be defined before components)
-import { AsyncElement } from './async-element';
+import { AsyncElement, whenReady } from './async-element';
 import { ModuleElement } from './module';
 import { AppElement } from './app';
 import { EntityElement } from './entity';
@@ -69,5 +69,8 @@ export {
     MaterialElement,
     ModelElement,
     SceneElement,
-    SkyElement
+    SkyElement,
+    whenReady
 };
+
+export type { AsyncElementTagName, NonAsyncElementTagName } from './async-element';

--- a/src/material.ts
+++ b/src/material.ts
@@ -138,4 +138,10 @@ class MaterialElement extends HTMLElement {
 
 customElements.define('pc-material', MaterialElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-material': MaterialElement;
+    }
+}
+
 export { MaterialElement };

--- a/src/model.ts
+++ b/src/model.ts
@@ -108,4 +108,10 @@ class ModelElement extends AsyncElement {
 
 customElements.define('pc-model', ModelElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-model': ModelElement;
+    }
+}
+
 export { ModelElement };

--- a/src/module.ts
+++ b/src/module.ts
@@ -40,4 +40,10 @@ class ModuleElement extends HTMLElement {
 
 customElements.define('pc-module', ModuleElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-module': ModuleElement;
+    }
+}
+
 export { ModuleElement };

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -214,4 +214,10 @@ class SceneElement extends AsyncElement {
 
 customElements.define('pc-scene', SceneElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-scene': SceneElement;
+    }
+}
+
 export { SceneElement };

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -41,15 +41,21 @@ class SceneElement extends AsyncElement {
      */
     private _gravity = new Vec3(0, -9.81, 0);
 
+    private _scene: Scene | null = null;
+
     /**
-     * The PlayCanvas scene instance.
+     * The PlayCanvas scene instance. Available once the element is ready — await
+     * {@link whenReady} or the element's `ready()` promise before accessing it.
+     * @returns The scene instance.
      */
-    scene: Scene | null = null;
+    get scene(): Scene {
+        return this._scene!;
+    }
 
     async connectedCallback() {
         await this.closestApp?.ready();
 
-        this.scene = this.closestApp!.app!.scene;
+        this._scene = this.closestApp!.app!.scene;
         this.updateSceneSettings();
 
         this._onReady();

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -290,4 +290,10 @@ class SkyElement extends AsyncElement {
 
 customElements.define('pc-sky', SkyElement);
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'pc-sky': SkyElement;
+    }
+}
+
 export { SkyElement };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "allowUnreachableCode": false
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
## What

Adds a generic, promise-based way to script against elements once they are fully initialized, replacing the taught pattern:

```js
// before
const appElement = await document.querySelector('pc-app').ready();
appElement.app.scene.gsplat.alphaClip = 0.1;

// after
import { whenReady } from '@playcanvas/web-components';

const { app } = await whenReady('pc-app');
app.scene.gsplat.alphaClip = 0.1;
```

- **`whenReady(target)`** (new export): accepts a tag name, any CSS selector, or an element reference, waits for DOM parse if called early, and resolves with the element once its engine object exists. Works uniformly for `pc-app`, `pc-scene`, `pc-entity`, `pc-camera`, etc. Multi-app pages disambiguate with a selector (`whenReady('#left')`). Throws descriptive errors for missing elements and for the four non-async elements (`pc-asset`, `pc-material`, `pc-module`, `pc-script`).
- **`HTMLElementTagNameMap` augmentation** at all 27 `customElements.define()` sites (Lit convention), so `document.querySelector('pc-app')` types as `AppElement | null`, `whenReady('pc-camera')` resolves `CameraComponentElement`, and `whenReady('pc-asset')` is a compile-time error.
- `element.ready()` is unchanged and remains the underlying primitive.

## Breaking changes (pre-1.0)

- **Engine handles are now typed non-null.** `AppElement.app`, `EntityElement.entity`, `SceneElement.scene` and `ComponentElement.component` (plus its subclass overrides) are getters typed `AppBase`/`Entity`/`Scene`/`Component` instead of `X | null`, so the awaited one-liner needs no null assertion in TypeScript. Runtime semantics are unchanged (pre-ready access still yields `null`); upgrading these to instructive throwing getters is deferred until a test harness exists, since the internal attribute plumbing deliberately probes handles pre-ready.
- **The `ready` event now bubbles and is composed**, so document-level delegation (`document.addEventListener('ready', ...)`) works.
- **TypeScript:** the package now augments `HTMLElementTagNameMap`; if you had added these entries manually in your own project, remove your local augmentation.

## Why

The old pattern is null-unsafe (chained call TypeErrors if the element is missing or not yet upgraded), does not typecheck (`querySelector` returned `Element | null`), and reaches through a nullable `.app`. The event-based alternative (A-Frame's `loaded` + `hasLoaded` dance) is racy by construction; an idempotent promise avoids that class of bug entirely.

## Notes for reviewers

- The 27 `declare global` blocks are mechanical; the interesting code is in `src/async-element.ts`.
- Usage documentation lives in the user manual — companion PR: playcanvas/developer-site#1111. The README continues to defer to the Getting Started Guide.
- Shared example modules (`examples/js/example.mjs`, loaded by 27 pages, and `material-variants.mjs`) import `whenReady` via a relative `dist/pwc.mjs` path rather than a bare specifier, to avoid adding an import-map entry to every page. They also drop their `DOMContentLoaded` wrappers in favor of top-level `await` — module scripts are deferred, so the wrapper never waited for anything real. Since CI lints unbuilt checkouts, `eslint.config.mjs` gains a scoped `import/no-unresolved` ignore for that path, and the TS-files block now applies typescript-eslint’s `eslint-recommended` companion preset — disabling the base rules the compiler already enforces (`no-redeclare` on overload signatures, `no-undef` on TS DOM types), which also replaced the config’s previous `AddEventListenerOptions`/`EventListener` globals workaround.
- The three inline example scripts use the bare specifier via a new import-map entry that resolves to the same URL as the head script tag, so the module cache dedupes and elements register once.

## Testing

- `npm run build`, `type-check`, `lint`, `publint`, `docs` all clean.
- TS consumer smoke test against the built package verified all three overload types and the `pc-asset` compile-time rejection.
- Verified in-browser: splat-flipbook applies `alphaClip: 0.1` via the new one-liner, solar-system's scroll-zoom works on the destructured `AppBase`, ar-hand-gestures boots without a `DOMContentLoaded` wrapper, shoe-configurator's material-variant buttons work via top-level `await` (variant click applies the material), `whenReady` returns the identical element instance the page registered (no double registration), both error paths throw the intended messages, and a late `await` resolves immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

