### PR TITLE
Add .claude directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dist
 .pnp.*
 
 docs
+
+# Claude Code local settings
+.claude/


### PR DESCRIPTION
## What changed

Adds `.claude/` to `.gitignore`.

## Why

The `.claude` directory holds local Claude Code session settings, which are machine-specific and shouldn't be committed. It was previously showing up as untracked in `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)