### PR TITLE
Fix uncaught errors when removing a running <pc-app> from the DOM

### DIFF
--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -1,5 +1,6 @@
 import { Component } from 'playcanvas';
 
+import { AppElement } from '../app';
 import { AsyncElement } from '../async-element';
 
 /**
@@ -13,6 +14,8 @@ class ComponentElement extends AsyncElement {
     private _enabled = true;
 
     private _component: Component | null = null;
+
+    private _appElement: AppElement | null = null;
 
     /**
      * Creates a new ComponentElement instance.
@@ -44,18 +47,22 @@ class ComponentElement extends AsyncElement {
     initComponent() {}
 
     async connectedCallback() {
-        await this.closestApp?.ready();
+        this._appElement = this.closestApp ?? null;
+        await this._appElement?.ready();
         await this.addComponent();
         this.initComponent();
         this._onReady();
     }
 
     disconnectedCallback() {
-        // Remove the component when the element is disconnected
-        if (this.component && this.component.entity) {
-            this._component!.entity.removeComponent(this._componentName);
-            this._component = null;
+        // Remove the component when the element is disconnected. Skip this when the owning
+        // application has already been destroyed — removing a <pc-app> disconnects it before
+        // its children, taking the component systems with it.
+        if (this._appElement?.app && this._component?.entity) {
+            this._component.entity.removeComponent(this._componentName);
         }
+        this._component = null;
+        this._appElement = null;
     }
 
     /**

--- a/src/components/sound-slot.ts
+++ b/src/components/sound-slot.ts
@@ -58,7 +58,9 @@ class SoundSlotElement extends AsyncElement {
     }
 
     disconnectedCallback() {
-        this.soundElement!.component!.removeSlot(this._name);
+        // The component is null if the parent <pc-sound> (or the whole <pc-app>) is being
+        // torn down — parents disconnect first and have already removed the component.
+        this.soundElement?.component?.removeSlot(this._name);
     }
 
     protected get soundElement(): SoundComponentElement | null {

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -1,5 +1,6 @@
 import { Asset, EnvLighting, LAYERID_SKYBOX, Quat, Scene, Texture, Vec3 } from 'playcanvas';
 
+import { AppElement } from './app';
 import { AssetElement } from './asset';
 import { AsyncElement } from './async-element';
 import { parseVec3 } from './utils';
@@ -28,6 +29,8 @@ class SkyElement extends AsyncElement {
 
     private _scene: Scene | null = null;
 
+    private _appElement: AppElement | null = null;
+
     connectedCallback() {
         this._loadSkybox();
         this._onReady();
@@ -35,6 +38,7 @@ class SkyElement extends AsyncElement {
 
     disconnectedCallback() {
         this._unloadSkybox();
+        this._appElement = null;
     }
 
     private _generateSkybox(asset: Asset) {
@@ -67,9 +71,11 @@ class SkyElement extends AsyncElement {
     private async _loadSkybox() {
         const appElement = await this.closestApp?.ready();
         const app = appElement?.app;
-        if (!app) {
+        if (!appElement || !app) {
             return;
         }
+
+        this._appElement = appElement;
 
         const asset = AssetElement.get(this._asset);
         if (!asset) {
@@ -89,16 +95,22 @@ class SkyElement extends AsyncElement {
     }
 
     private _unloadSkybox() {
-        if (!this._scene) return;
-
-        this._scene.skybox?.destroy();
-        // @ts-ignore
-        this._scene.skybox = null;
-        this._scene.envAtlas?.destroy();
-        // @ts-ignore
-        this._scene.envAtlas = null;
+        const scene = this._scene;
+        if (!scene) return;
 
         this._scene = null;
+
+        // If the owning application has already been destroyed (removing a <pc-app>
+        // disconnects it before its children), the scene, graphics device and skybox
+        // textures have all been destroyed along with it — nothing left to clean up.
+        if (!this._appElement?.app) return;
+
+        scene.skybox?.destroy();
+        // @ts-ignore
+        scene.skybox = null;
+        scene.envAtlas?.destroy();
+        // @ts-ignore
+        scene.envAtlas = null;
     }
 
     /**


### PR DESCRIPTION
## What changed

Removing a running `<pc-app>` element from the DOM (e.g. `document.querySelector('pc-app').remove()`) threw 6 uncaught TypeErrors on `examples/shoe-configurator.html`. It now tears down cleanly.

Custom element disconnect reactions run in tree order — parent before children — so `AppElement.disconnectedCallback` destroys the engine application before any child element runs its own cleanup. Children then crashed against destroyed engine state:

- `ComponentElement.disconnectedCallback` called `entity.removeComponent()`, which reads `entity._app.systems` — null after `AppBase.destroy()` — throwing once per component element (`Cannot read properties of null (reading 'camera'/'light'/'script')`).
- `SkyElement._unloadSkybox` destroyed its skybox/envAtlas textures, which touch the destroyed graphics device (`Cannot read properties of null (reading 'removeValue')`).

## How it's fixed

Each affected element captures its owning `AppElement` when it initializes, and skips engine cleanup when `appElement.app` has already been nulled by the app's own teardown (which happens before any child disconnects). DOM traversal can't answer this at disconnect time — `closestApp` returns `undefined` for an element removed directly — and the captured engine objects don't record their own destruction.

- **`src/components/component.ts`** — captures `_appElement` in `connectedCallback`; only calls `removeComponent` when the app is still alive; now always nulls `_component` (previously the throw left it set).
- **`src/sky.ts`** — captures `_appElement` in `_loadSkybox`; `_unloadSkybox` skips texture destruction when the app is gone.
- **`src/components/sound-slot.ts`** — `removeSlot` guarded with optional chaining. Required by the first fix: the parent `pc-sound`'s teardown now reliably nulls its component before the slot disconnects (previously it threw first), so the slot must tolerate a null component. Also stops a crash when removing a `pc-sound` slot element on its own.

## Verification

On `examples/shoe-configurator.html` with `error`/`unhandledrejection` listeners attached:

- Pre-fix build (negative control): exactly the 6 reported TypeErrors.
- Fixed build: **0 errors**, clean console.
- Live-removal paths still perform real cleanup: removing `pc-light` alone removes the engine light component, removing the shoe `pc-entity` removes it from the scene graph, removing `pc-sky` destroys and clears the skybox — all error-free.
- `npm run type-check`, `npm run build`, `npm run lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)