### PR TITLE
Unify number attribute parsing across all elements

### DIFF
--- a/src/asset.ts
+++ b/src/asset.ts
@@ -1,7 +1,7 @@
 import { Asset, SPRITE_RENDERMODE_SIMPLE, SPRITE_RENDERMODE_SLICED, SPRITE_RENDERMODE_TILED } from 'playcanvas';
 
 import { AsyncElement } from './async-element';
-import { parseBool, parseEnum } from './utils';
+import { parseBool, parseEnum, parseNumber } from './utils';
 import { MeshoptDecoder } from '../lib/meshopt_decoder.module.js';
 
 const renderModes = new Map<'simple' | 'sliced' | 'tiled', number>([
@@ -212,7 +212,7 @@ class AssetElement extends AsyncElement {
 
             const pixelsPerUnit = this.getAttribute('pixels-per-unit');
             if (pixelsPerUnit !== null) {
-                data.pixelsPerUnit = Number(pixelsPerUnit);
+                data.pixelsPerUnit = parseNumber(pixelsPerUnit, 1, 'pixels-per-unit');
             }
 
             const renderMode = this.getAttribute('render-mode');

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -2,7 +2,7 @@ import { BUTTON_TRANSITION_MODE_SPRITE_CHANGE, BUTTON_TRANSITION_MODE_TINT, Butt
 
 import { AssetElement } from '../asset';
 import { ComponentElement } from './component';
-import { getEntity, parseBool, parseColor, parseEnum, parseVec4 } from '../utils';
+import { getEntity, parseBool, parseColor, parseEnum, parseNumber, parseVec4 } from '../utils';
 
 const transitionModes = new Map<'tint' | 'sprite', number>([
     ['tint', BUTTON_TRANSITION_MODE_TINT],
@@ -422,25 +422,25 @@ class ButtonComponentElement extends ComponentElement {
                 this.inactiveTint = parseColor(newValue);
                 break;
             case 'fade-duration':
-                this.fadeDuration = Number(newValue);
+                this.fadeDuration = parseNumber(newValue, 0, name);
                 break;
             case 'hover-sprite-asset':
                 this.hoverSpriteAsset = newValue;
                 break;
             case 'hover-sprite-frame':
-                this.hoverSpriteFrame = Number(newValue);
+                this.hoverSpriteFrame = parseNumber(newValue, 0, name);
                 break;
             case 'pressed-sprite-asset':
                 this.pressedSpriteAsset = newValue;
                 break;
             case 'pressed-sprite-frame':
-                this.pressedSpriteFrame = Number(newValue);
+                this.pressedSpriteFrame = parseNumber(newValue, 0, name);
                 break;
             case 'inactive-sprite-asset':
                 this.inactiveSpriteAsset = newValue;
                 break;
             case 'inactive-sprite-frame':
-                this.inactiveSpriteFrame = Number(newValue);
+                this.inactiveSpriteFrame = parseNumber(newValue, 0, name);
                 break;
         }
     }

--- a/src/components/camera-component.ts
+++ b/src/components/camera-component.ts
@@ -1,7 +1,7 @@
 import { CameraComponent, Color, Vec4, GAMMA_NONE, GAMMA_SRGB, PROJECTION_ORTHOGRAPHIC, PROJECTION_PERSPECTIVE, TONEMAP_LINEAR, TONEMAP_FILMIC, TONEMAP_NEUTRAL, TONEMAP_ACES2, TONEMAP_ACES, TONEMAP_HEJL, TONEMAP_NONE, XRTYPE_VR } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseBool, parseColor, parseEnum, parseVec4 } from '../utils';
+import { parseBool, parseColor, parseEnum, parseNumber, parseVec4 } from '../utils';
 
 const tonemaps = new Map<'none' | 'linear' | 'filmic' | 'hejl' | 'aces' | 'aces2' | 'neutral', number>([
     ['none', TONEMAP_NONE],
@@ -510,13 +510,13 @@ class CameraComponentElement extends ComponentElement {
                 this.cullFaces = parseBool(newValue, true);
                 break;
             case 'far-clip':
-                this.farClip = parseFloat(newValue);
+                this.farClip = parseNumber(newValue, 1000, name);
                 break;
             case 'flip-faces':
                 this.flipFaces = parseBool(newValue, false);
                 break;
             case 'fov':
-                this.fov = parseFloat(newValue);
+                this.fov = parseNumber(newValue, 45, name);
                 break;
             case 'frustum-culling':
                 this.frustumCulling = parseBool(newValue, true);
@@ -528,16 +528,16 @@ class CameraComponentElement extends ComponentElement {
                 this.horizontalFov = parseBool(newValue, false);
                 break;
             case 'near-clip':
-                this.nearClip = parseFloat(newValue);
+                this.nearClip = parseNumber(newValue, 0.1, name);
                 break;
             case 'orthographic':
                 this.orthographic = parseBool(newValue, false);
                 break;
             case 'ortho-height':
-                this.orthoHeight = parseFloat(newValue);
+                this.orthoHeight = parseNumber(newValue, 10, name);
                 break;
             case 'priority':
-                this.priority = parseFloat(newValue);
+                this.priority = parseNumber(newValue, 0, name);
                 break;
             case 'rect':
                 this.rect = parseVec4(newValue);

--- a/src/components/collision-component.ts
+++ b/src/components/collision-component.ts
@@ -1,7 +1,7 @@
 import { CollisionComponent, Quat, Vec3 } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseBool, parseEnum, parseQuat, parseVec3 } from '../utils';
+import { parseBool, parseEnum, parseNumber, parseQuat, parseVec3 } from '../utils';
 
 /**
  * The CollisionComponentElement interface provides properties and methods for manipulating
@@ -154,7 +154,7 @@ class CollisionComponentElement extends ComponentElement {
                 this.angularOffset = parseQuat(newValue);
                 break;
             case 'axis':
-                this.axis = parseInt(newValue, 10);
+                this.axis = parseNumber(newValue, 1, name);
                 break;
             case 'convex-hull':
                 this.convexHull = parseBool(newValue, false);
@@ -163,13 +163,13 @@ class CollisionComponentElement extends ComponentElement {
                 this.halfExtents = parseVec3(newValue);
                 break;
             case 'height':
-                this.height = parseFloat(newValue);
+                this.height = parseNumber(newValue, 2, name);
                 break;
             case 'linear-offset':
                 this.linearOffset = parseVec3(newValue);
                 break;
             case 'radius':
-                this.radius = parseFloat(newValue);
+                this.radius = parseNumber(newValue, 0.5, name);
                 break;
             case 'type':
                 this.type = parseEnum(newValue, ['box', 'capsule', 'compound', 'cone', 'cylinder', 'mesh', 'sphere'], 'box', name);

--- a/src/components/element-component.ts
+++ b/src/components/element-component.ts
@@ -2,7 +2,7 @@ import { Color, ElementComponent, Vec2, Vec4 } from 'playcanvas';
 
 import { AssetElement } from '../asset';
 import { ComponentElement } from './component';
-import { parseBool, parseColor, parseEnum, parseVec2, parseVec4 } from '../utils';
+import { parseBool, parseColor, parseEnum, parseNumber, parseVec2, parseVec4 } from '../utils';
 
 /**
  * The ElementComponentElement interface provides properties and methods for manipulating
@@ -715,19 +715,19 @@ class ElementComponentElement extends ComponentElement {
                 this.fontAsset = newValue;
                 break;
             case 'font-size':
-                this.fontSize = Number(newValue);
+                this.fontSize = parseNumber(newValue, 32, name);
                 break;
             case 'max-font-size':
-                this.maxFontSize = Number(newValue);
+                this.maxFontSize = parseNumber(newValue, 32, name);
                 break;
             case 'min-font-size':
-                this.minFontSize = Number(newValue);
+                this.minFontSize = parseNumber(newValue, 8, name);
                 break;
             case 'height':
-                this.height = Number(newValue);
+                this.height = parseNumber(newValue, 0, name);
                 break;
             case 'line-height':
-                this.lineHeight = Number(newValue);
+                this.lineHeight = parseNumber(newValue, 32, name);
                 break;
             case 'margin':
                 this.margin = parseVec4(newValue);
@@ -736,19 +736,19 @@ class ElementComponentElement extends ComponentElement {
                 this.mask = parseBool(newValue, false);
                 break;
             case 'opacity':
-                this.opacity = Number(newValue);
+                this.opacity = parseNumber(newValue, 1, name);
                 break;
             case 'pivot':
                 this.pivot = parseVec2(newValue);
                 break;
             case 'pixels-per-unit':
-                this.pixelsPerUnit = Number(newValue);
+                this.pixelsPerUnit = parseNumber(newValue, null, name);
                 break;
             case 'sprite-asset':
                 this.spriteAsset = newValue;
                 break;
             case 'sprite-frame':
-                this.spriteFrame = Number(newValue);
+                this.spriteFrame = parseNumber(newValue, 0, name);
                 break;
             case 'text':
                 this.text = newValue;
@@ -763,7 +763,7 @@ class ElementComponentElement extends ComponentElement {
                 this.useInput = parseBool(newValue, false);
                 break;
             case 'width':
-                this.width = Number(newValue);
+                this.width = parseNumber(newValue, 0, name);
                 break;
             case 'wrap-lines':
                 this.wrapLines = parseBool(newValue, false);

--- a/src/components/gsplat-component.ts
+++ b/src/components/gsplat-component.ts
@@ -2,7 +2,7 @@ import { GSplatComponent } from 'playcanvas';
 
 import { ComponentElement } from './component';
 import { AssetElement } from '../asset';
-import { parseBool } from '../utils';
+import { parseBool, parseNumber } from '../utils';
 
 /**
  * The GSplatComponentElement interface provides properties and methods for manipulating
@@ -199,16 +199,16 @@ class GSplatComponentElement extends ComponentElement {
                 this.castShadows = parseBool(newValue, false);
                 break;
             case 'lod-base-distance':
-                this.lodBaseDistance = Number(newValue);
+                this.lodBaseDistance = parseNumber(newValue, 5, name);
                 break;
             case 'lod-multiplier':
-                this.lodMultiplier = Number(newValue);
+                this.lodMultiplier = parseNumber(newValue, 3, name);
                 break;
             case 'lod-range-min':
-                this.lodRangeMin = Number(newValue);
+                this.lodRangeMin = parseNumber(newValue, 0, name);
                 break;
             case 'lod-range-max':
-                this.lodRangeMax = Number(newValue);
+                this.lodRangeMax = parseNumber(newValue, 99, name);
                 break;
         }
     }

--- a/src/components/layoutchild-component.ts
+++ b/src/components/layoutchild-component.ts
@@ -1,7 +1,7 @@
 import { LayoutChildComponent } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseBool } from '../utils';
+import { parseBool, parseNumber } from '../utils';
 
 /**
  * The LayoutChildComponentElement interface provides properties and methods for manipulating
@@ -204,22 +204,22 @@ class LayoutChildComponentElement extends ComponentElement {
 
         switch (name) {
             case 'min-width':
-                this.minWidth = Number(newValue);
+                this.minWidth = parseNumber(newValue, 0, name);
                 break;
             case 'min-height':
-                this.minHeight = Number(newValue);
+                this.minHeight = parseNumber(newValue, 0, name);
                 break;
             case 'max-width':
-                this.maxWidth = newValue === '' ? null : Number(newValue);
+                this.maxWidth = parseNumber(newValue, null, name);
                 break;
             case 'max-height':
-                this.maxHeight = newValue === '' ? null : Number(newValue);
+                this.maxHeight = parseNumber(newValue, null, name);
                 break;
             case 'fit-width-proportion':
-                this.fitWidthProportion = Number(newValue);
+                this.fitWidthProportion = parseNumber(newValue, 0, name);
                 break;
             case 'fit-height-proportion':
-                this.fitHeightProportion = Number(newValue);
+                this.fitHeightProportion = parseNumber(newValue, 0, name);
                 break;
             case 'exclude-from-layout':
                 this.excludeFromLayout = parseBool(newValue, false);

--- a/src/components/light-component.ts
+++ b/src/components/light-component.ts
@@ -1,7 +1,7 @@
 import { Color, LightComponent, SHADOW_PCF1_16F, SHADOW_PCF1_32F, SHADOW_PCF3_16F, SHADOW_PCF3_32F, SHADOW_PCF5_16F, SHADOW_PCF5_32F, SHADOW_PCSS_32F, SHADOW_VSM_16F, SHADOW_VSM_32F } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseBool, parseColor, parseEnum } from '../utils';
+import { parseBool, parseColor, parseEnum, parseNumber } from '../utils';
 
 const shadowTypes = new Map<'pcf1-16f' | 'pcf1-32f' | 'pcf3-16f' | 'pcf3-32f' | 'pcf5-16f' | 'pcf5-32f' | 'vsm-16f' | 'vsm-32f' | 'pcss-32f', number>([
     ['pcf1-16f', SHADOW_PCF1_16F],
@@ -507,43 +507,43 @@ class LightComponentElement extends ComponentElement {
                 this.castShadows = parseBool(newValue, false);
                 break;
             case 'inner-cone-angle':
-                this.innerConeAngle = Number(newValue);
+                this.innerConeAngle = parseNumber(newValue, 40, name);
                 break;
             case 'intensity':
-                this.intensity = Number(newValue);
+                this.intensity = parseNumber(newValue, 1, name);
                 break;
             case 'normal-offset-bias':
-                this.normalOffsetBias = Number(newValue);
+                this.normalOffsetBias = parseNumber(newValue, 0.05, name);
                 break;
             case 'outer-cone-angle':
-                this.outerConeAngle = Number(newValue);
+                this.outerConeAngle = parseNumber(newValue, 45, name);
                 break;
             case 'penumbra-falloff':
-                this.penumbraFalloff = Number(newValue);
+                this.penumbraFalloff = parseNumber(newValue, 1, name);
                 break;
             case 'penumbra-size':
-                this.penumbraSize = Number(newValue);
+                this.penumbraSize = parseNumber(newValue, 1, name);
                 break;
             case 'range':
-                this.range = Number(newValue);
+                this.range = parseNumber(newValue, 10, name);
                 break;
             case 'shadow-bias':
-                this.shadowBias = Number(newValue);
+                this.shadowBias = parseNumber(newValue, 0.2, name);
                 break;
             case 'shadow-distance':
-                this.shadowDistance = Number(newValue);
+                this.shadowDistance = parseNumber(newValue, 16, name);
                 break;
             case 'shadow-blocker-samples':
-                this.shadowBlockerSamples = Number(newValue);
+                this.shadowBlockerSamples = parseNumber(newValue, 16, name);
                 break;
             case 'shadow-resolution':
-                this.shadowResolution = Number(newValue);
+                this.shadowResolution = parseNumber(newValue, 1024, name);
                 break;
             case 'shadow-intensity':
-                this.shadowIntensity = Number(newValue);
+                this.shadowIntensity = parseNumber(newValue, 1, name);
                 break;
             case 'shadow-samples':
-                this.shadowSamples = Number(newValue);
+                this.shadowSamples = parseNumber(newValue, 16, name);
                 break;
             case 'shadow-type':
                 this.shadowType = parseEnum(newValue, shadowTypes, 'pcf3-32f', name);
@@ -552,10 +552,10 @@ class LightComponentElement extends ComponentElement {
                 this.type = parseEnum(newValue, ['directional', 'omni', 'spot'], 'directional', name);
                 break;
             case 'vsm-bias':
-                this.vsmBias = Number(newValue);
+                this.vsmBias = parseNumber(newValue, 0.01, name);
                 break;
             case 'vsm-blur-size':
-                this.vsmBlurSize = Number(newValue);
+                this.vsmBlurSize = parseNumber(newValue, 11, name);
                 break;
         }
     }

--- a/src/components/rigidbody-component.ts
+++ b/src/components/rigidbody-component.ts
@@ -1,7 +1,7 @@
 import { RigidBodyComponent, Vec3 } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseEnum, parseVec3 } from '../utils';
+import { parseEnum, parseNumber, parseVec3 } from '../utils';
 
 /**
  * The RigidBodyComponentElement interface provides properties and methods for manipulating
@@ -192,28 +192,28 @@ class RigidBodyComponentElement extends ComponentElement {
 
         switch (name) {
             case 'angular-damping':
-                this.angularDamping = parseFloat(newValue);
+                this.angularDamping = parseNumber(newValue, 0, name);
                 break;
             case 'angular-factor':
                 this.angularFactor = parseVec3(newValue);
                 break;
             case 'friction':
-                this.friction = parseFloat(newValue);
+                this.friction = parseNumber(newValue, 0.5, name);
                 break;
             case 'linear-damping':
-                this.linearDamping = parseFloat(newValue);
+                this.linearDamping = parseNumber(newValue, 0, name);
                 break;
             case 'linear-factor':
                 this.linearFactor = parseVec3(newValue);
                 break;
             case 'mass':
-                this.mass = parseFloat(newValue);
+                this.mass = parseNumber(newValue, 1, name);
                 break;
             case 'restitution':
-                this.restitution = parseFloat(newValue);
+                this.restitution = parseNumber(newValue, 0, name);
                 break;
             case 'rolling-friction':
-                this.rollingFriction = parseFloat(newValue);
+                this.rollingFriction = parseNumber(newValue, 0, name);
                 break;
             case 'type':
                 this.type = parseEnum(newValue, ['static', 'dynamic', 'kinematic'], 'static', name);

--- a/src/components/screen-component.ts
+++ b/src/components/screen-component.ts
@@ -1,7 +1,7 @@
 import { SCALEMODE_BLEND, SCALEMODE_NONE, ScreenComponent, Vec2 } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseBool, parseVec2 } from '../utils';
+import { parseBool, parseNumber, parseVec2 } from '../utils';
 
 /**
  * The ScreenComponentElement interface provides properties and methods for manipulating
@@ -131,7 +131,7 @@ class ScreenComponentElement extends ComponentElement {
 
         switch (name) {
             case 'priority':
-                this.priority = parseInt(newValue, 10);
+                this.priority = parseNumber(newValue, 0, name);
                 break;
             case 'reference-resolution':
                 this.referenceResolution = parseVec2(newValue);
@@ -140,7 +140,7 @@ class ScreenComponentElement extends ComponentElement {
                 this.resolution = parseVec2(newValue);
                 break;
             case 'scale-blend':
-                this.scaleBlend = parseFloat(newValue);
+                this.scaleBlend = parseNumber(newValue, 0.5, name);
                 break;
             case 'blend':
                 this.blend = parseBool(newValue, false);

--- a/src/components/scrollbar-component.ts
+++ b/src/components/scrollbar-component.ts
@@ -1,7 +1,7 @@
 import { ORIENTATION_HORIZONTAL, ORIENTATION_VERTICAL, ScrollbarComponent } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { getEntity, parseEnum } from '../utils';
+import { getEntity, parseEnum, parseNumber } from '../utils';
 
 const orientations = new Map<'horizontal' | 'vertical', number>([
     ['horizontal', ORIENTATION_HORIZONTAL],
@@ -150,10 +150,10 @@ class ScrollbarComponentElement extends ComponentElement {
                 this.orientation = parseEnum(newValue, orientations, 'horizontal', name);
                 break;
             case 'value':
-                this.value = Number(newValue);
+                this.value = parseNumber(newValue, 0, name);
                 break;
             case 'handle-size':
-                this.handleSize = Number(newValue);
+                this.handleSize = parseNumber(newValue, 0.5, name);
                 break;
             case 'handle':
                 this.handle = newValue;

--- a/src/components/scrollview-component.ts
+++ b/src/components/scrollview-component.ts
@@ -1,7 +1,7 @@
 import { SCROLL_MODE_BOUNCE, SCROLL_MODE_CLAMP, SCROLL_MODE_INFINITE, SCROLLBAR_VISIBILITY_SHOW_ALWAYS, SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED, ScrollViewComponent, Vec2 } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { getEntity, parseBool, parseEnum, parseVec2 } from '../utils';
+import { getEntity, parseBool, parseEnum, parseNumber, parseVec2 } from '../utils';
 
 const scrollModes = new Map<'clamp' | 'bounce' | 'infinite', number>([
     ['clamp', SCROLL_MODE_CLAMP],
@@ -391,10 +391,10 @@ class ScrollViewComponentElement extends ComponentElement {
                 this.scrollMode = parseEnum(newValue, scrollModes, 'bounce', name);
                 break;
             case 'bounce-amount':
-                this.bounceAmount = Number(newValue);
+                this.bounceAmount = parseNumber(newValue, 0.1, name);
                 break;
             case 'friction':
-                this.friction = Number(newValue);
+                this.friction = parseNumber(newValue, 0.05, name);
                 break;
             case 'use-mouse-wheel':
                 this.useMouseWheel = parseBool(newValue, true);

--- a/src/components/sound-component.ts
+++ b/src/components/sound-component.ts
@@ -1,7 +1,7 @@
 import { SoundComponent } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseBool, parseEnum } from '../utils';
+import { parseBool, parseEnum, parseNumber } from '../utils';
 
 /**
  * The SoundComponentElement interface provides properties and methods for manipulating
@@ -205,22 +205,22 @@ class SoundComponentElement extends ComponentElement {
                 this.distanceModel = parseEnum(newValue, ['exponential', 'inverse', 'linear'], 'linear', name);
                 break;
             case 'max-distance':
-                this.maxDistance = parseFloat(newValue);
+                this.maxDistance = parseNumber(newValue, 10000, name);
                 break;
             case 'pitch':
-                this.pitch = parseFloat(newValue);
+                this.pitch = parseNumber(newValue, 1, name);
                 break;
             case 'positional':
                 this.positional = parseBool(newValue, false);
                 break;
             case 'ref-distance':
-                this.refDistance = parseFloat(newValue);
+                this.refDistance = parseNumber(newValue, 1, name);
                 break;
             case 'roll-off-factor':
-                this.rollOffFactor = parseFloat(newValue);
+                this.rollOffFactor = parseNumber(newValue, 1, name);
                 break;
             case 'volume':
-                this.volume = parseFloat(newValue);
+                this.volume = parseNumber(newValue, 1, name);
                 break;
         }
     }

--- a/src/components/sound-slot.ts
+++ b/src/components/sound-slot.ts
@@ -3,7 +3,7 @@ import { SoundSlot } from 'playcanvas';
 import { AssetElement } from '../asset';
 import { AsyncElement } from '../async-element';
 import { SoundComponentElement } from './sound-component';
-import { parseBool } from '../utils';
+import { parseBool, parseNumber } from '../utils';
 
 /**
  * The SoundSlotElement interface provides properties and methods for manipulating
@@ -117,12 +117,12 @@ class SoundSlotElement extends AsyncElement {
     }
 
     /**
-     * Sets the duration of the sound slot.
+     * Sets the duration of the sound slot, in seconds (or `null` to play the whole clip).
      * @param value - The duration.
      */
-    set duration(value: number) {
+    set duration(value: number | null) {
         this._duration = value;
-        if (this.soundSlot) {
+        if (this.soundSlot && value !== null) {
             this.soundSlot.duration = value;
         }
     }
@@ -131,8 +131,8 @@ class SoundSlotElement extends AsyncElement {
      * Gets the duration of the sound slot.
      * @returns The duration.
      */
-    get duration() {
-        return this._duration as number;
+    get duration(): number | null {
+        return this._duration;
     }
 
     /**
@@ -262,7 +262,7 @@ class SoundSlotElement extends AsyncElement {
                 this.autoPlay = parseBool(newValue, false);
                 break;
             case 'duration':
-                this.duration = parseFloat(newValue);
+                this.duration = parseNumber(newValue, null, name);
                 break;
             case 'loop':
                 this.loop = parseBool(newValue, false);
@@ -274,13 +274,13 @@ class SoundSlotElement extends AsyncElement {
                 this.overlap = parseBool(newValue, false);
                 break;
             case 'pitch':
-                this.pitch = parseFloat(newValue);
+                this.pitch = parseNumber(newValue, 1, name);
                 break;
             case 'start-time':
-                this.startTime = parseFloat(newValue);
+                this.startTime = parseNumber(newValue, 0, name);
                 break;
             case 'volume':
-                this.volume = parseFloat(newValue);
+                this.volume = parseNumber(newValue, 1, name);
                 break;
         }
     }

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -2,7 +2,7 @@ import { Color, Scene, Vec3 } from 'playcanvas';
 
 import { AppElement } from './app';
 import { AsyncElement } from './async-element';
-import { parseColor, parseEnum, parseVec3 } from './utils';
+import { parseColor, parseEnum, parseNumber, parseVec3 } from './utils';
 
 /**
  * The SceneElement interface provides properties and methods for manipulating
@@ -203,13 +203,13 @@ class SceneElement extends AsyncElement {
                 this.fogColor = parseColor(newValue);
                 break;
             case 'fog-density':
-                this.fogDensity = parseFloat(newValue);
+                this.fogDensity = parseNumber(newValue, 0, name);
                 break;
             case 'fog-start':
-                this.fogStart = parseFloat(newValue);
+                this.fogStart = parseNumber(newValue, 0, name);
                 break;
             case 'fog-end':
-                this.fogEnd = parseFloat(newValue);
+                this.fogEnd = parseNumber(newValue, 1000, name);
                 break;
             case 'gravity':
                 this.gravity = parseVec3(newValue);

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -3,7 +3,7 @@ import { Asset, EnvLighting, LAYERID_SKYBOX, Quat, Scene, Texture, Vec3 } from '
 import { AppElement } from './app';
 import { AssetElement } from './asset';
 import { AsyncElement } from './async-element';
-import { parseBool, parseEnum, parseVec3 } from './utils';
+import { parseBool, parseEnum, parseNumber, parseVec3 } from './utils';
 
 /**
  * The SkyElement interface provides properties and methods for manipulating
@@ -279,10 +279,10 @@ class SkyElement extends AsyncElement {
                 this.center = parseVec3(newValue);
                 break;
             case 'intensity':
-                this.intensity = parseFloat(newValue);
+                this.intensity = parseNumber(newValue, 1, name);
                 break;
             case 'level':
-                this.level = parseInt(newValue, 10);
+                this.level = parseNumber(newValue, 0, name);
                 break;
             case 'lighting':
                 this.lighting = parseBool(newValue, false);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -115,6 +115,28 @@ export const parseEnum = <T extends string>(
 };
 
 /**
+ * Parses a number attribute value. Returns the parsed number when the value is a finite number.
+ * Returns `defaultValue` when the attribute is absent (`null`), or when the value is not a
+ * finite number — the latter also logs a warning.
+ *
+ * @param value - The attribute value to parse (`null` when the attribute is absent).
+ * @param defaultValue - The value to use when the attribute is absent or invalid.
+ * @param attribute - The attribute name, used in the warning message.
+ * @returns The parsed number.
+ */
+export const parseNumber = <T extends number | null>(value: string | null, defaultValue: T, attribute: string): number | T => {
+    if (value === null) {
+        return defaultValue;
+    }
+    const number = value.trim() === '' ? NaN : Number(value);
+    if (!Number.isFinite(number)) {
+        console.warn(`Invalid value '${value}' for attribute '${attribute}'. Expected a finite number. Using '${defaultValue}'.`);
+        return defaultValue;
+    }
+    return number;
+};
+
+/**
  * Resolves a reference string to the {@link Entity} backing a `<pc-entity>` element. The reference
  * can be a CSS selector (e.g. `#my-id`, `pc-entity[name="Foo"]`), a bare element id, or a bare
  * entity name. Returns `null` if no matching element (or backing entity) is found.


### PR DESCRIPTION
## What

The "number parsing" stage of the attribute-conventions series (follows #272, #273, #274). All 73 numeric attribute sites now go through one `parseNumber(value, defaultValue, attribute)` helper with the same contract as `parseBool`/`parseEnum`:

| Markup | Result |
|---|---|
| finite number (`fov="60"`, `"1e3"`, negative, fractional) | that number |
| attribute absent (or removed at runtime) | engine default, silently |
| anything else (`fov="60deg"`, `fov=""`, `"Infinity"`) | console warning naming the attribute, then the default |

## Why

Three parsing styles were in use — 42× `Number()`, 27× `parseFloat()`, 3× `parseInt()` — with per-attribute quirks:

- `parseFloat` silently accepted trailing garbage: `fov="60deg"` → 60 on `pc-camera`, but the same value on a `Number()` attribute produced `NaN` fed straight to the engine.
- `Number("")` is `0`, so an empty attribute silently zeroed values (e.g. `intensity=""` turned a light off instead of leaving the default of 1).
- The same conceptual attribute parsed differently across elements (`pc-camera priority` used `parseFloat`, `pc-screen priority` used `parseInt`).

## Also fixes (nullable numbers)

`parseNumber` accepts a `null` default, which fixes latent removal bugs where `Number(null)` → `0`:

- Removing `max-width`/`max-height` on `pc-layoutchild` now restores `null` (no limit) instead of clamping to 0 — previously flagged in the audit as finding 10.
- Removing `pixels-per-unit` on `pc-element` and `duration` on `pc-sound` now restores unset instead of 0. `SoundSlotElement.duration` is now typed `number | null` to match its real semantics.

## Behavior notes for reviewers

- Integer-flavored attributes (`axis`, `priority`, sky `level`) no longer truncate via `parseInt` — a fractional value passes through to the engine as-is (writing `axis="1.5"` was always author error; it now behaves the same as every other numeric attribute).
- No shipped example uses any of the changed edge cases; all examples were lint-checked and spot-verified.

## Verification

- `npm run build`, `type-check`, `lint` all clean; grep shows zero remaining `Number(newValue)`/`parseFloat(newValue)`/`parseInt(newValue` and exactly 73 `parseNumber` call sites.
- Live-browser test page: 13/13 assertions (strictness vs `parseFloat`, empty-string trap, warning count/content, runtime set + removal restoring defaults, nullable `max-width`/`pixels-per-unit` removal → `null`).
- `physics.html` (rigidbody/collision numerics with the ammo module) runs clean with zero console output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)