### PR TITLE
Rename pc-element's font attribute from 'asset' to 'font-asset'

### DIFF
--- a/examples/screen.html
+++ b/examples/screen.html
@@ -30,13 +30,13 @@
                 <pc-entity name="screen">
                     <pc-screen screen-space></pc-screen>
                     <pc-entity name="text" position="0 40 0">
-                        <pc-element type="text" asset="arial" text="This is Arial"></pc-element>
+                        <pc-element type="text" font-asset="arial" text="This is Arial"></pc-element>
                     </pc-entity>
                     <pc-entity name="text2" position="0 0 0">
-                        <pc-element type="text" asset="courier" text="This is Courier"></pc-element>
+                        <pc-element type="text" font-asset="courier" text="This is Courier"></pc-element>
                     </pc-entity>
                     <pc-entity name="text3" position="0 -40 0">
-                        <pc-element type="text" asset="arial" enable-markup text='[color="#ff0000"]Red[/color] [color="#00ff00"]Green[/color] [color="#0088ff"]Blue[/color]'></pc-element>
+                        <pc-element type="text" font-asset="arial" enable-markup text='[color="#ff0000"]Red[/color] [color="#00ff00"]Green[/color] [color="#0088ff"]Blue[/color]'></pc-element>
                     </pc-entity>
                 </pc-entity>
             </pc-scene>

--- a/examples/text.html
+++ b/examples/text.html
@@ -28,7 +28,7 @@
                 </pc-entity>
                 <!-- Text -->
                 <pc-entity name="crawl text" position="0 -2 0" rotation="-72 0 0">
-                    <pc-element type="text" asset="trade-gothic" color="#ffe81f" auto-width="false" font-size="0.2" line-height="0.25" width="2.65" wrap-lines text="It is a period of civil war.
+                    <pc-element type="text" font-asset="trade-gothic" color="#ffe81f" auto-width="false" font-size="0.2" line-height="0.25" width="2.65" wrap-lines text="It is a period of civil war.
 Rebel spaceships, striking
 from a hidden base, have won
 their first victory against

--- a/examples/ui-scroll-view.html
+++ b/examples/ui-scroll-view.html
@@ -97,7 +97,7 @@
                             <pc-element type="image" anchor="0 1 0 1" pivot="0 1" width="190" height="45" sprite-asset="blue-button"></pc-element>
 
                             <pc-entity name="Text">
-                                <pc-element type="text" anchor="0.1 0.1 0.9 0.9" pivot="0.5 0.5" margin="0 0 0 0" asset="kenney" font-size="32" min-font-size="8" max-font-size="32" auto-fit-width auto-fit-height auto-width="false" color="1 1 1" text="Add entry"></pc-element>
+                                <pc-element type="text" anchor="0.1 0.1 0.9 0.9" pivot="0.5 0.5" margin="0 0 0 0" font-asset="kenney" font-size="32" min-font-size="8" max-font-size="32" auto-fit-width auto-fit-height auto-width="false" color="1 1 1" text="Add entry"></pc-element>
                             </pc-entity>
                         </pc-entity>
                     </pc-entity>
@@ -118,7 +118,7 @@
                     <pc-button transition-mode="tint" hover-tint="0.82 0.82 0.82 1" pressed-tint="0.361 0.361 0.361 1"></pc-button>
                 </pc-entity>
                 <pc-entity name="Text" position="12.888 0 0">
-                    <pc-element type="text" anchor="0 0.5 0 0.5" pivot="0 0.5" asset="kenney" font-size="32" color="1 1 1" text="1"></pc-element>
+                    <pc-element type="text" anchor="0 0.5 0 0.5" pivot="0 0.5" font-asset="kenney" font-size="32" color="1 1 1" text="1"></pc-element>
                 </pc-entity>
             </pc-entity>
         </template>
@@ -135,7 +135,7 @@
                     <pc-button transition-mode="tint" hover-tint="0.82 0.82 0.82 1" pressed-tint="0.361 0.361 0.361 1"></pc-button>
                 </pc-entity>
                 <pc-entity name="Text" position="12.888 0 0">
-                    <pc-element type="text" anchor="0 0.5 0 0.5" pivot="0 0.5" asset="kenney" font-size="32" color="1 1 1" text="1"></pc-element>
+                    <pc-element type="text" anchor="0 0.5 0 0.5" pivot="0 0.5" font-asset="kenney" font-size="32" color="1 1 1" text="1"></pc-element>
                 </pc-entity>
             </pc-entity>
         </template>
@@ -152,7 +152,7 @@
                     <pc-button transition-mode="tint" hover-tint="0.82 0.82 0.82 1" pressed-tint="0.361 0.361 0.361 1"></pc-button>
                 </pc-entity>
                 <pc-entity name="Text" position="12.888 0 0">
-                    <pc-element type="text" anchor="0 0.5 0 0.5" pivot="0 0.5" asset="kenney" font-size="32" color="1 1 1" text="1"></pc-element>
+                    <pc-element type="text" anchor="0 0.5 0 0.5" pivot="0 0.5" font-asset="kenney" font-size="32" color="1 1 1" text="1"></pc-element>
                 </pc-entity>
             </pc-entity>
         </template>

