### PR TITLE
Validate enum attributes and expose string-typed enum properties

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -71,7 +71,7 @@ import { AsyncElement } from './async-element';
 import { EntityElement } from './entity';
 import { MaterialElement } from './material';
 import { ModuleElement } from './module';
-import { parseBool } from './utils';
+import { parseBool, parseEnum } from './utils';
 
 /**
  * The AppElement interface provides properties and methods for manipulating
@@ -602,9 +602,7 @@ class AppElement extends AsyncElement {
                 this.antialias = parseBool(newValue, true);
                 break;
             case 'backend':
-                if (newValue === 'webgpu' || newValue === 'webgl2' || newValue === 'null') {
-                    this.backend = newValue;
-                }
+                this.backend = parseEnum(newValue, ['webgpu', 'webgl2', 'null'], 'webgl2', name);
                 break;
             case 'depth':
                 this.depth = parseBool(newValue, true);

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -4,7 +4,7 @@ import { AsyncElement } from './async-element';
 import { parseBool, parseEnum } from './utils';
 import { MeshoptDecoder } from '../lib/meshopt_decoder.module.js';
 
-const renderModes = new Map<string, number>([
+const renderModes = new Map<'simple' | 'sliced' | 'tiled', number>([
     ['simple', SPRITE_RENDERMODE_SIMPLE],
     ['sliced', SPRITE_RENDERMODE_SLICED],
     ['tiled', SPRITE_RENDERMODE_TILED]
@@ -217,7 +217,7 @@ class AssetElement extends AsyncElement {
 
             const renderMode = this.getAttribute('render-mode');
             if (renderMode !== null) {
-                data.renderMode = parseEnum(renderMode, renderModes, SPRITE_RENDERMODE_SIMPLE);
+                data.renderMode = renderModes.get(parseEnum(renderMode, renderModes, 'simple', 'render-mode'));
             }
 
             // Apply engine defaults for any values not supplied.

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -4,7 +4,7 @@ import { AssetElement } from '../asset';
 import { ComponentElement } from './component';
 import { getEntity, parseBool, parseColor, parseEnum, parseVec4 } from '../utils';
 
-const transitionModes = new Map<string, number>([
+const transitionModes = new Map<'tint' | 'sprite', number>([
     ['tint', BUTTON_TRANSITION_MODE_TINT],
     ['sprite', BUTTON_TRANSITION_MODE_SPRITE_CHANGE]
 ]);
@@ -24,7 +24,7 @@ class ButtonComponentElement extends ComponentElement {
 
     private _hitPadding = new Vec4(0, 0, 0, 0);
 
-    private _transitionMode: number = BUTTON_TRANSITION_MODE_TINT;
+    private _transitionMode: 'tint' | 'sprite' = 'tint';
 
     private _hoverTint = new Color(1, 1, 1, 1);
 
@@ -55,7 +55,7 @@ class ButtonComponentElement extends ComponentElement {
         const data: Record<string, any> = {
             active: this._active,
             hitPadding: this._hitPadding,
-            transitionMode: this._transitionMode,
+            transitionMode: transitionModes.get(this._transitionMode),
             hoverTint: this._hoverTint,
             pressedTint: this._pressedTint,
             inactiveTint: this._inactiveTint,
@@ -158,13 +158,14 @@ class ButtonComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets how the button reacts to being hovered/pressed. Can be `tint` (0) or `sprite` (1).
+     * Sets how the button reacts to being hovered/pressed. Can be `tint` or `sprite`. Defaults to
+     * `tint`.
      * @param value - The transition mode.
      */
