### PR TITLE
Import from '@playcanvas/web-components' in examples

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,8 +13,9 @@ export default [
             }
         },
         rules: {
-            // dist/pwc.mjs is a build output, so it is absent when linting an unbuilt checkout
-            'import/no-unresolved': ['error', { ignore: ['/dist/pwc\\.mjs$'] }]
+            // The package self-import resolves to dist/pwc.mjs, a build output that is absent
+            // when linting an unbuilt checkout
+            'import/no-unresolved': ['error', { ignore: ['^@playcanvas/web-components$'] }]
         }
     },
     {

--- a/examples/animation.html
+++ b/examples/animation.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }

--- a/examples/annotations.html
+++ b/examples/annotations.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }

--- a/examples/ar-avatar.html
+++ b/examples/ar-avatar.html
@@ -7,8 +7,9 @@
         <script type="importmap">
             {
                 "imports": {
-                    "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs",
-                    "@mediapipe/tasks-vision": "../node_modules/@mediapipe/tasks-vision/vision_bundle.mjs"
+                    "@mediapipe/tasks-vision": "../node_modules/@mediapipe/tasks-vision/vision_bundle.mjs",
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
+                    "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }
         </script>

--- a/examples/ar-hand-gestures.html
+++ b/examples/ar-hand-gestures.html
@@ -7,9 +7,9 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@mediapipe/tasks-vision": "../node_modules/@mediapipe/tasks-vision/vision_bundle.mjs",
                     "@playcanvas/web-components": "../dist/pwc.mjs",
-                    "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs",
-                    "@mediapipe/tasks-vision": "../node_modules/@mediapipe/tasks-vision/vision_bundle.mjs"
+                    "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }
         </script>

--- a/examples/assets/scripts/material-variants.mjs
+++ b/examples/assets/scripts/material-variants.mjs
@@ -1,4 +1,4 @@
-import { whenReady } from '../../../dist/pwc.mjs';
+import { whenReady } from '@playcanvas/web-components';
 
 await whenReady('pc-app');
 

--- a/examples/basic-particles.html
+++ b/examples/basic-particles.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }

--- a/examples/basic-shapes.html
+++ b/examples/basic-shapes.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }

--- a/examples/car-configurator.html
+++ b/examples/car-configurator.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }

--- a/examples/first-person-teleport.html
+++ b/examples/first-person-teleport.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }

--- a/examples/fps-controller.html
+++ b/examples/fps-controller.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }

--- a/examples/glb.html
+++ b/examples/glb.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }

--- a/examples/js/example.mjs
+++ b/examples/js/example.mjs
@@ -1,6 +1,5 @@
+import { whenReady } from '@playcanvas/web-components';
 import { MiniStats, XRTYPE_AR, XRTYPE_VR } from 'playcanvas';
-
-import { whenReady } from '../../dist/pwc.mjs';
 
 const appElement = await whenReady('pc-app');
 /** @type {import('playcanvas').AppBase} */

--- a/examples/physics-cluster.html
+++ b/examples/physics-cluster.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }

--- a/examples/physics.html
+++ b/examples/physics.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }

--- a/examples/positional-sound.html
+++ b/examples/positional-sound.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }

--- a/examples/screen.html
+++ b/examples/screen.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }

--- a/examples/shoe-configurator.html
+++ b/examples/shoe-configurator.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }

--- a/examples/sound.html
+++ b/examples/sound.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }

--- a/examples/spinning-cube.html
+++ b/examples/spinning-cube.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }

--- a/examples/splat-annotations.html
+++ b/examples/splat-annotations.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }

--- a/examples/splat-simple.html
+++ b/examples/splat-simple.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }

--- a/examples/text.html
+++ b/examples/text.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }

--- a/examples/text3d.html
+++ b/examples/text3d.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "earcut": "../node_modules/earcut/src/earcut.js",
                     "opentype.js": "../node_modules/opentype.js/dist/opentype.module.js",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"

--- a/examples/tween.html
+++ b/examples/tween.html
@@ -7,8 +7,9 @@
         <script type="importmap">
             {
                 "imports": {
-                    "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs",
-                    "@tweenjs/tween.js": "../node_modules/@tweenjs/tween.js/dist/tween.esm.js"
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
+                    "@tweenjs/tween.js": "../node_modules/@tweenjs/tween.js/dist/tween.esm.js",
+                    "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }
         </script>

--- a/examples/ui-scroll-view.html
+++ b/examples/ui-scroll-view.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }

--- a/examples/vibe-falling-blocks.html
+++ b/examples/vibe-falling-blocks.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }

--- a/examples/video-recorder.html
+++ b/examples/video-recorder.html
@@ -7,9 +7,10 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
+                    "@tweenjs/tween.js": "../node_modules/@tweenjs/tween.js/dist/tween.esm.js",
                     "mediabunny": "../node_modules/mediabunny/dist/bundles/mediabunny.min.mjs",
-                    "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs",
-                    "@tweenjs/tween.js": "../node_modules/@tweenjs/tween.js/dist/tween.esm.js"
+                    "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }
         </script>

--- a/examples/video-texture.html
+++ b/examples/video-texture.html
@@ -7,6 +7,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }


### PR DESCRIPTION
## What

Completes a migration that four newer examples (solar-system, splat-flipbook, spinning-cube-api, ar-hand-gestures) already started: examples now import the library by its package name instead of counting `../` segments to `dist`.

- All **29 example import maps** map `"@playcanvas/web-components": "../dist/pwc.mjs"` (25 added; 4 already had it).
- `examples/js/example.mjs` and `examples/assets/scripts/material-variants.mjs` — the last two relative-dist imports — switch to the bare specifier.
- Import-map entries are normalized to **alphabetical order** by specifier across all 29 maps (5 files had drifted: mediapipe/tween/mediabunny/earcut entries in inconsistent positions), matching how `import/order` sorts the external group in the linted example scripts.
- The `import/no-unresolved` carve-out in `eslint.config.mjs` moves from the relative dist pattern to the package name — same underlying reason as before (the target is build output, absent on unbuilt checkouts), plus the classic node resolver doesn't support package self-reference via `exports`.

## Why

Examples double as documentation: `import { whenReady } from '@playcanvas/web-components'` is exactly what an npm consumer writes, and the mapping mirrors the package's own `exports["."].import` → `./dist/pwc.mjs`. Module identity is preserved — the import-map target and the existing `<script type="module" src="../dist/pwc.mjs">` tags resolve to the same URL, so there is still exactly one module instance (relevant to `whenReady`'s `instanceof` check).

## Reviewer notes

- Independent of #267 — both touch adjacent lines in material-variants.mjs; a test merge confirms they auto-merge cleanly in either order.
- Verified in-browser: shoe-configurator (exercises both bare-specifier scripts) and tween (reordered multi-entry map) load and run with no console errors.
- Found in passing, **pre-existing on main and unrelated**: text3d.html is broken because opentype.js 2.0 (from the #265 dependency bump) no longer ships `dist/opentype.module.js` — its ESM build is now `dist/opentype.mjs`. Left untouched here to keep this PR mechanical; happy to fix in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)