### PR TITLE
Unify vector/color parsing and harden script attribute conversion

### DIFF
--- a/examples/animation.html
+++ b/examples/animation.html
@@ -37,10 +37,10 @@
                         <pc-camera></pc-camera>
                         <pc-scripts>
                             <pc-script name="cameraControls" attributes='{
-                                "focusPoint": "vec3:0,1.75,2",
-                                "pitchRange": "vec2:-90,0",
+                                "focusPoint": "vec3:0 1.75 2",
+                                "pitchRange": "vec2:-90 0",
                                 "sceneSize": 15,
-                                "zoomRange": "vec2:2,15"
+                                "zoomRange": "vec2:2 15"
                             }'></pc-script>
                         </pc-scripts>
                     </pc-entity>
@@ -66,7 +66,7 @@
                 <pc-entity name="shadow catcher">
                     <pc-scripts>
                         <pc-script name="shadowCatcher" attributes='{
-                            "scale": "vec3:14,14,14"
+                            "scale": "vec3:14 14 14"
                         }'></pc-script>
                     </pc-scripts>
                 </pc-entity>

--- a/examples/annotations.html
+++ b/examples/annotations.html
@@ -41,10 +41,10 @@
                         <pc-camera tonemap="aces2"></pc-camera>
                         <pc-scripts>
                             <pc-script name="cameraControls" attributes='{
-                                "focusPoint": "vec3:0,1.75,0",
-                                "pitchRange": "vec2:-90,0",
+                                "focusPoint": "vec3:0 1.75 0",
+                                "pitchRange": "vec2:-90 0",
                                 "sceneSize": 2,
-                                "zoomRange": "vec2:5,25"
+                                "zoomRange": "vec2:5 25"
                             }'></pc-script>
                         </pc-scripts>
                     </pc-entity>
@@ -136,7 +136,7 @@
                 <pc-entity name="shadow catcher">
                     <pc-scripts>
                         <pc-script name="shadowCatcher" attributes='{
-                            "scale": "vec3:15,15,15"
+                            "scale": "vec3:15 15 15"
                         }'></pc-script>
                     </pc-scripts>
                 </pc-entity>

--- a/examples/basic-shapes.html
+++ b/examples/basic-shapes.html
@@ -41,10 +41,10 @@
                             <pc-script name="cameraControls" attributes='{
                                 "enableFly": false,
                                 "enablePan": false,
-                                "focusPoint": "vec3:0,0.5,0",
-                                "pitchRange": "vec2:-90,0",
+                                "focusPoint": "vec3:0 0.5 0",
+                                "pitchRange": "vec2:-90 0",
                                 "sceneSize": 5,
-                                "zoomRange": "vec2:0.1,10"
+                                "zoomRange": "vec2:0.1 10"
                             }'></pc-script>
                         </pc-scripts>
                     </pc-entity>

--- a/examples/car-configurator.html
+++ b/examples/car-configurator.html
@@ -42,10 +42,10 @@
                             <pc-script name="cameraControls" attributes='{
                                 "enableFly": false,
                                 "enablePan": false,
-                                "focusPoint": "vec3:0,0.5,0",
-                                "pitchRange": "vec2:-90,0",
+                                "focusPoint": "vec3:0 0.5 0",
+                                "pitchRange": "vec2:-90 0",
                                 "sceneSize": 10,
-                                "zoomRange": "vec2:2.5,15"
+                                "zoomRange": "vec2:2.5 15"
                             }'></pc-script>
                         </pc-scripts>
                     </pc-entity>

--- a/examples/glb.html
+++ b/examples/glb.html
@@ -40,7 +40,7 @@
                                 "enableFly": false,
                                 "enablePan": false,
                                 "sceneSize": 1,
-                                "zoomRange": "vec2:1,10"
+                                "zoomRange": "vec2:1 10"
                             }'></pc-script>
                         </pc-scripts>
                     </pc-entity>

--- a/examples/physics.html
+++ b/examples/physics.html
@@ -40,7 +40,7 @@
                         <pc-scripts>
                             <pc-script name="cameraControls" attributes='{
                                 "sceneSize": 10,
-                                "zoomRange": "vec2:0.1,100"
+                                "zoomRange": "vec2:0.1 100"
                             }'></pc-script>
                         </pc-scripts>
                     </pc-entity>

--- a/examples/shoe-configurator.html
+++ b/examples/shoe-configurator.html
@@ -39,9 +39,9 @@
                             <pc-script name="cameraControls" attributes='{
                                 "enableFly": false,
                                 "enablePan": false,
-                                "focusPoint": "vec3:0,0.05,0",
+                                "focusPoint": "vec3:0 0.05 0",
                                 "sceneSize": 0.5,
-                                "zoomRange": "vec2:0.25,1"
+                                "zoomRange": "vec2:0.25 1"
                             }'></pc-script>
                         </pc-scripts>
                     </pc-entity>
@@ -67,7 +67,7 @@
                 <pc-entity name="shadow catcher">
                     <pc-scripts>
                         <pc-script name="shadowCatcher" attributes='{
-                            "scale": "vec3:0.5,0.5,0.5"
+                            "scale": "vec3:0.5 0.5 0.5"
                         }'></pc-script>
                     </pc-scripts>
                 </pc-entity>

--- a/examples/splat-annotations.html
+++ b/examples/splat-annotations.html
@@ -37,13 +37,13 @@
                             <pc-script name="cameraControls" attributes='{
                                 "enableFly": false,
                                 "enablePan": false,
-                                "focusPoint": "vec3:0,0.575,0",
-                                "zoomRange": "vec2:1,5"
+                                "focusPoint": "vec3:0 0.575 0",
+                                "zoomRange": "vec2:1 5"
                             }'></pc-script>
                             <pc-script name="cameraFrame" attributes='{
                                 "vignette": {
                                     "enabled": true,
-                                    "color": "color:0,0,0,1",
+                                    "color": "color:0 0 0 1",
                                     "curvature": 0.5,
                                     "intensity": 0.5,
                                     "inner": 0.5,

--- a/examples/splat-flipbook.html
+++ b/examples/splat-flipbook.html
@@ -39,8 +39,8 @@
                             <pc-script name="cameraControls" attributes='{
                                 "enableFly": false,
                                 "enablePan": true,
-                                "focusPoint": "vec3:0,1.25,0",
-                                "zoomRange": "vec2:0.2,2.5"
+                                "focusPoint": "vec3:0 1.25 0",
+                                "zoomRange": "vec2:0.2 2.5"
                             }'></pc-script>
                         </pc-scripts>
                     </pc-entity>
@@ -74,7 +74,7 @@
                     <pc-render type="plane" cast-shadows="false"></pc-render>
                     <pc-scripts>
                         <pc-script name="shadowCatcher" attributes='{
