### PR TITLE
Fix broken text3d example after opentype.js 2.0 upgrade

### DIFF
--- a/examples/text3d.html
+++ b/examples/text3d.html
@@ -9,7 +9,7 @@
                 "imports": {
                     "@playcanvas/web-components": "../dist/pwc.mjs",
                     "earcut": "../node_modules/earcut/src/earcut.js",
-                    "opentype.js": "../node_modules/opentype.js/dist/opentype.module.js",
+                    "opentype.js": "../node_modules/opentype.js/dist/opentype.mjs",
                     "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
                 }
             }


### PR DESCRIPTION
## What changed

Updated the `opentype.js` import map entry in `examples/text3d.html` from `../node_modules/opentype.js/dist/opentype.module.js` to `../node_modules/opentype.js/dist/opentype.mjs`.

## Why

The dependency update in #265 bumped opentype.js from 1.x to 2.0.0, which renamed its ESM bundle — `dist/opentype.module.js` no longer exists (the package's `module` entry is now `./dist/opentype.mjs`). Since `text3d.mjs` statically imports `{ parse }` from `opentype.js`, the dead import map target made the whole dynamic module import fail: the page rendered only the grid, with `Failed to fetch dynamically imported module: .../examples/assets/scripts/text3d.mjs` in the console.

## Notes for reviewers

- opentype.js 2.0.0 still exports `parse` as a named export (now aliased from `parseBuffer`), and the rest of the API the script relies on (`charToGlyph`, `getKerningValue`, `unitsPerEm`, `glyph.path.commands`, `glyph.advanceWidth`) works unchanged — so no edits to `text3d.mjs` were required.
- I audited every `node_modules` path referenced by the examples' import maps and `<pc-asset>` tags (earcut, @tweenjs/tween.js, mediabunny, @mediapipe/tasks-vision, playcanvas scripts) — this was the only path broken by the dependency update.
- Verified with `npm run serve`: the example renders the extruded "3D Text" mesh correctly with a clean console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)