### PR TITLE
Unify boolean attribute parsing across all elements

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -71,6 +71,7 @@ import { AsyncElement } from './async-element';
 import { EntityElement } from './entity';
 import { MaterialElement } from './material';
 import { ModuleElement } from './module';
+import { parseBool } from './utils';
 
 /**
  * The AppElement interface provides properties and methods for manipulating
@@ -595,10 +596,10 @@ class AppElement extends AsyncElement {
     attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
         switch (name) {
             case 'alpha':
-                this.alpha = newValue !== 'false';
+                this.alpha = parseBool(newValue, true);
                 break;
             case 'antialias':
-                this.antialias = newValue !== 'false';
+                this.antialias = parseBool(newValue, true);
                 break;
             case 'backend':
                 if (newValue === 'webgpu' || newValue === 'webgl2' || newValue === 'null') {
@@ -606,13 +607,13 @@ class AppElement extends AsyncElement {
                 }
                 break;
             case 'depth':
-                this.depth = newValue !== 'false';
+                this.depth = parseBool(newValue, true);
                 break;
             case 'high-resolution':
-                this.highResolution = newValue !== 'false';
+                this.highResolution = parseBool(newValue, true);
                 break;
             case 'stencil':
-                this.stencil = newValue !== 'false';
+                this.stencil = parseBool(newValue, true);
                 break;
         }
     }

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -1,7 +1,7 @@
 import { Asset, SPRITE_RENDERMODE_SIMPLE, SPRITE_RENDERMODE_SLICED, SPRITE_RENDERMODE_TILED } from 'playcanvas';
 
 import { AsyncElement } from './async-element';
-import { parseEnum } from './utils';
+import { parseBool, parseEnum } from './utils';
 import { MeshoptDecoder } from '../lib/meshopt_decoder.module.js';
 
 const renderModes = new Map<string, number>([
@@ -267,9 +267,9 @@ class AssetElement extends AsyncElement {
         return ['lazy'];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, _newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
         if (name === 'lazy') {
-            this.lazy = this.hasAttribute('lazy');
+            this.lazy = parseBool(newValue, false);
         }
     }
 }

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -2,7 +2,7 @@ import { BUTTON_TRANSITION_MODE_SPRITE_CHANGE, BUTTON_TRANSITION_MODE_TINT, Butt
 
 import { AssetElement } from '../asset';
 import { ComponentElement } from './component';
-import { getEntity, parseColor, parseEnum, parseVec4 } from '../utils';
+import { getEntity, parseBool, parseColor, parseEnum, parseVec4 } from '../utils';
 
 const transitionModes = new Map<string, number>([
     ['tint', BUTTON_TRANSITION_MODE_TINT],
@@ -400,7 +400,7 @@ class ButtonComponentElement extends ComponentElement {
 
         switch (name) {
             case 'active':
-                this.active = newValue !== 'false';
+                this.active = parseBool(newValue, true);
                 break;
             case 'image':
                 this.image = newValue;

--- a/src/components/camera-component.ts
+++ b/src/components/camera-component.ts
@@ -1,7 +1,7 @@
 import { CameraComponent, Color, Vec4, GAMMA_NONE, GAMMA_SRGB, PROJECTION_ORTHOGRAPHIC, PROJECTION_PERSPECTIVE, TONEMAP_LINEAR, TONEMAP_FILMIC, TONEMAP_NEUTRAL, TONEMAP_ACES2, TONEMAP_ACES, TONEMAP_HEJL, TONEMAP_NONE, XRTYPE_VR } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseColor, parseVec4 } from '../utils';
+import { parseBool, parseColor, parseVec4 } from '../utils';
 
 const tonemaps = new Map([
     ['none', TONEMAP_NONE],
@@ -77,7 +77,7 @@ class CameraComponentElement extends ComponentElement {
             gammaCorrection: this._gamma === 'srgb' ? GAMMA_SRGB : GAMMA_NONE,
             horizontalFov: this._horizontalFov,
             nearClip: this._nearClip,
-            orthographic: this._orthographic,
+            projection: this._orthographic ? PROJECTION_ORTHOGRAPHIC : PROJECTION_PERSPECTIVE,
             orthoHeight: this._orthoHeight,
             priority: this._priority,
             rect: this._rect,
@@ -498,40 +498,40 @@ class CameraComponentElement extends ComponentElement {
                 this.clearColor = parseColor(newValue);
                 break;
             case 'clear-color-buffer':
-                this.clearColorBuffer = newValue !== 'false';
+                this.clearColorBuffer = parseBool(newValue, true);
                 break;
             case 'clear-depth-buffer':
-                this.clearDepthBuffer = newValue !== 'false';
+                this.clearDepthBuffer = parseBool(newValue, true);
                 break;
             case 'clear-stencil-buffer':
-                this.clearStencilBuffer = newValue !== 'false';
+                this.clearStencilBuffer = parseBool(newValue, false);
                 break;
             case 'cull-faces':
-                this.cullFaces = newValue !== 'false';
+                this.cullFaces = parseBool(newValue, true);
                 break;
             case 'far-clip':
                 this.farClip = parseFloat(newValue);
                 break;
             case 'flip-faces':
-                this.flipFaces = newValue !== 'false';
+                this.flipFaces = parseBool(newValue, false);
                 break;
             case 'fov':
                 this.fov = parseFloat(newValue);
                 break;
             case 'frustum-culling':
-                this.frustumCulling = newValue !== 'false';
+                this.frustumCulling = parseBool(newValue, true);
                 break;
             case 'gamma':
                 this.gamma = newValue as 'linear' | 'srgb';
                 break;
             case 'horizontal-fov':
-                this.horizontalFov = this.hasAttribute('horizontal-fov');
+                this.horizontalFov = parseBool(newValue, false);
                 break;
             case 'near-clip':
                 this.nearClip = parseFloat(newValue);
                 break;
             case 'orthographic':
-                this.orthographic = this.hasAttribute('orthographic');
+                this.orthographic = parseBool(newValue, false);
                 break;
             case 'ortho-height':
                 this.orthoHeight = parseFloat(newValue);

--- a/src/components/collision-component.ts
+++ b/src/components/collision-component.ts
@@ -1,7 +1,7 @@
 import { CollisionComponent, Quat, Vec3 } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseQuat, parseVec3 } from '../utils';
+import { parseBool, parseQuat, parseVec3 } from '../utils';
 
 /**
  * The CollisionComponentElement interface provides properties and methods for manipulating
@@ -157,7 +157,7 @@ class CollisionComponentElement extends ComponentElement {
                 this.axis = parseInt(newValue, 10);
                 break;
             case 'convex-hull':
-                this.convexHull = this.hasAttribute('convex-hull');
+                this.convexHull = parseBool(newValue, false);
                 break;
             case 'half-extents':
                 this.halfExtents = parseVec3(newValue);

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -2,6 +2,7 @@ import { Component } from 'playcanvas';
 
 import { AppElement } from '../app';
 import { AsyncElement } from '../async-element';
+import { parseBool } from '../utils';
 
 /**
  * Represents a component in the PlayCanvas engine.
@@ -100,7 +101,7 @@ class ComponentElement extends AsyncElement {
     attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
         switch (name) {
             case 'enabled':
-                this.enabled = newValue !== 'false';
+                this.enabled = parseBool(newValue, true);
                 break;
         }
     }

--- a/src/components/element-component.ts
+++ b/src/components/element-component.ts
@@ -2,7 +2,7 @@ import { Color, ElementComponent, Vec2, Vec4 } from 'playcanvas';
 
 import { AssetElement } from '../asset';
 import { ComponentElement } from './component';
-import { parseColor, parseVec2, parseVec4 } from '../utils';
+import { parseBool, parseColor, parseVec2, parseVec4 } from '../utils';
 
 /**
  * The ElementComponentElement interface provides properties and methods for manipulating
@@ -697,22 +697,22 @@ class ElementComponentElement extends ComponentElement {
                 this.asset = newValue;
                 break;
             case 'auto-width':
-                this.autoWidth = newValue !== 'false';
+                this.autoWidth = parseBool(newValue, true);
                 break;
             case 'auto-height':
-                this.autoHeight = newValue !== 'false';
+                this.autoHeight = parseBool(newValue, true);
                 break;
             case 'auto-fit-width':
-                this.autoFitWidth = newValue !== 'false';
+                this.autoFitWidth = parseBool(newValue, false);
                 break;
             case 'auto-fit-height':
-                this.autoFitHeight = newValue !== 'false';
+                this.autoFitHeight = parseBool(newValue, false);
                 break;
             case 'color':
                 this.color = parseColor(newValue);
                 break;
             case 'enable-markup':
-                this.enableMarkup = this.hasAttribute(name);
+                this.enableMarkup = parseBool(newValue, false);
                 break;
             case 'font-size':
                 this.fontSize = Number(newValue);
@@ -733,7 +733,7 @@ class ElementComponentElement extends ComponentElement {
                 this.margin = parseVec4(newValue);
                 break;
             case 'mask':
-                this.mask = this.hasAttribute(name);
+                this.mask = parseBool(newValue, false);
                 break;
             case 'opacity':
                 this.opacity = Number(newValue);
@@ -760,13 +760,13 @@ class ElementComponentElement extends ComponentElement {
                 this.type = newValue as 'group' | 'image' | 'text';
                 break;
             case 'use-input':
-                this.useInput = this.hasAttribute(name);
+                this.useInput = parseBool(newValue, false);
                 break;
             case 'width':
                 this.width = Number(newValue);
                 break;
             case 'wrap-lines':
-                this.wrapLines = this.hasAttribute(name);
+                this.wrapLines = parseBool(newValue, false);
                 break;
         }
     }

--- a/src/components/gsplat-component.ts
+++ b/src/components/gsplat-component.ts
@@ -2,6 +2,7 @@ import { GSplatComponent } from 'playcanvas';
 
 import { ComponentElement } from './component';
 import { AssetElement } from '../asset';
+import { parseBool } from '../utils';
 
 /**
  * The GSplatComponentElement interface provides properties and methods for manipulating
@@ -195,7 +196,7 @@ class GSplatComponentElement extends ComponentElement {
                 this.asset = newValue;
                 break;
             case 'cast-shadows':
-                this.castShadows = this.hasAttribute('cast-shadows');
+                this.castShadows = parseBool(newValue, false);
                 break;
             case 'lod-base-distance':
                 this.lodBaseDistance = Number(newValue);

--- a/src/components/layoutchild-component.ts
+++ b/src/components/layoutchild-component.ts
@@ -1,6 +1,7 @@
 import { LayoutChildComponent } from 'playcanvas';
 
 import { ComponentElement } from './component';
+import { parseBool } from '../utils';
 
 /**
  * The LayoutChildComponentElement interface provides properties and methods for manipulating
@@ -221,7 +222,7 @@ class LayoutChildComponentElement extends ComponentElement {
                 this.fitHeightProportion = Number(newValue);
                 break;
             case 'exclude-from-layout':
-                this.excludeFromLayout = newValue !== 'false';
+                this.excludeFromLayout = parseBool(newValue, false);
                 break;
         }
     }

--- a/src/components/layoutgroup-component.ts
+++ b/src/components/layoutgroup-component.ts
@@ -1,7 +1,7 @@
 import { FITTING_NONE, FITTING_STRETCH, FITTING_SHRINK, FITTING_BOTH, LayoutGroupComponent, ORIENTATION_HORIZONTAL, ORIENTATION_VERTICAL, Vec2, Vec4 } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseEnum, parseVec2, parseVec4 } from '../utils';
+import { parseBool, parseEnum, parseVec2, parseVec4 } from '../utils';
 
 const orientations = new Map<string, number>([
     ['horizontal', ORIENTATION_HORIZONTAL],
@@ -265,10 +265,10 @@ class LayoutGroupComponentElement extends ComponentElement {
                 this.orientation = parseEnum(newValue, orientations, ORIENTATION_HORIZONTAL);
                 break;
             case 'reverse-x':
-                this.reverseX = newValue !== 'false';
+                this.reverseX = parseBool(newValue, false);
                 break;
             case 'reverse-y':
-                this.reverseY = newValue !== 'false';
+                this.reverseY = parseBool(newValue, false);
                 break;
             case 'alignment':
                 this.alignment = parseVec2(newValue);
@@ -286,7 +286,7 @@ class LayoutGroupComponentElement extends ComponentElement {
                 this.heightFitting = parseEnum(newValue, fittings, FITTING_NONE);
                 break;
             case 'wrap':
-                this.wrap = newValue !== 'false';
+                this.wrap = parseBool(newValue, false);
                 break;
         }
     }

--- a/src/components/light-component.ts
+++ b/src/components/light-component.ts
@@ -1,7 +1,7 @@
 import { Color, LightComponent, SHADOW_PCF1_16F, SHADOW_PCF1_32F, SHADOW_PCF3_16F, SHADOW_PCF3_32F, SHADOW_PCF5_16F, SHADOW_PCF5_32F, SHADOW_PCSS_32F, SHADOW_VSM_16F, SHADOW_VSM_32F } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseColor } from '../utils';
+import { parseBool, parseColor } from '../utils';
 
 const shadowTypes = new Map([
     ['pcf1-16f', SHADOW_PCF1_16F],
@@ -508,7 +508,7 @@ class LightComponentElement extends ComponentElement {
                 this.color = parseColor(newValue);
                 break;
             case 'cast-shadows':
-                this.castShadows = this.hasAttribute('cast-shadows');
+                this.castShadows = parseBool(newValue, false);
                 break;
             case 'inner-cone-angle':
                 this.innerConeAngle = Number(newValue);

--- a/src/components/render-component.ts
+++ b/src/components/render-component.ts
@@ -2,6 +2,7 @@ import { RenderComponent, StandardMaterial } from 'playcanvas';
 
 import { ComponentElement } from './component';
 import { MaterialElement } from '../material';
+import { parseBool } from '../utils';
 
 /**
  * The RenderComponentElement interface provides properties and methods for manipulating
@@ -127,13 +128,13 @@ class RenderComponentElement extends ComponentElement {
 
         switch (name) {
             case 'cast-shadows':
-                this.castShadows = newValue !== 'false';
+                this.castShadows = parseBool(newValue, true);
                 break;
             case 'material':
                 this.material = newValue;
                 break;
             case 'receive-shadows':
-                this.receiveShadows = newValue !== 'false';
+                this.receiveShadows = parseBool(newValue, true);
                 break;
             case 'type':
                 this.type = newValue as 'asset' | 'box' | 'capsule' | 'cone' | 'cylinder' | 'plane' | 'sphere';

--- a/src/components/screen-component.ts
+++ b/src/components/screen-component.ts
@@ -1,7 +1,7 @@
 import { SCALEMODE_BLEND, SCALEMODE_NONE, ScreenComponent, Vec2 } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseVec2 } from '../utils';
+import { parseBool, parseVec2 } from '../utils';
 
 /**
  * The ScreenComponentElement interface provides properties and methods for manipulating
@@ -143,10 +143,10 @@ class ScreenComponentElement extends ComponentElement {
                 this.scaleBlend = parseFloat(newValue);
                 break;
             case 'blend':
-                this.blend = this.hasAttribute('blend');
+                this.blend = parseBool(newValue, false);
                 break;
             case 'screen-space':
-                this.screenSpace = this.hasAttribute('screen-space');
+                this.screenSpace = parseBool(newValue, false);
                 break;
         }
     }

--- a/src/components/script.ts
+++ b/src/components/script.ts
@@ -1,3 +1,5 @@
+import { parseBool } from '../utils';
+
 /**
  * The ScriptElement interface provides properties and methods for manipulating
  * `<pc-script>` elements. The ScriptElement interface also inherits the properties and
@@ -76,7 +78,7 @@ class ScriptElement extends HTMLElement {
                 this.scriptAttributes = newValue;
                 break;
             case 'enabled':
-                this.enabled = newValue !== 'false';
+                this.enabled = parseBool(newValue, true);
                 break;
             case 'name':
                 this.name = newValue;

--- a/src/components/scrollview-component.ts
+++ b/src/components/scrollview-component.ts
@@ -1,7 +1,7 @@
 import { SCROLL_MODE_BOUNCE, SCROLL_MODE_CLAMP, SCROLL_MODE_INFINITE, SCROLLBAR_VISIBILITY_SHOW_ALWAYS, SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED, ScrollViewComponent, Vec2 } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { getEntity, parseEnum, parseVec2 } from '../utils';
+import { getEntity, parseBool, parseEnum, parseVec2 } from '../utils';
 
 const scrollModes = new Map<string, number>([
     ['clamp', SCROLL_MODE_CLAMP],
@@ -380,10 +380,10 @@ class ScrollViewComponentElement extends ComponentElement {
 
         switch (name) {
             case 'horizontal':
-                this.horizontal = newValue !== 'false';
+                this.horizontal = parseBool(newValue, true);
                 break;
             case 'vertical':
-                this.vertical = newValue !== 'false';
+                this.vertical = parseBool(newValue, true);
                 break;
             case 'scroll-mode':
                 this.scrollMode = parseEnum(newValue, scrollModes, SCROLL_MODE_BOUNCE);
@@ -395,7 +395,7 @@ class ScrollViewComponentElement extends ComponentElement {
                 this.friction = Number(newValue);
                 break;
             case 'use-mouse-wheel':
-                this.useMouseWheel = newValue !== 'false';
+                this.useMouseWheel = parseBool(newValue, true);
                 break;
             case 'mouse-wheel-sensitivity':
                 this.mouseWheelSensitivity = parseVec2(newValue);

--- a/src/components/sound-component.ts
+++ b/src/components/sound-component.ts
@@ -1,6 +1,7 @@
 import { SoundComponent } from 'playcanvas';
 
 import { ComponentElement } from './component';
+import { parseBool } from '../utils';
 
 /**
  * The SoundComponentElement interface provides properties and methods for manipulating
@@ -210,7 +211,7 @@ class SoundComponentElement extends ComponentElement {
                 this.pitch = parseFloat(newValue);
                 break;
             case 'positional':
-                this.positional = this.hasAttribute('positional');
+                this.positional = parseBool(newValue, false);
                 break;
             case 'ref-distance':
                 this.refDistance = parseFloat(newValue);

--- a/src/components/sound-slot.ts
+++ b/src/components/sound-slot.ts
@@ -3,6 +3,7 @@ import { SoundSlot } from 'playcanvas';
 import { AssetElement } from '../asset';
 import { AsyncElement } from '../async-element';
 import { SoundComponentElement } from './sound-component';
+import { parseBool } from '../utils';
 
 /**
  * The SoundSlotElement interface provides properties and methods for manipulating
@@ -258,19 +259,19 @@ class SoundSlotElement extends AsyncElement {
                 this.asset = newValue;
                 break;
             case 'auto-play':
-                this.autoPlay = this.hasAttribute('auto-play');
+                this.autoPlay = parseBool(newValue, false);
                 break;
             case 'duration':
                 this.duration = parseFloat(newValue);
                 break;
             case 'loop':
-                this.loop = this.hasAttribute('loop');
+                this.loop = parseBool(newValue, false);
                 break;
             case 'name':
                 this.name = newValue;
                 break;
             case 'overlap':
-                this.overlap = this.hasAttribute('overlap');
+                this.overlap = parseBool(newValue, false);
                 break;
             case 'pitch':
                 this.pitch = parseFloat(newValue);

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -1,7 +1,7 @@
 import { AppBase, Entity, Vec3 } from 'playcanvas';
 
 import { AsyncElement } from './async-element';
-import { parseVec3 } from './utils';
+import { parseBool, parseVec3 } from './utils';
 
 /**
  * The EntityElement interface provides properties and methods for manipulating
@@ -73,10 +73,7 @@ class EntityElement extends AsyncElement {
         const entity = new Entity(this.getAttribute('name') || this._name, app);
         this._entity = entity;
 
-        const enabled = this.getAttribute('enabled');
-        if (enabled) {
-            entity.enabled = enabled !== 'false';
-        }
+        entity.enabled = parseBool(this.getAttribute('enabled'), true);
 
         const position = this.getAttribute('position');
         if (position) {
@@ -310,7 +307,7 @@ class EntityElement extends AsyncElement {
     attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
         switch (name) {
             case 'enabled':
-                this.enabled = newValue !== 'false';
+                this.enabled = parseBool(newValue, true);
                 break;
             case 'name':
                 this.name = newValue;

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -3,7 +3,7 @@ import { Asset, EnvLighting, LAYERID_SKYBOX, Quat, Scene, Texture, Vec3 } from '
 import { AppElement } from './app';
 import { AssetElement } from './asset';
 import { AsyncElement } from './async-element';
-import { parseVec3 } from './utils';
+import { parseBool, parseVec3 } from './utils';
 
 /**
  * The SkyElement interface provides properties and methods for manipulating
@@ -285,7 +285,7 @@ class SkyElement extends AsyncElement {
                 this.level = parseInt(newValue, 10);
                 break;
             case 'lighting':
-                this.lighting = this.hasAttribute(name);
+                this.lighting = parseBool(newValue, false);
                 break;
             case 'rotation':
                 this.rotation = parseVec3(newValue);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,22 @@ import { Color, Entity, Quat, Vec2, Vec3, Vec4 } from 'playcanvas';
 import { CSS_COLORS } from './colors';
 
 /**
+ * Parse a boolean attribute value. The same rules apply to every boolean attribute:
+ *
+ * - Attribute absent (or removed): the supplied default is used.
+ * - Attribute set to the string 'false': `false`.
+ * - Attribute present with any other value, including the empty string of a bare boolean
+ *   attribute (e.g. `<pc-light cast-shadows>`): `true`.
+ *
+ * @param value - The attribute value to parse (`null` when the attribute is absent).
+ * @param defaultValue - The value to use when the attribute is absent or removed.
+ * @returns The parsed boolean.
+ */
+export const parseBool = (value: string | null, defaultValue: boolean): boolean => {
+    return value === null ? defaultValue : value !== 'false';
+};
+
+/**
  * Parse a color string into a Color object. String can be in the format of '#rgb', '#rgba',
  * '#rrggbb', '#rrggbbaa', or a string of 3 or 4 comma-delimited numbers.
  *


### PR DESCRIPTION
## What

Adds a single `parseBool(value, defaultValue)` helper to `src/utils.ts` and routes all 46 boolean attribute parse sites through it. The rule is now uniform everywhere:

| Markup | Result |
|---|---|
| attribute absent (or removed at runtime) | engine default |
| `attr` (bare presence) or any value other than `"false"` | `true` |
| `attr="false"` | `false` |

Engine-mirroring defaults are untouched, and bare-presence usage parses identically to before.

## Why

The codebase had two parsing styles: 29 attributes used `newValue !== 'false'` and 17 used `hasAttribute()`. The split roughly tracked engine defaults (presence style for default-false flags), but it leaked — 8 default-false attributes (`flip-faces`, `clear-stencil-buffer`, `auto-fit-width`, `auto-fit-height`, `reverse-x`, `reverse-y`, `wrap`, `exclude-from-layout`) were value-based anyway — and the split is invisible from markup. Concrete footguns this fixes:

- **Same attribute, opposite behavior**: `cast-shadows="false"` disabled shadows on `<pc-render>` but *enabled* them on `<pc-light>` and `<pc-gsplat>`. The shipped examples teach the `="false"` idiom (`horizontal="false"`, `auto-width="false"`), so this was an easy trap.
- **Removal left values stuck**: removing a default-false value-based attribute (e.g. `flip-faces`) left it stuck `true` because `null !== 'false'`. Removal now reliably restores the default.

Also fixes a latent bug found while verifying: declarative `<pc-camera orthographic>` never worked — `getInitialComponentData()` passed an `orthographic` key the engine doesn't recognize; it now maps to `projection` (matching what the runtime setter already did).

## Notes for reviewers

- This is stage 1 of a staged series from a full audit of the declarative attribute surface; follow-up PRs will cover enum handling, number/vector parsing, and the agreed `pc-sound`/`pc-sound-slot` renames.
- The only observable behavior changes are: `="false"` now always means false, and attribute removal restores the default. No shipped example relies on either changed case, so no example changes are needed.
- Verified with `npm run build`, `type-check`, `lint`, plus a live-browser test page exercising all changed semantics (10/10 assertions) and manual spot-checks of `ui-scroll-view`, `positional-sound`, and `spinning-cube`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)