-                            "scale": "vec3:10,10,10"
+                            "scale": "vec3:10 10 10"
                         }'></pc-script>
                     </pc-scripts>
                 </pc-entity>

--- a/examples/splat-simple.html
+++ b/examples/splat-simple.html
@@ -38,10 +38,10 @@
                             <pc-script name="cameraControls" attributes='{
                                 "enableFly": false,
                                 "enablePan": false,
-                                "focusPoint": "vec3:0,2,0",
-                                "pitchRange": "vec2:-90,0",
+                                "focusPoint": "vec3:0 2 0",
+                                "pitchRange": "vec2:-90 0",
                                 "sceneSize": 3,
-                                "zoomRange": "vec2:0.5,3"
+                                "zoomRange": "vec2:0.5 3"
                             }'></pc-script>
                         </pc-scripts>
                     </pc-entity>

--- a/examples/text3d.html
+++ b/examples/text3d.html
@@ -37,9 +37,9 @@
                         <pc-camera clear-color="black"></pc-camera>
                         <pc-scripts>
                             <pc-script name="cameraControls" attributes='{
-                                "focusPoint": "vec3:0,0.5,0",
+                                "focusPoint": "vec3:0 0.5 0",
                                 "sceneSize": 10,
-                                "zoomRange": "vec2:0.1,10"
+                                "zoomRange": "vec2:0.1 10"
                             }'></pc-script>
                         </pc-scripts>
                     </pc-entity>

