### PR TITLE
Improve script attribute ergonomics

### DIFF
--- a/src/components/script-component.ts
+++ b/src/components/script-component.ts
@@ -7,7 +7,7 @@ import { getEntity, parseComponents } from '../utils';
 
 // Add these interfaces at the top of the file, after the imports
 interface ScriptAttributesChangeEvent extends CustomEvent {
-    detail: { attributes: any };
+    detail: { attributes: Record<string, any> };
 }
 
 interface ScriptEnableChangeEvent extends CustomEvent {
@@ -54,11 +54,7 @@ class ScriptComponentElement extends ComponentElement {
     initComponent() {
         // Handle initial script elements
         this.querySelectorAll<ScriptElement>(':scope > pc-script').forEach((scriptElement) => {
-            const scriptName = scriptElement.getAttribute('name');
-            const attributes = scriptElement.getAttribute('attributes');
-            if (scriptName) {
-                this.createScript(scriptName, attributes, scriptElement.enabled);
-            }
+            this.createScript(scriptElement);
         });
     }
 
@@ -148,42 +144,72 @@ class ScriptComponentElement extends ComponentElement {
     }
 
     /**
-     * Recursively merge properties from source into target.
+     * Recursively merge properties from source into target. When the target value is a Vec2,
+     * Vec3, Vec4 or Color and the source value is a plain numeric array, the array is converted
+     * to the target's type — so script attributes with math-typed defaults can be written as
+     * plain JSON arrays (e.g. `"focusPoint": [0, 1.75, 0]`).
      * @param target - The target object to merge into.
      * @param source - The source object to merge from.
      * @returns The merged object.
      */
     private mergeDeep(target: any, source: any): any {
         for (const key in source) {
-            if (
-                source[key] &&
-                typeof source[key] === 'object' &&
-                !Array.isArray(source[key])
-            ) {
-                if (!target[key] || typeof target[key] !== 'object') {
+            const value = source[key];
+            const current = target[key];
+            if (this.isMathType(current) && Array.isArray(value)) {
+                const converted = this.arrayToMathType(current, value, key);
+                if (converted) {
+                    target[key] = converted;
+                }
+                continue;
+            }
+            if (value && typeof value === 'object' && !Array.isArray(value)) {
+                if (!current || typeof current !== 'object') {
                     target[key] = {};
                 }
-                this.mergeDeep(target[key], source[key]);
+                this.mergeDeep(target[key], value);
             } else {
-                target[key] = source[key];
+                target[key] = value;
             }
         }
         return target;
     }
 
     /**
+     * Checks whether a value is one of the math types that plain numeric arrays convert to.
+     * @param value - The value to check.
+     * @returns Whether the value is a math type.
+     */
+    private isMathType(value: any): value is Vec2 | Vec3 | Vec4 | Color {
+        return value instanceof Vec2 || value instanceof Vec3 || value instanceof Vec4 || value instanceof Color;
+    }
+
+    /**
+     * Converts a plain numeric array to the math type of `current`. Returns `null` (and logs a
+     * warning) when the array's length or contents don't match the type.
+     * @param current - The current (typed) value of the property.
+     * @param value - The incoming array.
+     * @param key - The property name, used in the warning message.
+     * @returns The converted value, or `null`.
+     */
+    private arrayToMathType(current: Vec2 | Vec3 | Vec4 | Color, value: any[], key: string): Vec2 | Vec3 | Vec4 | Color | null {
+        if (value.every(component => typeof component === 'number' && Number.isFinite(component))) {
+            if (current instanceof Vec2 && value.length === 2) return new Vec2(value);
+            if (current instanceof Vec3 && value.length === 3) return new Vec3(value);
+            if (current instanceof Vec4 && value.length === 4) return new Vec4(value);
+            if (current instanceof Color && (value.length === 3 || value.length === 4)) return new Color(value);
+        }
+        console.warn(`Cannot convert script attribute '${key}' array [${value}] to ${current.constructor.name}. Keeping the current value.`);
+        return null;
+    }
+
+    /**
      * Update script attributes by merging converted values into the script.
      * @param script - The script to update.
-     * @param name - The script name, used in the warning message.
      * @param attributes - The attributes to merge into the script.
      */
-    private applyAttributes(script: any, name: string, attributes: string | null) {
-        try {
-            const attributesObject = attributes ? JSON.parse(attributes) : {};
-            this.mergeDeep(script, this.convertAttributes(attributesObject));
-        } catch (error) {
-            console.warn(`Invalid 'attributes' JSON on pc-script '${name}': ${(error as Error).message}`);
-        }
+    private applyAttributes(script: any, attributes: Record<string, any>) {
+        this.mergeDeep(script, this.convertAttributes(attributes));
     }
 
     private handleScriptAttributesChange(event: ScriptAttributesChangeEvent) {
@@ -193,7 +219,7 @@ class ScriptComponentElement extends ComponentElement {
 
         const script = this.component.get(scriptName);
         if (script) {
-            this.applyAttributes(script, scriptName, event.detail.attributes);
+            this.applyAttributes(script, event.detail.attributes);
         }
     }
 
@@ -208,22 +234,27 @@ class ScriptComponentElement extends ComponentElement {
         }
     }
 
-    private createScript(name: string, attributes: string | null, enabled: boolean): Script | null {
-        if (!this.component) return null;
+    /**
+     * Creates the script instance for a `pc-script` element. The instance is created disabled,
+     * the element's converted attributes are merged over the instance's defaults (which is what
+     * allows plain numeric arrays to be typed against those defaults), and only then is the
+     * declared enabled state applied — so `initialize()` runs with every attribute in place.
+     * @param scriptElement - The `pc-script` element to create the script instance for.
+     * @returns The created script, or `null`.
+     */
+    private createScript(scriptElement: ScriptElement): Script | null {
+        const name = scriptElement.getAttribute('name');
+        if (!name || !this.component) return null;
 
-        let attributesObject = {};
-        if (attributes) {
-            try {
-                // Convert prefixed strings into vectors, colors, asset and entity references, etc.
-                attributesObject = this.convertAttributes(JSON.parse(attributes));
-            } catch (error) {
-                console.warn(`Invalid 'attributes' JSON on pc-script '${name}': ${(error as Error).message}`);
-            }
-        }
-        return this.component.create(name, {
-            enabled,
-            properties: attributesObject
-        });
+        const script = this.component.create(name, { enabled: false });
+        if (!script) return null;
+
+        this.mergeDeep(script, this.convertAttributes(scriptElement.scriptAttributes));
+        script.enabled = scriptElement.enabled;
+
+        scriptElement._onScriptCreated();
+
+        return script;
     }
 
     private destroyScript(name: string): void {
@@ -236,11 +267,7 @@ class ScriptComponentElement extends ComponentElement {
             // Handle added nodes
             mutation.addedNodes.forEach((node) => {
                 if (node instanceof HTMLElement && node.tagName.toLowerCase() === 'pc-script') {
-                    const scriptName = node.getAttribute('name');
-                    const attributes = node.getAttribute('attributes');
-                    if (scriptName) {
-                        this.createScript(scriptName, attributes, (node as ScriptElement).enabled);
-                    }
+                    this.createScript(node as ScriptElement);
                 }
             });
 

--- a/src/components/script.ts
+++ b/src/components/script.ts
@@ -1,25 +1,36 @@
+import { Script } from 'playcanvas';
+
+import { AsyncElement } from '../async-element';
 import { parseBool } from '../utils';
+import type { ScriptComponentElement } from './script-component';
 
 /**
  * The ScriptElement interface provides properties and methods for manipulating
  * `<pc-script>` elements. The ScriptElement interface also inherits the properties and
- * methods of the {@link HTMLElement} interface.
+ * methods of the {@link AsyncElement} interface.
+ *
+ * The element becomes ready once its script instance has been created by the parent
+ * `<pc-scripts>` element.
  */
-class ScriptElement extends HTMLElement {
-    private _attributes: string = '{}';
+class ScriptElement extends AsyncElement {
+    private _attributes: Record<string, any> = {};
 
     private _enabled: boolean = true;
 
     private _name: string = '';
 
     /**
-     * Sets the attributes of the script.
+     * Sets the attributes of the script as an object. Values are converted with the same rules
+     * as the `attributes` attribute: `asset:`/`entity:` references and `vec2:`/`vec3:`/`vec4:`/
+     * `color:` prefixed strings are resolved, and a plain numeric array is converted to the
+     * type of the attribute it targets when that attribute currently holds a Vec2, Vec3, Vec4
+     * or Color.
      * @param value - The attributes of the script.
      */
-    set scriptAttributes(value: string) {
-        this._attributes = value;
+    set scriptAttributes(value: Record<string, any>) {
+        this._attributes = value ?? {};
         this.dispatchEvent(new CustomEvent('scriptattributeschange', {
-            detail: { attributes: value },
+            detail: { attributes: this._attributes },
             bubbles: true
         }));
     }
@@ -28,7 +39,7 @@ class ScriptElement extends HTMLElement {
      * Gets the attributes of the script.
      * @returns The attributes of the script.
      */
-    get scriptAttributes() {
+    get scriptAttributes(): Record<string, any> {
         return this._attributes;
     }
 
@@ -68,6 +79,29 @@ class ScriptElement extends HTMLElement {
         return this._name;
     }
 
+    /**
+     * Gets the {@link Script} instance created for this element. Returns `null` until the
+     * instance exists — await {@link whenReady} or the element's `ready()` promise before
+     * accessing it.
+     * @returns The script instance, or `null`.
+     */
+    get script(): Script | null {
+        const parent = this.parentElement;
+        if (!parent || parent.tagName.toLowerCase() !== 'pc-scripts') {
+            return null;
+        }
+        const component = (parent as ScriptComponentElement).component;
+        return component ? (component.get(this._name) as Script | null) : null;
+    }
+
+    /**
+     * Called by the parent `<pc-scripts>` element when the script instance has been created.
+     * @ignore
+     */
+    _onScriptCreated() {
+        this._onReady();
+    }
+
     static get observedAttributes() {
         return ['attributes', 'enabled', 'name'];
     }
@@ -75,7 +109,15 @@ class ScriptElement extends HTMLElement {
     attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
         switch (name) {
             case 'attributes':
-                this.scriptAttributes = newValue;
+                if (newValue === null) {
+                    this.scriptAttributes = {};
+                    break;
+                }
+                try {
+                    this.scriptAttributes = JSON.parse(newValue);
+                } catch (error) {
+                    console.warn(`Invalid 'attributes' JSON on pc-script '${this.getAttribute('name')}': ${(error as Error).message}`);
+                }
                 break;
             case 'enabled':
                 this.enabled = parseBool(newValue, true);


### PR DESCRIPTION
## What

Tier 2 of the script-attributes DX review (follows the Tier 1 fixes in #277).

### Plain JSON arrays for math-typed attributes

```html
<pc-script name="cameraControls" attributes='{
    "focusPoint": [0, 1.75, 0],
    "pitchRange": [-90, 0]
}'></pc-script>
```

When a script's class-field default is a `Vec2`, `Vec3`, `Vec4` or `Color`, a plain numeric array of matching length converts to that type — no prefix strings needed. The type information comes from the script instance's own defaults, which required reordering creation: the script is created **disabled**, converted attributes are merged over its defaults, then the declared enabled state is applied. Verified against the engine source: `create()` only fires `initialize()` when the script is enabled, and the `enabled` setter fires `initialize` + `postInitialize` on first effective enable — so **`initialize()` sees fully typed attributes**, and entity/component-disabled deferral semantics are preserved.

Mismatched arrays (`"vec3Field": [1, 2]`) warn and keep the default. The `vec3:`/`color:` prefixes remain fully supported — they're still needed for untyped nesting (e.g. the tweener's config arrays) and `asset:`/`entity:` references.

### API improvements

- **`scriptAttributes` is now object-typed** — JS users write `el.scriptAttributes = { speed: 2 }` instead of `JSON.stringify(...)`. The attribute's JSON is parsed exactly once, in the element, with parse errors warning in element context.
- **`pc-script` gains a `script` getter** returning the live `Script` instance (previously you had to detour through `entity.script.<name>`).
- **`pc-script` is now an `AsyncElement`** — ready when its instance is created, so `whenReady('pc-script')`, `element.ready()`, and the `ready` event work like every other element.

## Behavior notes for reviewers

- Creation-time property application now uses the same deep-merge path as runtime updates. For object-valued attributes this means nested keys merge over class-field defaults at creation (`objField = {a:1, b:2}` + `{"objField": {"a": 5}}` → `{a:5, b:2}`) instead of the engine's previous wholesale `Object.assign` replacement. Consistent with runtime-update semantics, and arguably the right default — but it is a semantic change for scripts relying on replacement.
- `component.on('create')` listeners now observe the instance before attributes are merged (they fire inside the engine's `create()`).

## Verification

- `npm run build`, `type-check`, `lint` clean (the `ScriptElement` ↔ `ScriptComponentElement` reference is a type-only import — no runtime cycle).
- Live-browser page with a purpose-built test script: 17/17 assertions — array→Vec3/Color inference, `initialize()` observing inferred values and merged objects, mismatch warn-and-keep-default, `enabled="false"` deferring `initialize` until enable (then seeing correct values), prefix regression, object-typed property round-trip with live re-inference, `script` getter identity, and readiness.
- Script-heavy examples regression-checked in the browser: `shoe-configurator` (cameraControls reads attributes in `initialize` — framing correct), `vibe-falling-blocks` (game boots and plays), `tween` (nested prefix configs + hover tween works), all with no console errors from the current build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)