-    set transitionMode(value: number) {
+    set transitionMode(value: 'tint' | 'sprite') {
         this._transitionMode = value;
         if (this.component) {
-            this.component.transitionMode = value;
+            this.component.transitionMode = transitionModes.get(value) ?? BUTTON_TRANSITION_MODE_TINT;
         }
     }
 
@@ -409,7 +410,7 @@ class ButtonComponentElement extends ComponentElement {
                 this.hitPadding = parseVec4(newValue);
                 break;
             case 'transition-mode':
-                this.transitionMode = parseEnum(newValue, transitionModes, BUTTON_TRANSITION_MODE_TINT);
+                this.transitionMode = parseEnum(newValue, transitionModes, 'tint', name);
                 break;
             case 'hover-tint':
                 this.hoverTint = parseColor(newValue);

--- a/src/components/camera-component.ts
+++ b/src/components/camera-component.ts
@@ -1,9 +1,9 @@
 import { CameraComponent, Color, Vec4, GAMMA_NONE, GAMMA_SRGB, PROJECTION_ORTHOGRAPHIC, PROJECTION_PERSPECTIVE, TONEMAP_LINEAR, TONEMAP_FILMIC, TONEMAP_NEUTRAL, TONEMAP_ACES2, TONEMAP_ACES, TONEMAP_HEJL, TONEMAP_NONE, XRTYPE_VR } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseBool, parseColor, parseVec4 } from '../utils';
+import { parseBool, parseColor, parseEnum, parseVec4 } from '../utils';
 
-const tonemaps = new Map([
+const tonemaps = new Map<'none' | 'linear' | 'filmic' | 'hejl' | 'aces' | 'aces2' | 'neutral', number>([
     ['none', TONEMAP_NONE],
     ['linear', TONEMAP_LINEAR],
     ['filmic', TONEMAP_FILMIC],
@@ -522,7 +522,7 @@ class CameraComponentElement extends ComponentElement {
                 this.frustumCulling = parseBool(newValue, true);
                 break;
             case 'gamma':
-                this.gamma = newValue as 'linear' | 'srgb';
+                this.gamma = parseEnum(newValue, ['linear', 'srgb'], 'srgb', name);
                 break;
             case 'horizontal-fov':
                 this.horizontalFov = parseBool(newValue, false);
@@ -546,7 +546,7 @@ class CameraComponentElement extends ComponentElement {
                 this.scissorRect = parseVec4(newValue);
                 break;
             case 'tonemap':
-                this.tonemap = newValue as 'none' | 'linear' | 'filmic' | 'hejl' | 'aces' | 'aces2' | 'neutral';
+                this.tonemap = parseEnum(newValue, tonemaps, 'none', name);
                 break;
         }
     }

--- a/src/components/collision-component.ts
+++ b/src/components/collision-component.ts
@@ -1,7 +1,7 @@
 import { CollisionComponent, Quat, Vec3 } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseBool, parseQuat, parseVec3 } from '../utils';
+import { parseBool, parseEnum, parseQuat, parseVec3 } from '../utils';
 
 /**
  * The CollisionComponentElement interface provides properties and methods for manipulating
@@ -26,7 +26,7 @@ class CollisionComponentElement extends ComponentElement {
 
     private _radius: number = 0.5;
 
-    private _type: string = 'box';
+    private _type: 'box' | 'capsule' | 'compound' | 'cone' | 'cylinder' | 'mesh' | 'sphere' = 'box';
 
     /** @ignore */
     constructor() {
@@ -131,7 +131,7 @@ class CollisionComponentElement extends ComponentElement {
         return this._radius;
     }
 
-    set type(value: string) {
+    set type(value: 'box' | 'capsule' | 'compound' | 'cone' | 'cylinder' | 'mesh' | 'sphere') {
         this._type = value;
         if (this.component) {
             this.component.type = value;
@@ -172,7 +172,7 @@ class CollisionComponentElement extends ComponentElement {
                 this.radius = parseFloat(newValue);
                 break;
             case 'type':
-                this.type = newValue;
+                this.type = parseEnum(newValue, ['box', 'capsule', 'compound', 'cone', 'cylinder', 'mesh', 'sphere'], 'box', name);
                 break;
         }
     }

--- a/src/components/element-component.ts
+++ b/src/components/element-component.ts
@@ -2,7 +2,7 @@ import { Color, ElementComponent, Vec2, Vec4 } from 'playcanvas';
 
 import { AssetElement } from '../asset';
 import { ComponentElement } from './component';
-import { parseBool, parseColor, parseVec2, parseVec4 } from '../utils';
+import { parseBool, parseColor, parseEnum, parseVec2, parseVec4 } from '../utils';
 
 /**
  * The ElementComponentElement interface provides properties and methods for manipulating
@@ -757,7 +757,7 @@ class ElementComponentElement extends ComponentElement {
                 this.textureAsset = newValue;
                 break;
             case 'type':
-                this.type = newValue as 'group' | 'image' | 'text';
+                this.type = parseEnum(newValue, ['group', 'image', 'text'], 'group', name);
                 break;
             case 'use-input':
                 this.useInput = parseBool(newValue, false);

--- a/src/components/layoutgroup-component.ts
+++ b/src/components/layoutgroup-component.ts
@@ -3,12 +3,12 @@ import { FITTING_NONE, FITTING_STRETCH, FITTING_SHRINK, FITTING_BOTH, LayoutGrou
 import { ComponentElement } from './component';
 import { parseBool, parseEnum, parseVec2, parseVec4 } from '../utils';
 
-const orientations = new Map<string, number>([
+const orientations = new Map<'horizontal' | 'vertical', number>([
     ['horizontal', ORIENTATION_HORIZONTAL],
     ['vertical', ORIENTATION_VERTICAL]
 ]);
 
-const fittings = new Map<string, number>([
+const fittings = new Map<'none' | 'stretch' | 'shrink' | 'both', number>([
     ['none', FITTING_NONE],
     ['stretch', FITTING_STRETCH],
     ['shrink', FITTING_SHRINK],
@@ -24,7 +24,7 @@ const fittings = new Map<string, number>([
  * @category Components
  */
 class LayoutGroupComponentElement extends ComponentElement {
-    private _orientation: number = ORIENTATION_HORIZONTAL;
+    private _orientation: 'horizontal' | 'vertical' = 'horizontal';
 
     private _reverseX = false;
 
@@ -36,9 +36,9 @@ class LayoutGroupComponentElement extends ComponentElement {
 
     private _spacing = new Vec2(0, 0);
 
-    private _widthFitting: number = FITTING_NONE;
+    private _widthFitting: 'none' | 'stretch' | 'shrink' | 'both' = 'none';
 
-    private _heightFitting: number = FITTING_NONE;
+    private _heightFitting: 'none' | 'stretch' | 'shrink' | 'both' = 'none';
 
     private _wrap = false;
 
@@ -49,14 +49,14 @@ class LayoutGroupComponentElement extends ComponentElement {
 
     getInitialComponentData() {
         return {
-            orientation: this._orientation,
+            orientation: orientations.get(this._orientation),
             reverseX: this._reverseX,
             reverseY: this._reverseY,
             alignment: this._alignment,
             padding: this._padding,
             spacing: this._spacing,
-            widthFitting: this._widthFitting,
-            heightFitting: this._heightFitting,
+            widthFitting: fittings.get(this._widthFitting),
+            heightFitting: fittings.get(this._heightFitting),
             wrap: this._wrap
         };
     }
@@ -70,13 +70,14 @@ class LayoutGroupComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the orientation of the layout group. Can be `horizontal` (0) or `vertical` (1).
+     * Sets the orientation of the layout group. Can be `horizontal` or `vertical`. Defaults to
+     * `horizontal`.
      * @param value - The orientation.
      */
-    set orientation(value: number) {
+    set orientation(value: 'horizontal' | 'vertical') {
         this._orientation = value;
         if (this.component) {
-            this.component.orientation = value;
+            this.component.orientation = orientations.get(value) ?? ORIENTATION_HORIZONTAL;
         }
     }
 
@@ -184,14 +185,14 @@ class LayoutGroupComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the fitting mode along the horizontal axis. Can be `none` (0), `stretch` (1), `shrink`
-     * (2) or `both` (3).
+     * Sets the fitting mode along the horizontal axis. Can be `none`, `stretch`, `shrink` or
+     * `both`. Defaults to `none`.
      * @param value - The width fitting mode.
      */
-    set widthFitting(value: number) {
+    set widthFitting(value: 'none' | 'stretch' | 'shrink' | 'both') {
         this._widthFitting = value;
         if (this.component) {
-            this.component.widthFitting = value;
+            this.component.widthFitting = fittings.get(value) ?? FITTING_NONE;
         }
     }
 
@@ -204,14 +205,14 @@ class LayoutGroupComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the fitting mode along the vertical axis. Can be `none` (0), `stretch` (1), `shrink` (2)
-     * or `both` (3).
+     * Sets the fitting mode along the vertical axis. Can be `none`, `stretch`, `shrink` or
+     * `both`. Defaults to `none`.
      * @param value - The height fitting mode.
      */
-    set heightFitting(value: number) {
+    set heightFitting(value: 'none' | 'stretch' | 'shrink' | 'both') {
         this._heightFitting = value;
         if (this.component) {
-            this.component.heightFitting = value;
+            this.component.heightFitting = fittings.get(value) ?? FITTING_NONE;
         }
     }
 
@@ -262,7 +263,7 @@ class LayoutGroupComponentElement extends ComponentElement {
 
         switch (name) {
             case 'orientation':
-                this.orientation = parseEnum(newValue, orientations, ORIENTATION_HORIZONTAL);
+                this.orientation = parseEnum(newValue, orientations, 'horizontal', name);
                 break;
             case 'reverse-x':
                 this.reverseX = parseBool(newValue, false);
@@ -280,10 +281,10 @@ class LayoutGroupComponentElement extends ComponentElement {
                 this.spacing = parseVec2(newValue);
                 break;
             case 'width-fitting':
-                this.widthFitting = parseEnum(newValue, fittings, FITTING_NONE);
+                this.widthFitting = parseEnum(newValue, fittings, 'none', name);
                 break;
             case 'height-fitting':
-                this.heightFitting = parseEnum(newValue, fittings, FITTING_NONE);
+                this.heightFitting = parseEnum(newValue, fittings, 'none', name);
                 break;
             case 'wrap':
                 this.wrap = parseBool(newValue, false);

--- a/src/components/light-component.ts
+++ b/src/components/light-component.ts
@@ -1,9 +1,9 @@
 import { Color, LightComponent, SHADOW_PCF1_16F, SHADOW_PCF1_32F, SHADOW_PCF3_16F, SHADOW_PCF3_32F, SHADOW_PCF5_16F, SHADOW_PCF5_32F, SHADOW_PCSS_32F, SHADOW_VSM_16F, SHADOW_VSM_32F } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseBool, parseColor } from '../utils';
+import { parseBool, parseColor, parseEnum } from '../utils';
 
-const shadowTypes = new Map([
+const shadowTypes = new Map<'pcf1-16f' | 'pcf1-32f' | 'pcf3-16f' | 'pcf3-32f' | 'pcf5-16f' | 'pcf5-32f' | 'vsm-16f' | 'vsm-32f' | 'pcss-32f', number>([
     ['pcf1-16f', SHADOW_PCF1_16F],
     ['pcf1-32f', SHADOW_PCF1_32F],
     ['pcf3-16f', SHADOW_PCF3_16F],
@@ -48,7 +48,7 @@ class LightComponentElement extends ComponentElement {
 
     private _shadowType: 'pcf1-16f' | 'pcf1-32f' | 'pcf3-16f' | 'pcf3-32f' | 'pcf5-16f' | 'pcf5-32f' | 'vsm-16f' | 'vsm-32f' | 'pcss-32f' = 'pcf3-32f';
 
-    private _type = 'directional';
+    private _type: 'directional' | 'omni' | 'spot' = 'directional';
 
     private _vsmBias = 0.01;
 
@@ -338,15 +338,11 @@ class LightComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the type of the light.
+     * Sets the type of the light. Can be `directional`, `omni` or `spot`. Defaults to
+     * `directional`.
      * @param value - The type.
      */
-    set type(value: string) {
-        if (!['directional', 'omni', 'spot'].includes(value)) {
-            console.warn(`Invalid light type '${value}', using default type '${this._type}'.`);
-            return;
-        }
-
+    set type(value: 'directional' | 'omni' | 'spot') {
         this._type = value;
         if (this.component) {
             this.component.type = value;
@@ -550,10 +546,10 @@ class LightComponentElement extends ComponentElement {
                 this.shadowSamples = Number(newValue);
                 break;
             case 'shadow-type':
-                this.shadowType = newValue as 'pcf1-16f' | 'pcf1-32f' | 'pcf3-16f' | 'pcf3-32f' | 'pcf5-16f' | 'pcf5-32f' | 'vsm-16f' | 'vsm-32f' | 'pcss-32f';
+                this.shadowType = parseEnum(newValue, shadowTypes, 'pcf3-32f', name);
                 break;
             case 'type':
-                this.type = newValue;
+                this.type = parseEnum(newValue, ['directional', 'omni', 'spot'], 'directional', name);
                 break;
             case 'vsm-bias':
                 this.vsmBias = Number(newValue);

--- a/src/components/render-component.ts
+++ b/src/components/render-component.ts
@@ -2,7 +2,7 @@ import { RenderComponent, StandardMaterial } from 'playcanvas';
 
 import { ComponentElement } from './component';
 import { MaterialElement } from '../material';
-import { parseBool } from '../utils';
+import { parseBool, parseEnum } from '../utils';
 
 /**
  * The RenderComponentElement interface provides properties and methods for manipulating
@@ -137,7 +137,7 @@ class RenderComponentElement extends ComponentElement {
                 this.receiveShadows = parseBool(newValue, true);
                 break;
             case 'type':
-                this.type = newValue as 'asset' | 'box' | 'capsule' | 'cone' | 'cylinder' | 'plane' | 'sphere';
+                this.type = parseEnum(newValue, ['asset', 'box', 'capsule', 'cone', 'cylinder', 'plane', 'sphere'], 'asset', name);
                 break;
         }
     }

--- a/src/components/rigidbody-component.ts
+++ b/src/components/rigidbody-component.ts
@@ -1,7 +1,7 @@
 import { RigidBodyComponent, Vec3 } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseVec3 } from '../utils';
+import { parseEnum, parseVec3 } from '../utils';
 
 /**
  * The RigidBodyComponentElement interface provides properties and methods for manipulating
@@ -55,7 +55,7 @@ class RigidBodyComponentElement extends ComponentElement {
     /**
      * The type of the rigidbody.
      */
-    private _type: string = 'static';
+    private _type: 'static' | 'dynamic' | 'kinematic' = 'static';
 
     /** @ignore */
     constructor() {
@@ -172,10 +172,10 @@ class RigidBodyComponentElement extends ComponentElement {
         return this._rollingFriction;
     }
 
-    set type(value: string) {
+    set type(value: 'static' | 'dynamic' | 'kinematic') {
         this._type = value;
         if (this.component) {
-            this.component.type = value as 'static' | 'dynamic' | 'kinematic';
+            this.component.type = value;
         }
     }
 
@@ -216,7 +216,7 @@ class RigidBodyComponentElement extends ComponentElement {
                 this.rollingFriction = parseFloat(newValue);
                 break;
             case 'type':
-                this.type = newValue;
+                this.type = parseEnum(newValue, ['static', 'dynamic', 'kinematic'], 'static', name);
                 break;
         }
     }

--- a/src/components/scrollbar-component.ts
+++ b/src/components/scrollbar-component.ts
@@ -3,7 +3,7 @@ import { ORIENTATION_HORIZONTAL, ORIENTATION_VERTICAL, ScrollbarComponent } from
 import { ComponentElement } from './component';
 import { getEntity, parseEnum } from '../utils';
 
-const orientations = new Map<string, number>([
+const orientations = new Map<'horizontal' | 'vertical', number>([
     ['horizontal', ORIENTATION_HORIZONTAL],
     ['vertical', ORIENTATION_VERTICAL]
 ]);
@@ -17,7 +17,7 @@ const orientations = new Map<string, number>([
  * @category Components
  */
 class ScrollbarComponentElement extends ComponentElement {
-    private _orientation: number = ORIENTATION_HORIZONTAL;
+    private _orientation: 'horizontal' | 'vertical' = 'horizontal';
 
     private _value = 0;
 
@@ -32,7 +32,7 @@ class ScrollbarComponentElement extends ComponentElement {
 
     getInitialComponentData() {
         const data: Record<string, any> = {
-            orientation: this._orientation,
+            orientation: orientations.get(this._orientation),
             value: this._value,
             handleSize: this._handleSize
         };
@@ -54,13 +54,14 @@ class ScrollbarComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the orientation of the scrollbar. Can be `horizontal` (0) or `vertical` (1).
+     * Sets the orientation of the scrollbar. Can be `horizontal` or `vertical`. Defaults to
+     * `horizontal`.
      * @param value - The orientation.
      */
-    set orientation(value: number) {
+    set orientation(value: 'horizontal' | 'vertical') {
         this._orientation = value;
         if (this.component) {
-            this.component.orientation = value;
+            this.component.orientation = orientations.get(value) ?? ORIENTATION_HORIZONTAL;
         }
     }
 
@@ -146,7 +147,7 @@ class ScrollbarComponentElement extends ComponentElement {
 
         switch (name) {
             case 'orientation':
-                this.orientation = parseEnum(newValue, orientations, ORIENTATION_HORIZONTAL);
+                this.orientation = parseEnum(newValue, orientations, 'horizontal', name);
                 break;
             case 'value':
                 this.value = Number(newValue);

--- a/src/components/scrollview-component.ts
+++ b/src/components/scrollview-component.ts
@@ -3,13 +3,13 @@ import { SCROLL_MODE_BOUNCE, SCROLL_MODE_CLAMP, SCROLL_MODE_INFINITE, SCROLLBAR_
 import { ComponentElement } from './component';
 import { getEntity, parseBool, parseEnum, parseVec2 } from '../utils';
 
-const scrollModes = new Map<string, number>([
+const scrollModes = new Map<'clamp' | 'bounce' | 'infinite', number>([
     ['clamp', SCROLL_MODE_CLAMP],
     ['bounce', SCROLL_MODE_BOUNCE],
     ['infinite', SCROLL_MODE_INFINITE]
 ]);
 
-const visibilities = new Map<string, number>([
+const visibilities = new Map<'always' | 'when-required', number>([
     ['always', SCROLLBAR_VISIBILITY_SHOW_ALWAYS],
     ['when-required', SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED]
 ]);
@@ -27,7 +27,7 @@ class ScrollViewComponentElement extends ComponentElement {
 
     private _vertical = true;
 
-    private _scrollMode: number = SCROLL_MODE_BOUNCE;
+    private _scrollMode: 'clamp' | 'bounce' | 'infinite' = 'bounce';
 
     private _bounceAmount = 0.1;
 
@@ -37,9 +37,9 @@ class ScrollViewComponentElement extends ComponentElement {
 
     private _mouseWheelSensitivity = new Vec2(1, 1);
 
-    private _horizontalScrollbarVisibility: number = SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED;
+    private _horizontalScrollbarVisibility: 'always' | 'when-required' = 'when-required';
 
-    private _verticalScrollbarVisibility: number = SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED;
+    private _verticalScrollbarVisibility: 'always' | 'when-required' = 'when-required';
 
     private _viewport = '';
 
@@ -58,13 +58,13 @@ class ScrollViewComponentElement extends ComponentElement {
         const data: Record<string, any> = {
             horizontal: this._horizontal,
             vertical: this._vertical,
-            scrollMode: this._scrollMode,
+            scrollMode: scrollModes.get(this._scrollMode),
             bounceAmount: this._bounceAmount,
             friction: this._friction,
             useMouseWheel: this._useMouseWheel,
             mouseWheelSensitivity: this._mouseWheelSensitivity,
-            horizontalScrollbarVisibility: this._horizontalScrollbarVisibility,
-            verticalScrollbarVisibility: this._verticalScrollbarVisibility
+            horizontalScrollbarVisibility: visibilities.get(this._horizontalScrollbarVisibility),
+            verticalScrollbarVisibility: visibilities.get(this._verticalScrollbarVisibility)
         };
 
         const viewport = getEntity(this._viewport);
@@ -138,13 +138,13 @@ class ScrollViewComponentElement extends ComponentElement {
 
     /**
      * Sets how the scroll view should behave when the content is scrolled beyond its bounds. Can be
-     * `clamp` (0), `bounce` (1) or `infinite` (2).
+     * `clamp`, `bounce` or `infinite`. Defaults to `bounce`.
      * @param value - The scroll mode.
      */
-    set scrollMode(value: number) {
+    set scrollMode(value: 'clamp' | 'bounce' | 'infinite') {
         this._scrollMode = value;
         if (this.component) {
-            this.component.scrollMode = value;
+            this.component.scrollMode = scrollModes.get(value) ?? SCROLL_MODE_BOUNCE;
         }
     }
 
@@ -235,13 +235,14 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the visibility of the horizontal scrollbar. Can be `always` (0) or `when-required` (1).
+     * Sets the visibility of the horizontal scrollbar. Can be `always` or `when-required`.
+     * Defaults to `when-required`.
      * @param value - The horizontal scrollbar visibility.
      */
-    set horizontalScrollbarVisibility(value: number) {
+    set horizontalScrollbarVisibility(value: 'always' | 'when-required') {
         this._horizontalScrollbarVisibility = value;
         if (this.component) {
-            this.component.horizontalScrollbarVisibility = value;
+            this.component.horizontalScrollbarVisibility = visibilities.get(value) ?? SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED;
         }
     }
 
@@ -254,13 +255,14 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the visibility of the vertical scrollbar. Can be `always` (0) or `when-required` (1).
+     * Sets the visibility of the vertical scrollbar. Can be `always` or `when-required`.
+     * Defaults to `when-required`.
      * @param value - The vertical scrollbar visibility.
      */
-    set verticalScrollbarVisibility(value: number) {
+    set verticalScrollbarVisibility(value: 'always' | 'when-required') {
         this._verticalScrollbarVisibility = value;
         if (this.component) {
-            this.component.verticalScrollbarVisibility = value;
+            this.component.verticalScrollbarVisibility = visibilities.get(value) ?? SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED;
         }
     }
 
@@ -386,7 +388,7 @@ class ScrollViewComponentElement extends ComponentElement {
                 this.vertical = parseBool(newValue, true);
                 break;
             case 'scroll-mode':
-                this.scrollMode = parseEnum(newValue, scrollModes, SCROLL_MODE_BOUNCE);
+                this.scrollMode = parseEnum(newValue, scrollModes, 'bounce', name);
                 break;
             case 'bounce-amount':
                 this.bounceAmount = Number(newValue);
@@ -401,10 +403,10 @@ class ScrollViewComponentElement extends ComponentElement {
                 this.mouseWheelSensitivity = parseVec2(newValue);
                 break;
             case 'horizontal-scrollbar-visibility':
-                this.horizontalScrollbarVisibility = parseEnum(newValue, visibilities, SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED);
+                this.horizontalScrollbarVisibility = parseEnum(newValue, visibilities, 'when-required', name);
                 break;
             case 'vertical-scrollbar-visibility':
-                this.verticalScrollbarVisibility = parseEnum(newValue, visibilities, SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED);
+                this.verticalScrollbarVisibility = parseEnum(newValue, visibilities, 'when-required', name);
                 break;
             case 'viewport':
                 this.viewport = newValue;

--- a/src/components/sound-component.ts
+++ b/src/components/sound-component.ts
@@ -1,7 +1,7 @@
 import { SoundComponent } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseBool } from '../utils';
+import { parseBool, parseEnum } from '../utils';
 
 /**
  * The SoundComponentElement interface provides properties and methods for manipulating
@@ -202,7 +202,7 @@ class SoundComponentElement extends ComponentElement {
 
         switch (name) {
             case 'distance-model':
-                this.distanceModel = newValue as 'exponential' | 'inverse' | 'linear';
+                this.distanceModel = parseEnum(newValue, ['exponential', 'inverse', 'linear'], 'linear', name);
                 break;
             case 'max-distance':
                 this.maxDistance = parseFloat(newValue);

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -2,7 +2,7 @@ import { Color, Scene, Vec3 } from 'playcanvas';
 
 import { AppElement } from './app';
 import { AsyncElement } from './async-element';
-import { parseColor, parseVec3 } from './utils';
+import { parseColor, parseEnum, parseVec3 } from './utils';
 
 /**
  * The SceneElement interface provides properties and methods for manipulating
@@ -14,7 +14,7 @@ class SceneElement extends AsyncElement {
     /**
      * The fog type of the scene.
      */
-    private _fog = 'none'; // possible values: 'none', 'linear', 'exp', 'exp2'
+    private _fog: 'none' | 'linear' | 'exp' | 'exp2' = 'none';
 
     /**
      * The color of the fog.
@@ -75,7 +75,8 @@ class SceneElement extends AsyncElement {
     }
 
     /**
-     * Sets the fog type of the scene.
+     * Sets the fog type of the scene. Can be `none`, `linear`, `exp` or `exp2`. Defaults to
+     * `none`.
      * @param value - The fog type.
      */
     set fog(value) {
@@ -196,7 +197,7 @@ class SceneElement extends AsyncElement {
     attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
         switch (name) {
             case 'fog':
-                this.fog = newValue;
+                this.fog = parseEnum(newValue, ['none', 'linear', 'exp', 'exp2'], 'none', name);
                 break;
             case 'fog-color':
                 this.fogColor = parseColor(newValue);

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -3,7 +3,7 @@ import { Asset, EnvLighting, LAYERID_SKYBOX, Quat, Scene, Texture, Vec3 } from '
 import { AppElement } from './app';
 import { AssetElement } from './asset';
 import { AsyncElement } from './async-element';
-import { parseBool, parseVec3 } from './utils';
+import { parseBool, parseEnum, parseVec3 } from './utils';
 
 /**
  * The SkyElement interface provides properties and methods for manipulating
@@ -294,7 +294,7 @@ class SkyElement extends AsyncElement {
                 this.scale = parseVec3(newValue);
                 break;
             case 'type':
-                this.type = newValue as 'box' | 'dome' | 'infinite' | 'none';
+                this.type = parseEnum(newValue, ['box', 'dome', 'infinite', 'none'], 'infinite', name);
                 break;
         }
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,21 +87,31 @@ export const parseVec4 = (value: string): Vec4 => {
 };
 
 /**
- * Resolves an enum value supplied as either a named string (looked up in `map`) or a numeric
- * string. Falls back to `defaultValue` when the value is neither a known name nor a finite number.
+ * Resolves an enum attribute value against its set of valid names. Returns the value when it is
+ * one of the valid names. Returns `defaultValue` when the attribute is absent (`null`), or when
+ * the value is invalid — the latter also logs a warning listing the valid names.
  *
- * @param value - The attribute value to parse.
- * @param map - A map of named values to their numeric enum equivalents.
- * @param defaultValue - The value to return when parsing fails.
- * @returns The resolved numeric enum value.
+ * @param value - The attribute value to parse (`null` when the attribute is absent).
+ * @param valid - The valid names: an array, or a map whose keys are the valid names.
+ * @param defaultValue - The value to use when the attribute is absent or invalid.
+ * @param attribute - The attribute name, used in the warning message.
+ * @returns The resolved enum name.
  */
-export const parseEnum = (value: string, map: Map<string, number>, defaultValue: number): number => {
-    const named = map.get(value);
-    if (named !== undefined) {
-        return named;
+export const parseEnum = <T extends string>(
+    value: string | null,
+    valid: readonly T[] | ReadonlyMap<T, number>,
+    defaultValue: T,
+    attribute: string
+): T => {
+    if (value === null) {
+        return defaultValue;
     }
-    const numeric = Number(value);
-    return Number.isFinite(numeric) ? numeric : defaultValue;
+    const names = Array.isArray(valid) ? valid : [...(valid as ReadonlyMap<T, number>).keys()];
+    if (names.includes(value as T)) {
+        return value as T;
+    }
+    console.warn(`Invalid value '${value}' for attribute '${attribute}'. Valid values: ${names.join(', ')}. Using '${defaultValue}'.`);
+    return defaultValue;
 };
 
 /**


### PR DESCRIPTION
## What

Stage 2 of the attribute-conventions series (follows #272). All enum attributes now resolve through one upgraded `parseEnum()` helper with a uniform contract:

| Markup | Result |
|---|---|
| valid name (e.g. `scroll-mode="clamp"`) | accepted |
| attribute absent (or removed at runtime) | engine default, silently |
| invalid value (e.g. `tonemap="bogus"`) | console warning listing the valid names, then the default |

Example warning: `Invalid value 'bogus' for attribute 'scroll-mode'. Valid values: clamp, bounce, infinite. Using 'bounce'.`

The eight enum properties that leaked raw engine constants through the JS API — `scrollbar.orientation`, `scrollview.scrollMode`, both scrollbar visibilities, `layoutgroup.orientation`/`widthFitting`/`heightFitting`, `button.transitionMode` — are now typed string unions, matching what `camera.tonemap` and `light.shadowType` already did. Engine numeric constants are produced only at the component boundary, so `document.querySelector('pc-scrollbar').orientation` now returns `'vertical'` instead of `1`.

## Why

Enum handling previously had four different behaviors: unvalidated `as`-casts that silently accepted garbage (`gamma`, `tonemap`, all the `type` attributes, `distance-model`, `fog`, `backend`), silent fallbacks via map lookup, a warning on `pc-light type` only, and an undocumented numeric-string passthrough on the map-based attributes (`scroll-mode="1"` worked; it is now rejected with a warning, since the declarative layer is names-only). Users got no feedback for typos, and the JS API returned strings from some elements and raw numbers from others.

## Breaking changes

- The 8 properties listed above now accept/return string names instead of engine numeric constants (TypeScript unions enforce this at compile time).
- Numeric strings are no longer accepted for map-based enum attributes.
- Attributes whose values pass through unvalidated previously (e.g. `fog="foo"`, `backend="webgl1"`) now warn and use the default instead of feeding garbage to the engine.

## Verification

- `npm run build`, `type-check`, `lint` all clean; zero `newValue as '...'` casts remain; exactly 21 `parseEnum` call sites.
- Live-browser test page: 18/18 assertions covering valid mapping, invalid-value warnings (count, attribute name, valid-values list), numeric rejection, string-typed properties, JS setter mapping, and silent removal-restores-default.
- Grepped all examples: none use numeric enum values or read the converted properties from JS; `ui-scroll-view` (heaviest enum consumer) renders identically with zero console output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)