### PR TITLE
Restrict TypeScript updates to major version 6

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,6 +26,12 @@
         "eslint"
       ],
       "allowedVersions": "<10.0.0"
+    },
+    {
+      "matchPackageNames": [
+        "typescript"
+      ],
+      "allowedVersions": "<7.0.0"
     }
   ]
 }


### PR DESCRIPTION
Adds a Renovate package rule pinning `typescript` to `<7.0.0`, keeping it on the current major (6.x) until we're ready to move to 7. Follows the same pattern as the existing `eslint` restriction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)