### PR TITLE
Fix inline onpointer* handlers by leaning on the platform

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -321,6 +321,14 @@ class AppElement extends AsyncElement {
         ['pointermove', 'pointerdown', 'pointerup', 'pointerenter', 'pointerleave'].forEach((type) => {
             this.addEventListener(`${type}:connect`, () => this._onPointerListenerAdded(type));
             this.addEventListener(`${type}:disconnect`, () => this._onPointerListenerRemoved(type));
+
+            // Attach canvas handlers for listeners registered before this point (e.g. handlers
+            // created from onpointer* attributes when their elements were first upgraded)
+            const anyListeners = Array.from(this.querySelectorAll<EntityElement>('pc-entity'))
+            .some(entity => entity.hasListeners(type));
+            if (anyListeners) {
+                this._onPointerListenerAdded(type);
+            }
         });
     }
 
@@ -338,6 +346,13 @@ class AppElement extends AsyncElement {
             pointermove: null,
             pointerdown: null,
             pointerup: null
+        };
+        this._hasPointerListeners = {
+            pointerenter: false,
+            pointerleave: false,
+            pointerdown: false,
+            pointerup: false,
+            pointermove: false
         };
     }
 

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -46,6 +46,11 @@ class EntityElement extends AsyncElement {
     private _listeners: { [key: string]: EventListener[] } = {};
 
     /**
+     * The event types for which an inline `onpointer*` attribute is currently present.
+     */
+    private _inlineHandlerTypes = new Set<string>();
+
+    /**
      * Whether the hierarchy has been built for this entity.
      */
     private _built = false;
@@ -94,31 +99,6 @@ class EntityElement extends AsyncElement {
         if (tags) {
             entity.tags.add(tags.split(',').map(tag => tag.trim()));
         }
-
-        // Handle pointer events
-        const pointerEvents = [
-            'onpointerenter',
-            'onpointerleave',
-            'onpointerdown',
-            'onpointerup',
-            'onpointermove'
-        ];
-
-        pointerEvents.forEach((eventName) => {
-            const handler = this.getAttribute(eventName);
-            if (handler) {
-                const eventType = eventName.substring(2); // remove 'on' prefix
-                const eventHandler = (event: Event) => {
-                    try {
-                        /* eslint-disable-next-line no-new-func */
-                        new Function('event', handler).call(this, event);
-                    } catch (e) {
-                        console.error('Error in event handler:', e);
-                    }
-                };
-                this.addEventListener(eventType, eventHandler);
-            }
-        });
     }
 
     buildHierarchy(app: AppBase) {
@@ -288,6 +268,31 @@ class EntityElement extends AsyncElement {
         return this._tags;
     }
 
+    /**
+     * Tracks whether an inline `onpointer*` attribute is present. The browser itself compiles and
+     * runs these attributes — they are standard `GlobalEventHandlers`, so setting one replaces
+     * the previous handler and removing it removes the handler, exactly like `onclick` on any
+     * HTML element. But because they bypass {@link addEventListener}, the connect/disconnect
+     * bookkeeping that lets the application lazily attach its canvas pointer handlers must be
+     * kept in sync here.
+     *
+     * @param name - The attribute name (e.g. 'onpointerdown').
+     * @param value - The attribute value, or `null` when the attribute has been removed.
+     */
+    private _updateInlineHandler(name: string, value: string | null) {
+        const type = name.substring(2);
+        const had = this._inlineHandlerTypes.has(type);
+        const has = value !== null;
+
+        if (has && !had) {
+            this._inlineHandlerTypes.add(type);
+            this.dispatchEvent(new CustomEvent(`${type}:connect`, { bubbles: true }));
+        } else if (!has && had) {
+            this._inlineHandlerTypes.delete(type);
+            this.dispatchEvent(new CustomEvent(`${type}:disconnect`, { bubbles: true }));
+        }
+    }
+
     static get observedAttributes() {
         return [
             'enabled',
@@ -329,20 +334,7 @@ class EntityElement extends AsyncElement {
             case 'onpointerdown':
             case 'onpointerup':
             case 'onpointermove':
-                if (newValue) {
-                    const eventName = name.substring(2);
-                    // Use Function.prototype.bind to avoid new Function
-                    const handler = (event: Event) => {
-                        try {
-                            const handlerStr = this.getAttribute(eventName) || '';
-                            /* eslint-disable-next-line no-new-func */
-                            new Function('event', handlerStr).call(this, event);
-                        } catch (e) {
-                            console.error('Error in event handler:', e);
-                        }
-                    };
-                    this.addEventListener(eventName, handler);
-                }
+                this._updateInlineHandler(name, newValue);
                 break;
         }
     }
@@ -369,7 +361,7 @@ class EntityElement extends AsyncElement {
     }
 
     hasListeners(type: string): boolean {
-        return Boolean(this._listeners[type]?.length);
+        return Boolean(this._listeners[type]?.length) || this._inlineHandlerTypes.has(type);
     }
 }
 


### PR DESCRIPTION
## What

The onpointer* stage of the attribute-conventions series (follows #272, #273, #274, #275).

While reworking `pc-entity`'s manual `onpointer*` handling, verification surfaced the real story: **`onpointerdown`/`up`/`move`/`enter`/`leave` are standard `GlobalEventHandlers`** — the browser already compiles these attributes into native inline handlers on every HTML element, custom elements included, with exactly the semantics we want (set replaces, removal removes, `this` = the element, `event` in scope, live updates).

So instead of reimplementing that, this PR deletes the manual compilation entirely. `pc-entity` now keeps only the piece the platform can't do: native handler slots bypass the overridden `addEventListener`, so attribute changes drive the `hasListeners()` bookkeeping and the `pointer*:connect`/`:disconnect` events that `pc-app` uses to lazily attach its canvas pointer handlers.

## Bugs this fixes

- **Every inline handler fired twice per event in shipped releases** — the browser's native handler plus the manually registered copy from `createEntity`. Nobody noticed because typical handlers (play a tween) are idempotent.
- The `attributeChangedCallback` registration path read a stripped attribute name (`getAttribute('pointerenter')` instead of `onpointerenter`), so its handlers were silent no-ops — and it stacked a new listener on every attribute change without ever removing one.
- Setting an `onpointer*` attribute **at runtime** (after entity creation) never worked; now it does (natively).
- `pc-app` never heard about listeners registered before its picker existed (e.g. at element upgrade time, or user `addEventListener` calls before app boot) — `_pickerCreate` now scans for pre-existing listeners, and `_pickerDestroy` resets the tracking flags so canvas handlers re-attach after an app disconnect/reconnect.

Net: −40 lines of hand-rolled handler code, `new Function` gone entirely (the CSP profile is unchanged — native inline handlers have the same requirements the manual `new Function` path had).

## Verification

- `npm run build`, `type-check`, `lint` all clean.
- Live-browser semantics page, 11/11: exactly-once firing, live replacement on set, removal, runtime-added attributes with correct `this`-binding, invalid-handler safety, mixed inline + `addEventListener` bookkeeping, and the app's canvas-attach flag set via the new picker-time scan.
- `tween.html` end-to-end through the real canvas → picker → dispatch path with counters attached: hover fired `pointerenter` once (scale tweened 1.0 → 1.2), click fired `pointerdown` once (Y-spin tween, caught mid-rotation on screenshot), hover-off fired `pointerleave` once (scale settled back to 1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)