--- a/src/components/element-component.ts
+++ b/src/components/element-component.ts
@@ -15,8 +15,6 @@ import { parseBool, parseColor, parseEnum, parseVec2, parseVec4 } from '../utils
 class ElementComponentElement extends ComponentElement {
     private _anchor: Vec4 = new Vec4(0.5, 0.5, 0.5, 0.5);
 
-    private _asset: string = '';
-
     private _autoWidth: boolean = true;
 
     private _autoHeight: boolean = true;
@@ -28,6 +26,8 @@ class ElementComponentElement extends ComponentElement {
     private _color: Color = new Color(1, 1, 1, 1);
 
     private _enableMarkup: boolean = false;
+
+    private _fontAsset: string = '';
 
     private _fontSize: number = 32;
 
@@ -116,7 +116,7 @@ class ElementComponentElement extends ComponentElement {
 
         // Asset references are resolved from `<pc-asset>` element ids to engine asset ids. They are
         // only included when they resolve, so image/group elements (with no font) don't error.
-        const fontAsset = AssetElement.get(this._asset);
+        const fontAsset = AssetElement.get(this._fontAsset);
         if (fontAsset) {
             data.fontAsset = fontAsset.id;
         }
@@ -169,26 +169,6 @@ class ElementComponentElement extends ComponentElement {
      */
     get anchor() {
         return this._anchor;
-    }
-
-    /**
-     * Sets the id of the `pc-asset` to use for the font (text elements).
-     * @param value - The asset ID.
-     */
-    set asset(value: string) {
-        this._asset = value;
-        const asset = AssetElement.get(value);
-        if (this.component && asset) {
-            this.component.fontAsset = asset.id;
-        }
-    }
-
-    /**
-     * Gets the id of the `pc-asset` to use for the font.
-     * @returns The asset ID.
-     */
-    get asset() {
-        return this._asset;
     }
 
     /**
@@ -267,6 +247,26 @@ class ElementComponentElement extends ComponentElement {
      */
     get enableMarkup() {
         return this._enableMarkup;
+    }
+
+    /**
+     * Sets the id of the `pc-asset` to use for the font (text elements).
+     * @param value - The font asset ID.
+     */
+    set fontAsset(value: string) {
+        this._fontAsset = value;
+        const asset = AssetElement.get(value);
+        if (this.component && asset) {
+            this.component.fontAsset = asset.id;
+        }
+    }
+
+    /**
+     * Gets the id of the `pc-asset` to use for the font.
+     * @returns The font asset ID.
+     */
+    get fontAsset() {
+        return this._fontAsset;
     }
 
     /**
@@ -658,13 +658,13 @@ class ElementComponentElement extends ComponentElement {
         return [
             ...super.observedAttributes,
             'anchor',
-            'asset',
             'auto-width',
             'auto-height',
             'auto-fit-width',
             'auto-fit-height',
             'color',
             'enable-markup',
+            'font-asset',
             'font-size',
             'max-font-size',
             'min-font-size',
@@ -693,9 +693,6 @@ class ElementComponentElement extends ComponentElement {
             case 'anchor':
                 this.anchor = parseVec4(newValue);
                 break;
-            case 'asset':
-                this.asset = newValue;
-                break;
             case 'auto-width':
                 this.autoWidth = parseBool(newValue, true);
                 break;
@@ -713,6 +710,9 @@ class ElementComponentElement extends ComponentElement {
                 break;
             case 'enable-markup':
                 this.enableMarkup = parseBool(newValue, false);
+                break;
+            case 'font-asset':
+                this.fontAsset = newValue;
                 break;
             case 'font-size':
                 this.fontSize = Number(newValue);

--- a/src/components/sound-slot.ts
+++ b/src/components/sound-slot.ts
@@ -68,7 +68,7 @@ class SoundSlotElement extends AsyncElement {
         const soundElement = this.parentElement as SoundComponentElement;
 
         if (!(soundElement instanceof SoundComponentElement)) {
-            console.warn('pc-sound-slot must be a direct child of a pc-sound element');
+            console.warn('pc-sound must be a direct child of a pc-sounds element');
             return null;
         }
 


### PR DESCRIPTION
## What

Stage 4 of the attribute-conventions series (follows #272, #273).

- `<pc-element>`'s font reference is now `font-asset` (attribute) / `fontAsset` (JS property), replacing the bare `asset`. This matches its sibling attributes `texture-asset` and `sprite-asset`, and the engine's `ElementComponent.fontAsset`.
- `asset` is untouched everywhere else — it remains the right name where an element has one obvious asset (`pc-model`, `pc-gsplat`, `pc-sky`, `pc-sound`, `pc-particles`).
- Fixes the misparented sound-slot warning, which named tags that don't exist in that relationship ("pc-sound-slot must be a direct child of a pc-sound element" → "pc-sound must be a direct child of a pc-sounds element").
- Updates the three examples that used the old attribute (`screen.html`, `text.html`, `ui-scroll-view.html`).

Per earlier discussion, the `pc-sounds`/`pc-sound` tag rename originally scoped into this stage was dropped: `pc-sound-slot` would be the only tag with a hyphen beyond the `pc-` prefix, and the plural-container pattern (matching `pc-scripts`/`pc-script`) stays as the deliberate convention.

## Breaking change

`<pc-element type="text" asset="my-font">` no longer resolves the font — use `font-asset="my-font"`. The old `asset` property is gone from `ElementComponentElement` (TypeScript users get a compile error; the attribute is simply ignored at runtime like any unknown attribute).

## Verification

- `npm run build`, `type-check`, `lint` all clean; grep confirms no `asset` references remain in `element-component.ts` and no bare `asset=` remains on any `pc-element` in the examples.
- Live-browser checks of all three updated examples: `screen.html` renders Arial and Courier as visibly distinct fonts plus the `enable-markup` colored line; `text.html` renders the trade-gothic crawl; `ui-scroll-view.html` renders the kenney font everywhere, including entries cloned from `<template>` at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)