### PR TITLE
Add whenReady() support to pc-asset

### DIFF
--- a/examples/assets/scripts/material-variants.mjs
+++ b/examples/assets/scripts/material-variants.mjs
@@ -1,41 +1,39 @@
 import { whenReady } from '../../../dist/pwc.mjs';
 
-await whenReady('pc-app');
+const [entityElement, assetElement] = await Promise.all([
+    whenReady('pc-entity[name="shoe"]'),
+    whenReady('pc-asset#shoe')
+]);
 
-const entityElement = document.querySelector('pc-entity[name="shoe"]');
-const assetElement = document.querySelector('pc-asset#shoe');
+const resource = assetElement.asset.resource;
+const variants = resource.getMaterialVariants();
 
-if (entityElement && assetElement) {
-    const resource = assetElement.asset.resource;
-    const variants = resource.getMaterialVariants();
+// create container for buttons
+const buttonContainer = document.createElement('div');
+buttonContainer.classList.add('example-button-container', 'top-right');
 
-    // create container for buttons
-    const buttonContainer = document.createElement('div');
-    buttonContainer.classList.add('example-button-container', 'top-right');
+// create a button for each variant
+variants.forEach((variant) => {
+    const button = document.createElement('button');
+    button.textContent = variant.split('-')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
 
-    // create a button for each variant
-    variants.forEach((variant) => {
-        const button = document.createElement('button');
-        button.textContent = variant.split('-')
-        .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-        .join(' ');
+    button.classList.add('example-button');
 
-        button.classList.add('example-button');
+    button.onmouseenter = () => {
+        button.style.background = 'rgba(255, 255, 255, 1)';
+    };
 
-        button.onmouseenter = () => {
-            button.style.background = 'rgba(255, 255, 255, 1)';
-        };
+    button.onmouseleave = () => {
+        button.style.background = 'rgba(255, 255, 255, 0.9)';
+    };
 
-        button.onmouseleave = () => {
-            button.style.background = 'rgba(255, 255, 255, 0.9)';
-        };
-
-        button.addEventListener('click', () => {
-            resource.applyMaterialVariant(entityElement.entity, variant);
-        });
-
-        buttonContainer.appendChild(button);
+    button.addEventListener('click', () => {
+        resource.applyMaterialVariant(entityElement.entity, variant);
     });
 
-    document.body.appendChild(buttonContainer);
-}
+    buttonContainer.appendChild(button);
+});
+
+document.body.appendChild(buttonContainer);

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -1,5 +1,6 @@
 import { Asset, SPRITE_RENDERMODE_SIMPLE, SPRITE_RENDERMODE_SLICED, SPRITE_RENDERMODE_TILED } from 'playcanvas';
 
+import { AsyncElement } from './async-element';
 import { parseEnum } from './utils';
 import { MeshoptDecoder } from '../lib/meshopt_decoder.module.js';
 
@@ -74,14 +75,58 @@ const processBufferView = (
  * {@link https://developer.playcanvas.com/user-manual/web-components/tags/pc-asset/ | `<pc-asset>`} elements.
  * The AssetElement interface also inherits the properties and methods of the
  * {@link HTMLElement} interface.
+ *
+ * The element becomes ready once the containing application has started and the asset is in the
+ * state declared by the markup: loaded for preloaded assets (even if loading failed — check the
+ * asset's `resource`), or registered and awaiting a load for `lazy` assets. Elements inserted
+ * while the application is running are created and registered on insertion, and begin loading
+ * immediately unless `lazy`. A `pc-asset` must be a direct child of `pc-app` — elements placed
+ * elsewhere, or with an unsupported asset type, never become ready.
  */
-class AssetElement extends HTMLElement {
+class AssetElement extends AsyncElement {
     private _lazy: boolean = false;
 
     /**
-     * The asset that is loaded.
+     * The asset that is loaded. Available once the element is ready — await
+     * {@link whenReady} or the element's `ready()` promise before accessing it.
      */
     asset: Asset | null = null;
+
+    async connectedCallback() {
+        const appElement = this.closestApp;
+        if (!appElement) return;
+
+        // Assets must be direct children of pc-app (matches the boot query ':scope > pc-asset')
+        if (this.parentElement !== appElement) {
+            console.warn(`pc-asset '${this.getAttribute('id') ?? this.getAttribute('src')}' must be a direct child of pc-app - asset not created`);
+            return;
+        }
+
+        await appElement.ready();
+
+        // The element may have been removed or re-parented while waiting for the app
+        if (!this.isConnected || this.parentElement !== appElement) return;
+
+        // Assets present at startup are created by AppElement's boot; this branch handles
+        // elements inserted (or re-inserted) after the app is already running
+        if (!this.asset) {
+            const app = appElement.app;
+            if (!app) return; // pc-app is re-connecting; its own boot will create this asset
+
+            this.createAsset();
+            if (this.asset) {
+                app.assets.add(this.asset); // add() auto-loads when preload is true
+                if (!this.lazy) {
+                    app.assets.load(this.asset);
+                }
+            }
+        }
+
+        // Never ready if createAsset failed (unsupported asset type)
+        if (this.asset) {
+            this._onReady();
+        }
+    }
 
     disconnectedCallback() {
         this.destroyAsset();
@@ -187,6 +232,8 @@ class AssetElement extends HTMLElement {
 
     destroyAsset() {
         if (this.asset) {
+            // Deregister first so unload() can still notify the registry
+            this.asset.registry?.remove(this.asset);
             this.asset.unload();
             this.asset = null;
         }


### PR DESCRIPTION
## What

`AssetElement` now extends `AsyncElement`, joining the readiness API added in #264 — previously it was the only engine-object-wrapping element outside it, so `whenReady('pc-asset#…')` threw. Because `pc-asset` already has an `HTMLElementTagNameMap` entry, the typed `whenReady('pc-asset')` overload works with zero changes to `async-element.ts`.

**Readiness contract:** the element becomes ready once the containing application has started and the asset is in the state its markup declared:

- **Preloaded** assets are loaded (app-ready implies preload completed). Note the engine counts load *errors* toward preload completion, so ready fires even then — check `asset.resource`.
- **Lazy** assets are registered and awaiting `app.assets.load()`.
- Elements outside a `pc-app`, not a *direct child* of `pc-app` (matching the boot query `:scope > pc-asset`; a console warning is emitted), or with an unsupported type never become ready — consistent with the documented `whenReady()` caveats.

The same lifecycle closes a pre-existing gap: `pc-asset` elements inserted **after the app is running** were silently ignored; they are now created, registered, and (unless `lazy`) loaded on insertion. `disconnectedCallback` now also deregisters the asset from `app.assets`, so remove → re-add round-trips without duplicate registry entries.

The material-variants example becomes the motivating use case — awaiting the entity and asset it actually uses instead of the whole app:

```js
const [entityElement, assetElement] = await Promise.all([
    whenReady('pc-entity[name="shoe"]'),
    whenReady('pc-asset#shoe')
]);
```

## Why app-ready rather than registration or load

- Registration-time readiness buys nothing: the boot block from `assets.add()` to `app.preload()` is synchronous, so no user microtask can run in that window anyway.
- Load-based readiness would hang `whenReady` forever on a 404 (the ready promise has no rejection path) and would deadlock for `lazy` assets — the very elements you most need a handle on programmatically.
- Gating on app-ready matches `pc-component`/`pc-scene` (`await this.closestApp?.ready()`), keeps lazy assets awaitable, and for preloaded assets quietly guarantees `asset.resource` is usable — what nearly every caller wants.

## Reviewer notes

- The boot path in `app.ts` is untouched: declarative assets are still created/registered synchronously before `preload()`; their parked `connectedCallback`s just fire `_onReady()` after app-ready. All existing `AssetElement.get()` call sites are unaffected.
- Unlike `component.ts`, the `closestApp` guard is an explicit early return, so a `pc-asset` outside a `pc-app` never reports ready.
- Known cosmetic wart: a declarative asset with an unsupported type logs the "Unsupported asset type" warning twice (boot + the connectedCallback retry).
- Verified: `build`/`type-check`/`lint` clean; shoe-configurator variant swapping works in-browser; solar-system's 8 lazy assets regress nothing; dynamic-insertion smoke tests (eager load, lazy + un-lazy, remove/re-add, nested warning, unsupported type, whole-app teardown) all pass. Teardown of a whole `pc-app` still logs 6 pre-existing TypeErrors from sky/component cleanup (stack-traced to `sky.ts`/`component.ts`, not this change) — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)