--- a/examples/tween.html
+++ b/examples/tween.html
@@ -41,24 +41,24 @@
                             "tweens": [
                                 {
                                     "path": "localScale",
-                                    "start": "vec4:1,1,1,0",
-                                    "end": "vec4:1.2,1.2,1.2,0",
+                                    "start": "vec4:1 1 1 0",
+                                    "end": "vec4:1.2 1.2 1.2 0",
                                     "duration": 500,
                                     "easingFunction": "Elastic",
                                     "easingType": "Out"
                                 },
                                 {
                                     "path": "localScale",
-                                    "start": "vec4:1.2,1.2,1.2,0",
-                                    "end": "vec4:1,1,1,0",
+                                    "start": "vec4:1.2 1.2 1.2 0",
+                                    "end": "vec4:1 1 1 0",
                                     "duration": 500,
                                     "easingFunction": "Elastic",
                                     "easingType": "Out"
                                 },
                                 {
                                     "path": "localEulerAngles",
-                                    "start": "vec4:0,0,0,0",
-                                    "end": "vec4:0,360,0,0",
+                                    "start": "vec4:0 0 0 0",
+                                    "end": "vec4:0 360 0 0",
                                     "duration": 2000,
                                     "easingFunction": "Elastic",
                                     "easingType": "Out"

--- a/examples/video-recorder.html
+++ b/examples/video-recorder.html
@@ -38,8 +38,8 @@
                                 "tweens": [
                                     {
                                         "path": "localEulerAngles",
-                                        "start": "vec4:-10,0,0,0",
-                                        "end": "vec4:10,0,0,0",
+                                        "start": "vec4:-10 0 0 0",
+                                        "end": "vec4:10 0 0 0",
                                         "duration": 7500,
                                         "easingFunction": "Sinusoidal",
                                         "easingType": "InOut",
@@ -56,8 +56,8 @@
                             "tweens": [
                                 {
                                     "path": "localEulerAngles",
-                                    "start": "vec4:0,0,0,0",
-                                    "end": "vec4:0,-180,0,0",
+                                    "start": "vec4:0 0 0 0",
+                                    "end": "vec4:0 -180 0 0",
                                     "duration": 5000,
                                     "easingFunction": "Cubic",
                                     "easingType": "InOut",

--- a/examples/video-texture.html
+++ b/examples/video-texture.html
@@ -43,10 +43,10 @@
                             <pc-script name="cameraControls" attributes='{
                                 "enableFly": false,
                                 "enablePan": false,
-                                "focusPoint": "vec3:0,0.225,0",
-                                "pitchRange": "vec2:-90,0",
+                                "focusPoint": "vec3:0 0.225 0",
+                                "pitchRange": "vec2:-90 0",
                                 "sceneSize": 1,
-                                "zoomRange": "vec2:0.5,3"
+                                "zoomRange": "vec2:0.5 3"
                             }'></pc-script>
                         </pc-scripts>
                     </pc-entity>
@@ -78,7 +78,7 @@
                 <pc-entity name="shadow catcher">
                     <pc-scripts>
                         <pc-script name="shadowCatcher" attributes='{
-                            "scale": "vec3:2,3,3"
+                            "scale": "vec3:2 3 3"
                         }'></pc-script>
                     </pc-scripts>
                 </pc-entity>

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -407,19 +407,19 @@ class ButtonComponentElement extends ComponentElement {
                 this.image = newValue;
                 break;
             case 'hit-padding':
-                this.hitPadding = parseVec4(newValue);
+                this.hitPadding = parseVec4(newValue, new Vec4(0, 0, 0, 0), name);
                 break;
             case 'transition-mode':
                 this.transitionMode = parseEnum(newValue, transitionModes, 'tint', name);
                 break;
             case 'hover-tint':
-                this.hoverTint = parseColor(newValue);
+                this.hoverTint = parseColor(newValue, new Color(1, 1, 1, 1), name);
                 break;
             case 'pressed-tint':
-                this.pressedTint = parseColor(newValue);
+                this.pressedTint = parseColor(newValue, new Color(1, 1, 1, 1), name);
                 break;
             case 'inactive-tint':
-                this.inactiveTint = parseColor(newValue);
+                this.inactiveTint = parseColor(newValue, new Color(1, 1, 1, 1), name);
                 break;
             case 'fade-duration':
                 this.fadeDuration = parseNumber(newValue, 0, name);

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -407,19 +407,19 @@ class ButtonComponentElement extends ComponentElement {
                 this.image = newValue;
                 break;
             case 'hit-padding':
-                this.hitPadding = parseVec4(newValue, new Vec4(0, 0, 0, 0), name);
+                this.hitPadding = parseVec4(newValue, Vec4.ZERO, name);
                 break;
             case 'transition-mode':
                 this.transitionMode = parseEnum(newValue, transitionModes, 'tint', name);
                 break;
             case 'hover-tint':
-                this.hoverTint = parseColor(newValue, new Color(1, 1, 1, 1), name);
+                this.hoverTint = parseColor(newValue, Color.WHITE, name);
                 break;
             case 'pressed-tint':
-                this.pressedTint = parseColor(newValue, new Color(1, 1, 1, 1), name);
+                this.pressedTint = parseColor(newValue, Color.WHITE, name);
                 break;
             case 'inactive-tint':
-                this.inactiveTint = parseColor(newValue, new Color(1, 1, 1, 1), name);
+                this.inactiveTint = parseColor(newValue, Color.WHITE, name);
                 break;
             case 'fade-duration':
                 this.fadeDuration = parseNumber(newValue, 0, name);

--- a/src/components/camera-component.ts
+++ b/src/components/camera-component.ts
@@ -495,7 +495,7 @@ class CameraComponentElement extends ComponentElement {
 
         switch (name) {
             case 'clear-color':
-                this.clearColor = parseColor(newValue);
+                this.clearColor = parseColor(newValue, new Color(0.75, 0.75, 0.75, 1), name);
                 break;
             case 'clear-color-buffer':
                 this.clearColorBuffer = parseBool(newValue, true);
@@ -540,10 +540,10 @@ class CameraComponentElement extends ComponentElement {
                 this.priority = parseNumber(newValue, 0, name);
                 break;
             case 'rect':
-                this.rect = parseVec4(newValue);
+                this.rect = parseVec4(newValue, new Vec4(0, 0, 1, 1), name);
                 break;
             case 'scissor-rect':
-                this.scissorRect = parseVec4(newValue);
+                this.scissorRect = parseVec4(newValue, new Vec4(0, 0, 1, 1), name);
                 break;
             case 'tonemap':
                 this.tonemap = parseEnum(newValue, tonemaps, 'none', name);

--- a/src/components/collision-component.ts
+++ b/src/components/collision-component.ts
@@ -151,7 +151,7 @@ class CollisionComponentElement extends ComponentElement {
 
         switch (name) {
             case 'angular-offset':
-                this.angularOffset = parseQuat(newValue, new Quat(), name);
+                this.angularOffset = parseQuat(newValue, Quat.IDENTITY, name);
                 break;
             case 'axis':
                 this.axis = parseNumber(newValue, 1, name);
@@ -166,7 +166,7 @@ class CollisionComponentElement extends ComponentElement {
                 this.height = parseNumber(newValue, 2, name);
                 break;
             case 'linear-offset':
-                this.linearOffset = parseVec3(newValue, new Vec3(), name);
+                this.linearOffset = parseVec3(newValue, Vec3.ZERO, name);
                 break;
             case 'radius':
                 this.radius = parseNumber(newValue, 0.5, name);

--- a/src/components/collision-component.ts
+++ b/src/components/collision-component.ts
@@ -151,7 +151,7 @@ class CollisionComponentElement extends ComponentElement {
 
         switch (name) {
             case 'angular-offset':
-                this.angularOffset = parseQuat(newValue);
+                this.angularOffset = parseQuat(newValue, new Quat(), name);
                 break;
             case 'axis':
                 this.axis = parseNumber(newValue, 1, name);
@@ -160,13 +160,13 @@ class CollisionComponentElement extends ComponentElement {
                 this.convexHull = parseBool(newValue, false);
                 break;
             case 'half-extents':
-                this.halfExtents = parseVec3(newValue);
+                this.halfExtents = parseVec3(newValue, new Vec3(0.5, 0.5, 0.5), name);
                 break;
             case 'height':
                 this.height = parseNumber(newValue, 2, name);
                 break;
             case 'linear-offset':
-                this.linearOffset = parseVec3(newValue);
+                this.linearOffset = parseVec3(newValue, new Vec3(), name);
                 break;
             case 'radius':
                 this.radius = parseNumber(newValue, 0.5, name);

--- a/src/components/element-component.ts
+++ b/src/components/element-component.ts
@@ -706,7 +706,7 @@ class ElementComponentElement extends ComponentElement {
                 this.autoFitHeight = parseBool(newValue, false);
                 break;
             case 'color':
-                this.color = parseColor(newValue, new Color(1, 1, 1, 1), name);
+                this.color = parseColor(newValue, Color.WHITE, name);
                 break;
             case 'enable-markup':
                 this.enableMarkup = parseBool(newValue, false);

--- a/src/components/element-component.ts
+++ b/src/components/element-component.ts
@@ -691,7 +691,7 @@ class ElementComponentElement extends ComponentElement {
 
         switch (name) {
             case 'anchor':
-                this.anchor = parseVec4(newValue);
+                this.anchor = parseVec4(newValue, new Vec4(0.5, 0.5, 0.5, 0.5), name);
                 break;
             case 'auto-width':
                 this.autoWidth = parseBool(newValue, true);
@@ -706,7 +706,7 @@ class ElementComponentElement extends ComponentElement {
                 this.autoFitHeight = parseBool(newValue, false);
                 break;
             case 'color':
-                this.color = parseColor(newValue);
+                this.color = parseColor(newValue, new Color(1, 1, 1, 1), name);
                 break;
             case 'enable-markup':
                 this.enableMarkup = parseBool(newValue, false);
@@ -730,7 +730,7 @@ class ElementComponentElement extends ComponentElement {
                 this.lineHeight = parseNumber(newValue, 32, name);
                 break;
             case 'margin':
-                this.margin = parseVec4(newValue);
+                this.margin = parseVec4(newValue, null, name);
                 break;
             case 'mask':
                 this.mask = parseBool(newValue, false);
@@ -739,7 +739,7 @@ class ElementComponentElement extends ComponentElement {
                 this.opacity = parseNumber(newValue, 1, name);
                 break;
             case 'pivot':
-                this.pivot = parseVec2(newValue);
+                this.pivot = parseVec2(newValue, new Vec2(0.5, 0.5), name);
                 break;
             case 'pixels-per-unit':
                 this.pixelsPerUnit = parseNumber(newValue, null, name);

--- a/src/components/layoutgroup-component.ts
+++ b/src/components/layoutgroup-component.ts
@@ -275,10 +275,10 @@ class LayoutGroupComponentElement extends ComponentElement {
                 this.alignment = parseVec2(newValue, new Vec2(0, 1), name);
                 break;
             case 'padding':
-                this.padding = parseVec4(newValue, new Vec4(0, 0, 0, 0), name);
+                this.padding = parseVec4(newValue, Vec4.ZERO, name);
                 break;
             case 'spacing':
-                this.spacing = parseVec2(newValue, new Vec2(0, 0), name);
+                this.spacing = parseVec2(newValue, Vec2.ZERO, name);
                 break;
             case 'width-fitting':
                 this.widthFitting = parseEnum(newValue, fittings, 'none', name);

--- a/src/components/layoutgroup-component.ts
+++ b/src/components/layoutgroup-component.ts
@@ -272,13 +272,13 @@ class LayoutGroupComponentElement extends ComponentElement {
                 this.reverseY = parseBool(newValue, false);
                 break;
             case 'alignment':
-                this.alignment = parseVec2(newValue);
+                this.alignment = parseVec2(newValue, new Vec2(0, 1), name);
                 break;
             case 'padding':
-                this.padding = parseVec4(newValue);
+                this.padding = parseVec4(newValue, new Vec4(0, 0, 0, 0), name);
                 break;
             case 'spacing':
-                this.spacing = parseVec2(newValue);
+                this.spacing = parseVec2(newValue, new Vec2(0, 0), name);
                 break;
             case 'width-fitting':
                 this.widthFitting = parseEnum(newValue, fittings, 'none', name);

--- a/src/components/light-component.ts
+++ b/src/components/light-component.ts
@@ -501,7 +501,7 @@ class LightComponentElement extends ComponentElement {
 
         switch (name) {
             case 'color':
-                this.color = parseColor(newValue);
+                this.color = parseColor(newValue, new Color(1, 1, 1), name);
                 break;
             case 'cast-shadows':
                 this.castShadows = parseBool(newValue, false);

--- a/src/components/light-component.ts
+++ b/src/components/light-component.ts
@@ -501,7 +501,7 @@ class LightComponentElement extends ComponentElement {
 
         switch (name) {
             case 'color':
-                this.color = parseColor(newValue, new Color(1, 1, 1), name);
+                this.color = parseColor(newValue, Color.WHITE, name);
                 break;
             case 'cast-shadows':
                 this.castShadows = parseBool(newValue, false);

--- a/src/components/rigidbody-component.ts
+++ b/src/components/rigidbody-component.ts
@@ -195,7 +195,7 @@ class RigidBodyComponentElement extends ComponentElement {
                 this.angularDamping = parseNumber(newValue, 0, name);
                 break;
             case 'angular-factor':
-                this.angularFactor = parseVec3(newValue, new Vec3(1, 1, 1), name);
+                this.angularFactor = parseVec3(newValue, Vec3.ONE, name);
                 break;
             case 'friction':
                 this.friction = parseNumber(newValue, 0.5, name);
@@ -204,7 +204,7 @@ class RigidBodyComponentElement extends ComponentElement {
                 this.linearDamping = parseNumber(newValue, 0, name);
                 break;
             case 'linear-factor':
-                this.linearFactor = parseVec3(newValue, new Vec3(1, 1, 1), name);
+                this.linearFactor = parseVec3(newValue, Vec3.ONE, name);
                 break;
             case 'mass':
                 this.mass = parseNumber(newValue, 1, name);

--- a/src/components/rigidbody-component.ts
+++ b/src/components/rigidbody-component.ts
@@ -195,7 +195,7 @@ class RigidBodyComponentElement extends ComponentElement {
                 this.angularDamping = parseNumber(newValue, 0, name);
                 break;
             case 'angular-factor':
-                this.angularFactor = parseVec3(newValue);
+                this.angularFactor = parseVec3(newValue, new Vec3(1, 1, 1), name);
                 break;
             case 'friction':
                 this.friction = parseNumber(newValue, 0.5, name);
@@ -204,7 +204,7 @@ class RigidBodyComponentElement extends ComponentElement {
                 this.linearDamping = parseNumber(newValue, 0, name);
                 break;
             case 'linear-factor':
-                this.linearFactor = parseVec3(newValue);
+                this.linearFactor = parseVec3(newValue, new Vec3(1, 1, 1), name);
                 break;
             case 'mass':
                 this.mass = parseNumber(newValue, 1, name);

--- a/src/components/screen-component.ts
+++ b/src/components/screen-component.ts
@@ -134,10 +134,10 @@ class ScreenComponentElement extends ComponentElement {
                 this.priority = parseNumber(newValue, 0, name);
                 break;
             case 'reference-resolution':
-                this.referenceResolution = parseVec2(newValue);
+                this.referenceResolution = parseVec2(newValue, new Vec2(640, 320), name);
                 break;
             case 'resolution':
-                this.resolution = parseVec2(newValue);
+                this.resolution = parseVec2(newValue, new Vec2(640, 320), name);
                 break;
             case 'scale-blend':
                 this.scaleBlend = parseNumber(newValue, 0.5, name);

--- a/src/components/script-component.ts
+++ b/src/components/script-component.ts
@@ -2,8 +2,8 @@ import { Color, ScriptComponent, Script, Vec2, Vec3, Vec4 } from 'playcanvas';
 
 import { AssetElement } from '../asset';
 import { ComponentElement } from './component';
-import { EntityElement } from '../entity';
 import { ScriptElement } from './script';
+import { getEntity, parseComponents } from '../utils';
 
 // Add these interfaces at the top of the file, after the imports
 interface ScriptAttributesChangeEvent extends CustomEvent {
@@ -39,13 +39,16 @@ class ScriptComponentElement extends ComponentElement {
 
         // Create mutation observer to watch for child script elements
         this.observer = new MutationObserver(this.handleMutations.bind(this));
-        this.observer.observe(this, {
-            childList: true
-        });
 
         // Listen for script attribute and enable changes
         this.addEventListener('scriptattributeschange', this.handleScriptAttributesChange.bind(this));
         this.addEventListener('scriptenablechange', this.handleScriptEnableChange.bind(this));
+    }
+
+    connectedCallback() {
+        // (Re-)observe on every connection - disconnectedCallback disconnects the observer
+        this.observer.observe(this, { childList: true });
+        return super.connectedCallback();
     }
 
     initComponent() {
@@ -54,72 +57,83 @@ class ScriptComponentElement extends ComponentElement {
             const scriptName = scriptElement.getAttribute('name');
             const attributes = scriptElement.getAttribute('attributes');
             if (scriptName) {
-                this.createScript(scriptName, attributes);
+                this.createScript(scriptName, attributes, scriptElement.enabled);
             }
         });
     }
 
     /**
      * Recursively converts raw attribute data into proper PlayCanvas types. Supported conversions:
-     * - "asset:assetId" → resolves to an Asset instance
-     * - "entity:entityId" → resolves to an Entity instance
-     * - "vec2:1,2" → new Vec2(1,2)
-     * - "vec3:1,2,3" → new Vec3(1,2,3)
-     * - "vec4:1,2,3,4" → new Vec4(1,2,3,4)
-     * - "color:1,0.5,0.5,1" → new Color(1,0.5,0.5,1)
+     * - "asset:id" → the Asset created by the `pc-asset` element with that id
+     * - "entity:ref" → the Entity backing a `pc-entity` element. The reference can be a CSS
+     *   selector, an element id or an entity name.
+     * - "vec2:1 2" → new Vec2(1, 2)
+     * - "vec3:1 2 3" → new Vec3(1, 2, 3)
+     * - "vec4:1 2 3 4" → new Vec4(1, 2, 3, 4)
+     * - "color:1 0.5 0.5 1" → new Color(1, 0.5, 0.5, 1)
+     *
+     * A prefixed string that fails to resolve or parse logs a warning and is left as the raw
+     * string.
      * @param item - The item to convert.
      * @returns The converted item.
      */
     private convertAttributes(item: any): any {
         if (typeof item === 'string') {
             if (item.startsWith('asset:')) {
-                const assetId = item.slice(6);
-                const assetElement = document.querySelector(`pc-asset#${assetId}`) as AssetElement;
-                if (assetElement) {
-                    return assetElement.asset;
+                const id = item.slice(6);
+                const asset = AssetElement.get(id);
+                if (asset) {
+                    return asset;
                 }
+                console.warn(`Unable to resolve '${item}' in script attributes - no pc-asset found with id '${id}'.`);
+                return item;
             }
             if (item.startsWith('entity:')) {
-                const entityId = item.slice(7);
-                const entityElement = document.querySelector(`pc-entity[name="${entityId}"]`) as EntityElement;
-                if (entityElement) {
-                    return entityElement.entity;
+                const ref = item.slice(7);
+                const entity = getEntity(ref);
+                if (entity) {
+                    return entity;
                 }
+                console.warn(`Unable to resolve '${item}' in script attributes - no pc-entity found matching '${ref}'.`);
+                return item;
             }
             if (item.startsWith('vec2:')) {
-                const parts = item.slice(5).split(',').map(Number);
-                if (parts.length === 2 && parts.every(v => !isNaN(v))) {
-                    return new Vec2(parts[0], parts[1]);
+                const components = parseComponents(item.slice(5), 2);
+                if (components) {
+                    return new Vec2(components);
                 }
+                console.warn(`Invalid script attribute value '${item}'. Expected 2 space-separated numbers after 'vec2:'.`);
+                return item;
             }
             if (item.startsWith('vec3:')) {
-                const parts = item.slice(5).split(',').map(Number);
-                if (parts.length === 3 && parts.every(v => !isNaN(v))) {
-                    return new Vec3(parts[0], parts[1], parts[2]);
+                const components = parseComponents(item.slice(5), 3);
+                if (components) {
+                    return new Vec3(components);
                 }
+                console.warn(`Invalid script attribute value '${item}'. Expected 3 space-separated numbers after 'vec3:'.`);
+                return item;
             }
             if (item.startsWith('vec4:')) {
-                const parts = item.slice(5).split(',').map(Number);
-                if (parts.length === 4 && parts.every(v => !isNaN(v))) {
-                    return new Vec4(parts[0], parts[1], parts[2], parts[3]);
+                const components = parseComponents(item.slice(5), 4);
+                if (components) {
+                    return new Vec4(components);
                 }
+                console.warn(`Invalid script attribute value '${item}'. Expected 4 space-separated numbers after 'vec4:'.`);
+                return item;
             }
             if (item.startsWith('color:')) {
-                const parts = item.slice(6).split(',').map(Number);
-                if (parts.length === 4 && parts.every(v => !isNaN(v))) {
-                    return new Color(parts[0], parts[1], parts[2], parts[3]);
+                const components = parseComponents(item.slice(6), 4) ?? parseComponents(item.slice(6), 3);
+                if (components) {
+                    return new Color(components);
                 }
+                console.warn(`Invalid script attribute value '${item}'. Expected 3 or 4 space-separated numbers after 'color:'.`);
+                return item;
             }
             return item;
         }
 
         if (Array.isArray(item)) {
-            // If it's an array of objects, convert each element individually.
-            if (item.length > 0 && typeof item[0] === 'object') {
-                return item.map((el: any) => this.convertAttributes(el));
-            }
-            // Otherwise, leave the numeric array unchanged but process each element.
-            return item.map((el: any) => this.convertAttributes(el));
+            return item.map((element: any) => this.convertAttributes(element));
         }
 
         if (item && typeof item === 'object') {
@@ -131,15 +145,6 @@ class ScriptComponentElement extends ComponentElement {
         }
 
         return item;
-    }
-
-    /**
-     * Preprocess the attributes object by converting its values.
-     * @param attrs - The attributes object to preprocess.
-     * @returns The preprocessed attributes object.
-     */
-    private preprocessAttributes(attrs: any): any {
-        return this.convertAttributes(attrs);
     }
 
     /**
@@ -167,17 +172,17 @@ class ScriptComponentElement extends ComponentElement {
     }
 
     /**
-     * Update script attributes by merging preprocessed values into the script.
+     * Update script attributes by merging converted values into the script.
      * @param script - The script to update.
+     * @param name - The script name, used in the warning message.
      * @param attributes - The attributes to merge into the script.
      */
-    private applyAttributes(script: any, attributes: string | null) {
+    private applyAttributes(script: any, name: string, attributes: string | null) {
         try {
             const attributesObject = attributes ? JSON.parse(attributes) : {};
-            const converted = this.convertAttributes(attributesObject);
-            this.mergeDeep(script, converted);
+            this.mergeDeep(script, this.convertAttributes(attributesObject));
         } catch (error) {
-            console.error(`Error parsing attributes JSON string ${attributes}:`, error);
+            console.warn(`Invalid 'attributes' JSON on pc-script '${name}': ${(error as Error).message}`);
         }
     }
 
@@ -188,7 +193,7 @@ class ScriptComponentElement extends ComponentElement {
 
         const script = this.component.get(scriptName);
         if (script) {
-            this.applyAttributes(script, event.detail.attributes);
+            this.applyAttributes(script, scriptName, event.detail.attributes);
         }
     }
 
@@ -203,20 +208,20 @@ class ScriptComponentElement extends ComponentElement {
         }
     }
 
-    private createScript(name: string, attributes: string | null): Script | null {
+    private createScript(name: string, attributes: string | null, enabled: boolean): Script | null {
         if (!this.component) return null;
 
         let attributesObject = {};
         if (attributes) {
             try {
-                attributesObject = JSON.parse(attributes);
-                // Preprocess attributes: convert arrays or strings into vectors, colors, asset references, etc.
-                attributesObject = this.preprocessAttributes(attributesObject);
+                // Convert prefixed strings into vectors, colors, asset and entity references, etc.
+                attributesObject = this.convertAttributes(JSON.parse(attributes));
             } catch (error) {
-                console.error(`Error parsing attributes JSON string ${attributes}:`, error);
+                console.warn(`Invalid 'attributes' JSON on pc-script '${name}': ${(error as Error).message}`);
             }
         }
         return this.component.create(name, {
+            enabled,
             properties: attributesObject
         });
     }
@@ -234,7 +239,7 @@ class ScriptComponentElement extends ComponentElement {
                     const scriptName = node.getAttribute('name');
                     const attributes = node.getAttribute('attributes');
                     if (scriptName) {
-                        this.createScript(scriptName, attributes);
+                        this.createScript(scriptName, attributes, (node as ScriptElement).enabled);
                     }
                 }
             });

--- a/src/components/scrollview-component.ts
+++ b/src/components/scrollview-component.ts
@@ -400,7 +400,7 @@ class ScrollViewComponentElement extends ComponentElement {
                 this.useMouseWheel = parseBool(newValue, true);
                 break;
             case 'mouse-wheel-sensitivity':
-                this.mouseWheelSensitivity = parseVec2(newValue, new Vec2(1, 1), name);
+                this.mouseWheelSensitivity = parseVec2(newValue, Vec2.ONE, name);
                 break;
             case 'horizontal-scrollbar-visibility':
                 this.horizontalScrollbarVisibility = parseEnum(newValue, visibilities, 'when-required', name);

--- a/src/components/scrollview-component.ts
+++ b/src/components/scrollview-component.ts
@@ -400,7 +400,7 @@ class ScrollViewComponentElement extends ComponentElement {
                 this.useMouseWheel = parseBool(newValue, true);
                 break;
             case 'mouse-wheel-sensitivity':
-                this.mouseWheelSensitivity = parseVec2(newValue);
+                this.mouseWheelSensitivity = parseVec2(newValue, new Vec2(1, 1), name);
                 break;
             case 'horizontal-scrollbar-visibility':
                 this.horizontalScrollbarVisibility = parseEnum(newValue, visibilities, 'when-required', name);

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -79,9 +79,9 @@ class EntityElement extends AsyncElement {
         this._entity = entity;
 
         entity.enabled = parseBool(this.getAttribute('enabled'), true);
-        entity.setLocalPosition(parseVec3(this.getAttribute('position'), new Vec3(), 'position'));
-        entity.setLocalEulerAngles(parseVec3(this.getAttribute('rotation'), new Vec3(), 'rotation'));
-        entity.setLocalScale(parseVec3(this.getAttribute('scale'), new Vec3(1, 1, 1), 'scale'));
+        entity.setLocalPosition(parseVec3(this.getAttribute('position'), Vec3.ZERO, 'position'));
+        entity.setLocalEulerAngles(parseVec3(this.getAttribute('rotation'), Vec3.ZERO, 'rotation'));
+        entity.setLocalScale(parseVec3(this.getAttribute('scale'), Vec3.ONE, 'scale'));
 
         const tags = this.getAttribute('tags');
         if (tags) {
@@ -306,13 +306,13 @@ class EntityElement extends AsyncElement {
                 this.name = newValue;
                 break;
             case 'position':
-                this.position = parseVec3(newValue, new Vec3(), name);
+                this.position = parseVec3(newValue, Vec3.ZERO, name);
                 break;
             case 'rotation':
-                this.rotation = parseVec3(newValue, new Vec3(), name);
+                this.rotation = parseVec3(newValue, Vec3.ZERO, name);
                 break;
             case 'scale':
-                this.scale = parseVec3(newValue, new Vec3(1, 1, 1), name);
+                this.scale = parseVec3(newValue, Vec3.ONE, name);
                 break;
             case 'tags':
                 this.tags = newValue.split(',').map(tag => tag.trim());

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -79,21 +79,9 @@ class EntityElement extends AsyncElement {
         this._entity = entity;
 
         entity.enabled = parseBool(this.getAttribute('enabled'), true);
-
-        const position = this.getAttribute('position');
-        if (position) {
-            entity.setLocalPosition(parseVec3(position));
-        }
-
-        const rotation = this.getAttribute('rotation');
-        if (rotation) {
-            entity.setLocalEulerAngles(parseVec3(rotation));
-        }
-
-        const scale = this.getAttribute('scale');
-        if (scale) {
-            entity.setLocalScale(parseVec3(scale));
-        }
+        entity.setLocalPosition(parseVec3(this.getAttribute('position'), new Vec3(), 'position'));
+        entity.setLocalEulerAngles(parseVec3(this.getAttribute('rotation'), new Vec3(), 'rotation'));
+        entity.setLocalScale(parseVec3(this.getAttribute('scale'), new Vec3(1, 1, 1), 'scale'));
 
         const tags = this.getAttribute('tags');
         if (tags) {
@@ -318,13 +306,13 @@ class EntityElement extends AsyncElement {
                 this.name = newValue;
                 break;
             case 'position':
-                this.position = parseVec3(newValue);
+                this.position = parseVec3(newValue, new Vec3(), name);
                 break;
             case 'rotation':
-                this.rotation = parseVec3(newValue);
+                this.rotation = parseVec3(newValue, new Vec3(), name);
                 break;
             case 'scale':
-                this.scale = parseVec3(newValue);
+                this.scale = parseVec3(newValue, new Vec3(1, 1, 1), name);
                 break;
             case 'tags':
                 this.tags = newValue.split(',').map(tag => tag.trim());

--- a/src/material.ts
+++ b/src/material.ts
@@ -118,7 +118,7 @@ class MaterialElement extends HTMLElement {
     attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
         switch (name) {
             case 'diffuse':
-                this.diffuse = parseColor(newValue, new Color(1, 1, 1), name);
+                this.diffuse = parseColor(newValue, Color.WHITE, name);
                 break;
             case 'diffuse-map':
                 this.diffuseMap = newValue;

--- a/src/material.ts
+++ b/src/material.ts
@@ -118,7 +118,7 @@ class MaterialElement extends HTMLElement {
     attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
         switch (name) {
             case 'diffuse':
-                this.diffuse = parseColor(newValue);
+                this.diffuse = parseColor(newValue, new Color(1, 1, 1), name);
                 break;
             case 'diffuse-map':
                 this.diffuseMap = newValue;

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -200,7 +200,7 @@ class SceneElement extends AsyncElement {
                 this.fog = parseEnum(newValue, ['none', 'linear', 'exp', 'exp2'], 'none', name);
                 break;
             case 'fog-color':
-                this.fogColor = parseColor(newValue);
+                this.fogColor = parseColor(newValue, new Color(1, 1, 1), name);
                 break;
             case 'fog-density':
                 this.fogDensity = parseNumber(newValue, 0, name);
@@ -212,7 +212,7 @@ class SceneElement extends AsyncElement {
                 this.fogEnd = parseNumber(newValue, 1000, name);
                 break;
             case 'gravity':
-                this.gravity = parseVec3(newValue);
+                this.gravity = parseVec3(newValue, new Vec3(0, -9.81, 0), name);
                 break;
             // ... handle other attributes as well
         }

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -200,7 +200,7 @@ class SceneElement extends AsyncElement {
                 this.fog = parseEnum(newValue, ['none', 'linear', 'exp', 'exp2'], 'none', name);
                 break;
             case 'fog-color':
-                this.fogColor = parseColor(newValue, new Color(1, 1, 1), name);
+                this.fogColor = parseColor(newValue, Color.WHITE, name);
                 break;
             case 'fog-density':
                 this.fogDensity = parseNumber(newValue, 0, name);

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -288,7 +288,7 @@ class SkyElement extends AsyncElement {
                 this.lighting = parseBool(newValue, false);
                 break;
             case 'rotation':
-                this.rotation = parseVec3(newValue, new Vec3(), name);
+                this.rotation = parseVec3(newValue, Vec3.ZERO, name);
                 break;
             case 'scale':
                 this.scale = parseVec3(newValue, new Vec3(100, 100, 100), name);

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -276,7 +276,7 @@ class SkyElement extends AsyncElement {
                 this.asset = newValue;
                 break;
             case 'center':
-                this.center = parseVec3(newValue);
+                this.center = parseVec3(newValue, new Vec3(0, 0.01, 0), name);
                 break;
             case 'intensity':
                 this.intensity = parseNumber(newValue, 1, name);
@@ -288,10 +288,10 @@ class SkyElement extends AsyncElement {
                 this.lighting = parseBool(newValue, false);
                 break;
             case 'rotation':
-                this.rotation = parseVec3(newValue);
+                this.rotation = parseVec3(newValue, new Vec3(), name);
                 break;
             case 'scale':
-                this.scale = parseVec3(newValue);
+                this.scale = parseVec3(newValue, new Vec3(100, 100, 100), name);
                 break;
             case 'type':
                 this.type = parseEnum(newValue, ['box', 'dome', 'infinite', 'none'], 'infinite', name);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,70 +19,160 @@ export const parseBool = (value: string | null, defaultValue: boolean): boolean 
 };
 
 /**
- * Parse a color string into a Color object. String can be in the format of '#rgb', '#rgba',
- * '#rrggbb', '#rrggbbaa', or a string of 3 or 4 comma-delimited numbers.
+ * Splits an attribute value into exactly `count` numeric components. Returns `null` when the
+ * value does not consist of exactly `count` whitespace-separated finite numbers.
  *
- * @param value - The color string to parse.
+ * @param value - The value to split.
+ * @param count - The required number of components.
+ * @returns The parsed components, or `null`.
+ * @ignore
+ */
+export const parseComponents = (value: string, count: number): number[] | null => {
+    const components = value.trim().split(/\s+/).map(Number);
+    if (components.length !== count || components.some(component => !Number.isFinite(component))) {
+        return null;
+    }
+    return components;
+};
+
+/**
+ * Clones a math-type default so parsed results never alias the caller's default instance.
+ *
+ * @param value - The default value to clone (`null` is passed through).
+ * @returns The cloned value.
+ */
+const cloneDefault = <T extends Color | Quat | Vec2 | Vec3 | Vec4 | null>(value: T): T => {
+    return (value === null ? null : value.clone()) as T;
+};
+
+/**
+ * Parse a color attribute value. The expected format is a CSS color name (e.g. 'rebeccapurple'),
+ * a hex color (e.g. '#ff0000' or '#f00'), or 3 or 4 space-separated numbers in the range 0 to 1
+ * (e.g. '1 0.5 0.5' or '1 0.5 0.5 0.5'). Returns `defaultValue` (cloned, when it is a color)
+ * when the attribute is absent (`null`), or when the value is malformed — the latter also logs
+ * a warning.
+ *
+ * @param value - The attribute value to parse (`null` when the attribute is absent).
+ * @param defaultValue - The value to use when the attribute is absent or invalid.
+ * @param attribute - The attribute name, used in the warning message.
  * @returns The parsed Color object.
  */
-export const parseColor = (value: string): Color => {
-    // Check if it's a CSS color name first
+export const parseColor = <T extends Color | null>(value: string | null, defaultValue: T, attribute: string): Color | T => {
+    if (value === null) {
+        return cloneDefault(defaultValue);
+    }
+
+    // A CSS color name (e.g. 'rebeccapurple')
     const hexColor = CSS_COLORS[value.toLowerCase()];
     if (hexColor) {
         return new Color().fromString(hexColor);
     }
 
-    if (value.startsWith('#')) {
-        return new Color().fromString(value);
+    // A hex color (e.g. '#ff0000'), expanding short forms (e.g. '#f00') for Color.fromString
+    if (/^#(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(value)) {
+        let hex = value.slice(1);
+        if (hex.length === 3 || hex.length === 4) {
+            hex = hex.split('').map(char => char + char).join('');
+        }
+        return new Color().fromString(`#${hex}`);
     }
 
-    const components = value.split(' ').map(Number);
-    return new Color(components);
+    // 3 or 4 space-separated components (e.g. '1 0.5 0.5')
+    const components = parseComponents(value, 4) ?? parseComponents(value, 3);
+    if (components) {
+        return new Color(components);
+    }
+
+    console.warn(`Invalid value '${value}' for attribute '${attribute}'. Expected a CSS color name, a hex color or 3 or 4 space-separated numbers. Using '${defaultValue}'.`);
+    return cloneDefault(defaultValue);
 };
 
 /**
- * Parse an Euler angles string into a Quat object. String can be in the format of 'x,y,z'.
+ * Parse an Euler-angles attribute value into a quaternion. The expected format is 3
+ * space-separated angles in degrees (e.g. '0 90 0'). Returns `defaultValue` (cloned, when it is
+ * a quaternion) when the attribute is absent (`null`), or when the value is malformed — the
+ * latter also logs a warning.
  *
- * @param value - The Euler angles string to parse.
+ * @param value - The attribute value to parse (`null` when the attribute is absent).
+ * @param defaultValue - The value to use when the attribute is absent or invalid.
+ * @param attribute - The attribute name, used in the warning message.
  * @returns The parsed Quat object.
  */
-export const parseQuat = (value: string): Quat => {
-    const [x, y, z] = value.split(' ').map(Number);
-    const q = new Quat();
-    q.setFromEulerAngles(x, y, z);
-    return q;
+export const parseQuat = <T extends Quat | null>(value: string | null, defaultValue: T, attribute: string): Quat | T => {
+    if (value === null) {
+        return cloneDefault(defaultValue);
+    }
+    const components = parseComponents(value, 3);
+    if (!components) {
+        console.warn(`Invalid value '${value}' for attribute '${attribute}'. Expected 3 space-separated numbers. Using '${defaultValue}'.`);
+        return cloneDefault(defaultValue);
+    }
+    return new Quat().setFromEulerAngles(components[0], components[1], components[2]);
 };
 
 /**
- * Parse a Vec2 string into a Vec2 object. String can be in the format of 'x,y'.
+ * Parse a Vec2 attribute value. The expected format is 2 space-separated numbers (e.g. '1 2').
+ * Returns `defaultValue` (cloned, when it is a vector) when the attribute is absent (`null`),
+ * or when the value is malformed — the latter also logs a warning.
  *
- * @param value - The Vec2 string to parse.
+ * @param value - The attribute value to parse (`null` when the attribute is absent).
+ * @param defaultValue - The value to use when the attribute is absent or invalid.
+ * @param attribute - The attribute name, used in the warning message.
  * @returns The parsed Vec2 object.
  */
-export const parseVec2 = (value: string): Vec2 => {
-    const components = value.split(' ').map(Number);
+export const parseVec2 = <T extends Vec2 | null>(value: string | null, defaultValue: T, attribute: string): Vec2 | T => {
+    if (value === null) {
+        return cloneDefault(defaultValue);
+    }
+    const components = parseComponents(value, 2);
+    if (!components) {
+        console.warn(`Invalid value '${value}' for attribute '${attribute}'. Expected 2 space-separated numbers. Using '${defaultValue}'.`);
+        return cloneDefault(defaultValue);
+    }
     return new Vec2(components);
 };
 
 /**
- * Parse a Vec3 string into a Vec3 object. String can be in the format of 'x,y,z'.
+ * Parse a Vec3 attribute value. The expected format is 3 space-separated numbers (e.g. '1 2 3').
+ * Returns `defaultValue` (cloned, when it is a vector) when the attribute is absent (`null`),
+ * or when the value is malformed — the latter also logs a warning.
  *
- * @param value - The Vec3 string to parse.
+ * @param value - The attribute value to parse (`null` when the attribute is absent).
+ * @param defaultValue - The value to use when the attribute is absent or invalid.
+ * @param attribute - The attribute name, used in the warning message.
  * @returns The parsed Vec3 object.
  */
-export const parseVec3 = (value: string): Vec3 => {
-    const components = value.split(' ').map(Number);
+export const parseVec3 = <T extends Vec3 | null>(value: string | null, defaultValue: T, attribute: string): Vec3 | T => {
+    if (value === null) {
+        return cloneDefault(defaultValue);
+    }
+    const components = parseComponents(value, 3);
+    if (!components) {
+        console.warn(`Invalid value '${value}' for attribute '${attribute}'. Expected 3 space-separated numbers. Using '${defaultValue}'.`);
+        return cloneDefault(defaultValue);
+    }
     return new Vec3(components);
 };
 
 /**
- * Parse a Vec4 string into a Vec4 object. String can be in the format of 'x,y,z,w'.
+ * Parse a Vec4 attribute value. The expected format is 4 space-separated numbers
+ * (e.g. '1 2 3 4'). Returns `defaultValue` (cloned, when it is a vector) when the attribute is
+ * absent (`null`), or when the value is malformed — the latter also logs a warning.
  *
- * @param value - The Vec4 string to parse.
+ * @param value - The attribute value to parse (`null` when the attribute is absent).
+ * @param defaultValue - The value to use when the attribute is absent or invalid.
+ * @param attribute - The attribute name, used in the warning message.
  * @returns The parsed Vec4 object.
  */
-export const parseVec4 = (value: string): Vec4 => {
-    const components = value.split(' ').map(Number);
+export const parseVec4 = <T extends Vec4 | null>(value: string | null, defaultValue: T, attribute: string): Vec4 | T => {
+    if (value === null) {
+        return cloneDefault(defaultValue);
+    }
+    const components = parseComponents(value, 4);
+    if (!components) {
+        console.warn(`Invalid value '${value}' for attribute '${attribute}'. Expected 4 space-separated numbers. Using '${defaultValue}'.`);
+        return cloneDefault(defaultValue);
+    }
     return new Vec4(components);
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,7 +36,9 @@ export const parseComponents = (value: string, count: number): number[] | null =
 };
 
 /**
- * Clones a math-type default so parsed results never alias the caller's default instance.
+ * Clones a math-type default so parsed results never alias the caller's default instance. This
+ * is what makes it safe to pass the engine's shared frozen constants (e.g. `Vec3.ZERO`,
+ * `Color.WHITE`) as defaults.
  *
  * @param value - The default value to clone (`null` is passed through).
  * @returns The cloned value.


### PR DESCRIPTION
## What

The vector/color stage of the attribute-conventions series (follows #272, #273, #274, #275, #276), plus Tier 1 of the script-attributes DX review.

### Vector/color/quaternion attributes

All 35 sites now parse through upgraded shared helpers (`parseVec2/3/4`, `parseColor`, `parseQuat`) with the established contract:

| Markup | Result |
|---|---|
| whitespace-separated numbers, exact count (`position="0 1.5 0"`, any amount of whitespace) | parsed |
| attribute absent (or removed at runtime) | engine default, silently — defaults are **cloned**, so parsed results never alias a shared instance |
| anything else (commas, wrong count, NaN) | console warning naming the attribute + expected format, then the default |

Per the narrow-and-consistent decision: formatting robustness (double spaces, leading/trailing whitespace) is tolerated because it's invisible to authors, but grammar expansion (commas) is rejected with a teaching warning rather than silently accepted. `parseColor` gains validation plus `#f00`/`#f00f` short-hex support, and the stale JSDoc claiming comma formats is gone. `pc-element margin` (nullable) now restores `null` on removal.

### Script attributes (Tier 1 of the DX review)

- **Prefix payloads are now space-separated** (`"vec3:0 1.75 0"`), unifying the third grammar with the rest of the library. All 14 example files updated. Old comma payloads get a loud warning pointing at the exact string.
- **Malformed prefixes warn** instead of silently assigning the raw string to the script property (previously `"color:1,0,0"` — 3 components — silently became a string).
- **`asset:` resolves via `AssetElement.get()`** — the old `pc-asset#id` selector threw an *uncaught SyntaxError* for ids starting with a digit. **`entity:` resolves via `getEntity()`**, so it accepts a CSS selector, element id, or entity name like every other entity reference (previously name-only). Unresolved references warn.
- **`enabled="false"` on `pc-script` is honored at creation.** The enable-change event fired at element upgrade, before the script component existed, and was dropped — declaratively disabled scripts started enabled. `createScript` now passes `enabled` to the engine's `create()`.
- **The childList `MutationObserver` re-attaches on reconnection** — previously `pc-script` elements added after a disconnect/reconnect cycle were silently ignored.
- Invalid `attributes` JSON warns naming the script; the redundant `preprocessAttributes` indirection and a duplicated array branch are gone.

## Breaking changes

- Comma-separated vector/color values (attributes and `vec*:`/`color:` prefixes) are no longer accepted — they warn and fall back. Canonical format is space-separated.
- Scripts declared with `enabled="false"` now actually start disabled.

## Verification

- `npm run build`, `type-check`, `lint` clean; grep confirms no single-arg parse calls and no `split(' ')` remain.
- Live-browser page: 20/20 assertions across both halves (multi-space parsing, comma/count rejection with warnings, short-hex + CSS names, clone-not-alias defaults, margin null-restore, prefix conversion in nested arrays, digit-leading `asset:` id, `entity:#id` selector, unresolved-ref warnings, `enabled="false"` at creation, post-reconnect script creation).
- Examples: `shoe-configurator` (cameraControls focus/zoom vecs) renders correctly framed with zero console output; `tween` hover tween works with nested `vec4:` payloads confirmed as real `Vec4` instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)