### PR TITLE
Use whenReady() in the physics cluster example

### DIFF
--- a/examples/physics-cluster.html
+++ b/examples/physics-cluster.html
@@ -72,25 +72,25 @@
                 </pc-entity>
             </pc-scene>
         </pc-app>
-        <script>
-            document.addEventListener('DOMContentLoaded', () => {
-                const scene = document.querySelector('pc-scene');
-                const sphereTemplate = document.getElementById('sphere-template');
+        <script type="module">
+            import { whenReady } from '@playcanvas/web-components';
 
-                // Clone and append 40 spheres
-                for (let i = 0; i < 40; i++) {
-                    // Clone the sphere template
-                    const clone = document.importNode(sphereTemplate.content, true);
-                    const sphereEntity = clone.querySelector('pc-entity');
+            const scene = await whenReady('pc-scene');
+            const sphereTemplate = document.getElementById('sphere-template');
 
-                    // Set a random start position
-                    const rnd = (max) => (Math.random() - 0.5) * max;
-                    sphereEntity.setAttribute('position', `${rnd(10)} ${rnd(10)} ${rnd(10)}`);
+            // Clone and append 40 spheres
+            for (let i = 0; i < 40; i++) {
+                // Clone the sphere template
+                const clone = document.importNode(sphereTemplate.content, true);
+                const sphereEntity = clone.querySelector('pc-entity');
 
-                    // Append the clone to the scene
-                    scene.appendChild(clone);
-                }
-            });
+                // Set a random start position
+                const rnd = (max) => (Math.random() - 0.5) * max;
+                sphereEntity.setAttribute('position', `${rnd(10)} ${rnd(10)} ${rnd(10)}`);
+
+                // Append the clone to the scene
+                scene.appendChild(clone);
+            }
         </script>
         <script type="module" src="js/example.mjs"></script>
     </body>


### PR DESCRIPTION
## What

The sphere-spawning script in `examples/physics-cluster.html` was the last example waiting on `DOMContentLoaded` — which signals that the HTML is parsed, not that the scene exists as an engine object. It's now a `type="module"` script that awaits the exact element it appends to, importing by package name via the import map added in #268:

```js
import { whenReady } from '@playcanvas/web-components';

const scene = await whenReady('pc-scene');
```

Scene-ready implies the application has started, so the 40 template clones are created through the dynamic-insertion path at runtime — which also makes the example a cleaner demonstration of spawning templated entities into a running app.

## Reviewer notes

- Behavioral nuance: the spheres now spawn just after `app.start()` instead of riding along in the boot sweep — imperceptible here (within a frame of startup), and the physics behavior is unchanged.
- Verified in-browser: all 40 spheres are created with entities and rigidbody components attached (40/40/40 probe), the simulation runs, and the page logs no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)