### PR TITLE
Rebuild AR Hand Gestures example as an interactive neon showcase

### DIFF
--- a/examples/ar-hand-gestures.html
+++ b/examples/ar-hand-gestures.html
@@ -16,38 +16,388 @@
 
         <script type="module" src="../dist/pwc.mjs"></script>
         <link rel="stylesheet" href="css/example.css">
+        <style>
+            :root {
+                --font: 'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif;
+                --hud-bg: rgba(8, 12, 24, 0.55);
+                --hud-border: rgba(255, 255, 255, 0.14);
+                --hud-ink: #eef2ff;
+                --hand-0: #19d9ff;
+                --hand-1: #ff40d9;
+            }
+
+            body {
+                background-color: #05060a;
+            }
+
+            /* Dim the camera feed a little so the neon visuals read over it */
+            video {
+                filter: brightness(0.72) saturate(1.15);
+            }
+
+            #vignette {
+                position: fixed;
+                inset: 0;
+                z-index: 1;
+                pointer-events: none;
+                background: radial-gradient(ellipse at center, transparent 52%, rgba(2, 4, 12, 0.55) 100%);
+            }
+
+            /* Status banner */
+            #status {
+                position: fixed;
+                top: max(18px, env(safe-area-inset-top));
+                left: 50%;
+                transform: translateX(-50%);
+                z-index: 10;
+                display: flex;
+                align-items: center;
+                gap: 10px;
+                padding: 10px 18px;
+                background: var(--hud-bg);
+                border: 1px solid var(--hud-border);
+                border-radius: 999px;
+                backdrop-filter: blur(12px);
+                -webkit-backdrop-filter: blur(12px);
+                color: var(--hud-ink);
+                font-family: var(--font);
+                font-size: 14px;
+                letter-spacing: 0.02em;
+                white-space: nowrap;
+                transition: opacity 0.35s ease, transform 0.35s ease;
+            }
+            #status.hidden {
+                opacity: 0;
+                transform: translateX(-50%) translateY(-8px);
+            }
+            .status-dot {
+                width: 8px;
+                height: 8px;
+                border-radius: 50%;
+                background: var(--hand-0);
+                animation: pulse 1.2s ease-in-out infinite;
+            }
+            #status.error .status-dot {
+                background: #ff5470;
+                animation: none;
+            }
+            @keyframes pulse {
+                0%, 100% { opacity: 0.3; }
+                50% { opacity: 1; }
+            }
+
+            /* Per-hand gesture chips */
+            .hand-chip {
+                position: fixed;
+                left: 0;
+                top: 0;
+                z-index: 10;
+                display: flex;
+                align-items: center;
+                gap: 10px;
+                padding: 8px 14px 8px 10px;
+                background: var(--hud-bg);
+                border: 1px solid var(--hud-border);
+                border-left: 3px solid var(--accent);
+                border-radius: 12px;
+                backdrop-filter: blur(12px);
+                -webkit-backdrop-filter: blur(12px);
+                color: var(--hud-ink);
+                font-family: var(--font);
+                opacity: 0;
+                transition: opacity 0.2s ease;
+                pointer-events: none;
+                will-change: transform;
+            }
+            .hand-chip.visible { opacity: 1; }
+            .hand-chip.pop { animation: chip-pop 0.3s ease; }
+            #chip-0 { --accent: var(--hand-0); }
+            #chip-1 { --accent: var(--hand-1); }
+            .chip-emoji { font-size: 24px; }
+            .chip-label {
+                font-size: 12px;
+                font-weight: 600;
+                letter-spacing: 0.08em;
+                text-transform: uppercase;
+                white-space: nowrap;
+            }
+            .chip-hand {
+                font-size: 10px;
+                opacity: 0.6;
+                letter-spacing: 0.08em;
+                text-transform: uppercase;
+                white-space: nowrap;
+            }
+            .chip-bar {
+                margin-top: 4px;
+                width: 92px;
+                height: 3px;
+                border-radius: 2px;
+                background: rgba(255, 255, 255, 0.15);
+                overflow: hidden;
+            }
+            .chip-fill {
+                height: 100%;
+                width: 0%;
+                background: var(--accent);
+                border-radius: 2px;
+                transition: width 0.15s linear;
+            }
+            @keyframes chip-pop {
+                0% { scale: 1; }
+                40% { scale: 1.14; }
+                100% { scale: 1; }
+            }
+
+            /* Gesture collection legend */
+            #legend {
+                position: fixed;
+                bottom: max(18px, env(safe-area-inset-bottom));
+                left: 50%;
+                transform: translateX(-50%);
+                z-index: 10;
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                gap: 9px;
+                pointer-events: none;
+            }
+            .legend-row {
+                display: flex;
+                gap: 8px;
+            }
+            .legend-item {
+                width: 42px;
+                height: 42px;
+                display: grid;
+                place-items: center;
+                font-size: 21px;
+                background: var(--hud-bg);
+                border: 1px solid var(--hud-border);
+                border-radius: 10px;
+                backdrop-filter: blur(12px);
+                -webkit-backdrop-filter: blur(12px);
+                opacity: 0.45;
+                filter: grayscale(0.9);
+                transition: opacity 0.4s ease, filter 0.4s ease, box-shadow 0.4s ease, border-color 0.4s ease;
+            }
+            .legend-item.lit {
+                opacity: 1;
+                filter: none;
+                border-color: var(--g);
+                box-shadow: 0 0 16px var(--g);
+                animation: legend-pop 0.45s ease;
+            }
+            @keyframes legend-pop {
+                0% { scale: 1; }
+                45% { scale: 1.25; }
+                100% { scale: 1; }
+            }
+            #legend.complete .legend-item {
+                animation: legend-wave 0.7s ease;
+            }
+            #legend.complete .legend-item:nth-child(2) { animation-delay: 0.06s; }
+            #legend.complete .legend-item:nth-child(3) { animation-delay: 0.12s; }
+            #legend.complete .legend-item:nth-child(4) { animation-delay: 0.18s; }
+            #legend.complete .legend-item:nth-child(5) { animation-delay: 0.24s; }
+            #legend.complete .legend-item:nth-child(6) { animation-delay: 0.3s; }
+            #legend.complete .legend-item:nth-child(7) { animation-delay: 0.36s; }
+            @keyframes legend-wave {
+                0% { translate: 0 0; }
+                35% { translate: 0 -14px; }
+                100% { translate: 0 0; }
+            }
+            .legend-caption {
+                font-family: var(--font);
+                font-size: 11px;
+                letter-spacing: 0.14em;
+                text-transform: uppercase;
+                color: rgba(238, 242, 255, 0.75);
+                text-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
+                white-space: nowrap;
+            }
+        </style>
     </head>
     <body>
         <pc-app>
             <!-- Assets -->
             <pc-asset src="assets/scripts/camera-feed.mjs"></pc-asset>
             <pc-asset src="assets/scripts/hand-gestures.mjs"></pc-asset>
-            <pc-asset src="assets/skies/shanghai-riverside-4k.hdr" id="shanghai"></pc-asset>
+            <pc-asset src="assets/scripts/hand-visuals.mjs"></pc-asset>
             <!-- Scene -->
             <pc-scene>
-                <!-- Sky -->
-                <pc-sky asset="shanghai" type="none" lighting></pc-sky>
                 <!-- Camera -->
                 <pc-entity name="camera">
                     <pc-camera clear-color="0 0 0 0" fov="80"></pc-camera>
                     <pc-scripts>
                         <pc-script name="cameraFeed"></pc-script>
                         <pc-script name="handGestureController"></pc-script>
+                        <pc-script name="handVisuals"></pc-script>
                     </pc-scripts>
                 </pc-entity>
             </pc-scene>
         </pc-app>
+
+        <!-- HUD -->
+        <div id="vignette"></div>
+        <div id="status"><span class="status-dot"></span><span id="status-text">Loading hand tracking…</span></div>
+        <div class="hand-chip" id="chip-0">
+            <span class="chip-emoji">👋</span>
+            <div>
+                <div class="chip-label">Tracking</div>
+                <div class="chip-hand"></div>
+                <div class="chip-bar"><div class="chip-fill"></div></div>
+            </div>
+        </div>
+        <div class="hand-chip" id="chip-1">
+            <span class="chip-emoji">👋</span>
+            <div>
+                <div class="chip-label">Tracking</div>
+                <div class="chip-hand"></div>
+                <div class="chip-bar"><div class="chip-fill"></div></div>
+            </div>
+        </div>
+        <div id="legend">
+            <div class="legend-row" id="legend-row"></div>
+            <div class="legend-caption">Find all 7 · 🖐️ charges an orb · ✊ crushes it</div>
+        </div>
+
         <script type="module">
             import { whenReady } from '@playcanvas/web-components';
 
             const { app } = await whenReady('pc-app');
 
-            app.on('hand:gesture', (handIndex, gesture, score) => {
-                console.log(`Hand ${handIndex} detected gesture: ${gesture} (score: ${score})`);
+            const GESTURES = {
+                Open_Palm: { emoji: '🖐️', label: 'Open palm', color: '#19d9ff' },
+                Closed_Fist: { emoji: '✊', label: 'Fist', color: '#ff40d9' },
+                Pointing_Up: { emoji: '☝️', label: 'Pointing up', color: '#ffffff' },
+                Thumb_Up: { emoji: '👍', label: 'Thumbs up', color: '#ffa626' },
+                Thumb_Down: { emoji: '👎', label: 'Thumbs down', color: '#6680ff' },
+                Victory: { emoji: '✌️', label: 'Victory', color: '#4dff80' },
+                ILoveYou: { emoji: '🤟', label: 'I love you', color: '#ff4073' }
+            };
+
+            // Build the collection legend
+            const legend = document.getElementById('legend');
+            const legendRow = document.getElementById('legend-row');
+            const legendItems = new Map();
+            for (const [name, { emoji, label, color }] of Object.entries(GESTURES)) {
+                const item = document.createElement('div');
+                item.className = 'legend-item';
+                item.style.setProperty('--g', color);
+                item.title = label;
+                item.textContent = emoji;
+                legendRow.appendChild(item);
+                legendItems.set(name, item);
+            }
+            const collected = new Set();
+
+            // Status banner
+            const status = document.getElementById('status');
+            const statusText = document.getElementById('status-text');
+            const setStatus = (text, cls = '') => {
+                statusText.textContent = text;
+                status.className = cls;
+            };
+
+            let tracking = false;
+            let cameraError = false;
+            let lastSeen = 0;
+            let stickyUntil = 0;
+
+            app.on('camera:error', () => {
+                cameraError = true;
+                setStatus('Camera unavailable — check permissions', 'error');
             });
 
-            app.on('hand:position', (handIndex, position) => {
-                console.log(`Hand ${handIndex} position: ${position}`);
+            app.on('hands:ready', () => {
+                tracking = true;
+                if (!cameraError) setStatus('Show your hands 👋');
+            });
+
+            // Per-hand gesture chips that follow the wrists
+            const chips = [0, 1].map((i) => {
+                const chip = document.getElementById(`chip-${i}`);
+                return {
+                    chip,
+                    emoji: chip.querySelector('.chip-emoji'),
+                    label: chip.querySelector('.chip-label'),
+                    hand: chip.querySelector('.chip-hand'),
+                    fill: chip.querySelector('.chip-fill'),
+                    seen: false,
+                    visible: false
+                };
+            });
+
+            app.on('hands:update', (hands) => {
+                const now = performance.now();
+                if (hands.length > 0) {
+                    lastSeen = now;
+                    if (tracking && now > stickyUntil) status.classList.add('hidden');
+                } else if (tracking && !cameraError && status.classList.contains('hidden') && now - lastSeen > 4000) {
+                    setStatus('Show your hands 👋');
+                }
+
+                for (const c of chips) c.seen = false;
+
+                for (const hand of hands) {
+                    const c = chips[hand.slot];
+                    if (!c) continue;
+                    c.seen = true;
+
+                    const wrist = hand.screenLandmarks[0];
+                    c.chip.style.transform = `translate3d(${wrist.x.toFixed(1)}px, ${(wrist.y + 26).toFixed(1)}px, 0) translate(-50%, 0)`;
+
+                    const meta = GESTURES[hand.gesture.name];
+                    c.emoji.textContent = meta ? meta.emoji : '👋';
+                    c.label.textContent = meta ? meta.label : 'Tracking';
+                    c.hand.textContent = hand.handedness ? `${hand.handedness} hand` : '';
+                    c.fill.style.width = `${Math.round((meta ? hand.gesture.score : 0) * 100)}%`;
+
+                    if (!c.visible) {
+                        c.visible = true;
+                        c.chip.classList.add('visible');
+                    }
+                }
+
+                for (const c of chips) {
+                    if (!c.seen && c.visible) {
+                        c.visible = false;
+                        c.chip.classList.remove('visible');
+                    }
+                }
+            });
+
+            app.on('hand:lost', (slot) => {
+                const c = chips[slot];
+                if (c && c.visible) {
+                    c.visible = false;
+                    c.chip.classList.remove('visible');
+                }
+            });
+
+            app.on('hand:gesture', (slot, name) => {
+                const c = chips[slot];
+                if (c && GESTURES[name]) {
+                    c.chip.classList.remove('pop');
+                    void c.chip.offsetWidth;
+                    c.chip.classList.add('pop');
+                }
+
+                // Light up the legend the first time each gesture is performed
+                const item = legendItems.get(name);
+                if (item && !collected.has(name)) {
+                    collected.add(name);
+                    item.classList.add('lit');
+
+                    if (collected.size === legendItems.size) {
+                        legend.classList.add('complete');
+                        setStatus('All 7 gestures found! 🎉');
+                        stickyUntil = performance.now() + 3500;
+                        app.fire('gestures:complete');
+                        setTimeout(() => status.classList.add('hidden'), 3500);
+                    }
+                }
             });
         </script>
         <script type="module" src="js/example.mjs"></script>

--- a/examples/assets/scripts/camera-feed.mjs
+++ b/examples/assets/scripts/camera-feed.mjs
@@ -5,6 +5,12 @@ import { Script } from 'playcanvas';
  *
  * This script creates a video element and requests access to the device's camera.
  * It then streams the camera's video to the video element and plays it.
+ *
+ * Fires the following events on the application:
+ *
+ * - `camera:ready` - Fired with the video element once the stream is playing and
+ *   its dimensions are known.
+ * - `camera:error` - Fired with the error if the camera could not be accessed.
  */
 export class CameraFeed extends Script {
     static scriptName = 'cameraFeed';
@@ -65,19 +71,24 @@ export class CameraFeed extends Script {
             this.video = null;
         });
 
-        // Request access to the webcam
+        // Request access to the webcam (prefer the front-facing camera on mobile)
         if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
-            navigator.mediaDevices.getUserMedia({ video: true, audio: false })
+            navigator.mediaDevices.getUserMedia({ video: { facingMode: 'user' }, audio: false })
             .then((stream) => {
                 // Stream the webcam to the video element and play it
                 this.video.srcObject = stream;
+                this.video.addEventListener('loadedmetadata', () => {
+                    this.app.fire('camera:ready', this.video);
+                }, { once: true });
                 this.video.play();
             })
             .catch((error) => {
                 console.error('Error accessing the webcam:', error);
+                this.app.fire('camera:error', error);
             });
         } else {
             console.error('getUserMedia is not supported in this browser.');
+            this.app.fire('camera:error', new Error('getUserMedia is not supported in this browser.'));
         }
     }
 

--- a/examples/assets/scripts/hand-gestures.mjs
+++ b/examples/assets/scripts/hand-gestures.mjs
@@ -1,135 +1,392 @@
-import { HandLandmarker, GestureRecognizer, FilesetResolver } from '@mediapipe/tasks-vision';
-import { Script, Vec3 } from 'playcanvas';
+import { FilesetResolver, GestureRecognizer } from '@mediapipe/tasks-vision';
+import { Script } from 'playcanvas';
 
+/** The number of landmarks that MediaPipe reports for each hand. */
+const NUM_LANDMARKS = 21;
+
+/** The maximum wrist travel between inferences (in normalized units) for slot matching. */
+const MAX_JUMP = 0.35;
+
+/** The number of inference frames a hand may go undetected before its slot is released. */
+const MAX_MISSED_FRAMES = 5;
+
+/**
+ * Detects hands in a camera feed using MediaPipe's gesture recognizer and fires events
+ * describing them. The script performs no rendering itself - it is a data source for other
+ * scripts (like `handVisuals`) and for the host page.
+ *
+ * Each detected hand is assigned to a persistent slot (0 to maxNumHands - 1) by matching
+ * wrist positions between frames, so a slot reliably refers to the same physical hand even
+ * when MediaPipe's detection order changes. Landmark positions are exponentially smoothed at
+ * render rate and converted to viewport pixels, accounting for the `object-fit: cover`
+ * cropping of the video element created by the `cameraFeed` script.
+ *
+ * Fires the following events on the application:
+ *
+ * - `hands:ready` - Fired once the model is loaded and warmed up.
+ * - `hands:update` - Fired every frame with an array of active hands. Each entry is
+ *   `{ slot, handedness, gesture: { name, score }, screenLandmarks, landmarks }` where
+ *   `screenLandmarks` holds 21 smoothed `{ x, y, z }` entries in viewport pixels (z is
+ *   MediaPipe's normalized depth hint) and `landmarks` holds the latest raw normalized
+ *   landmarks. Entries and arrays are reused between frames - copy anything you keep.
+ * - `hand:gesture` - Fired with (slot, name, score) when a hand's gesture changes and has
+ *   remained stable for `stableFrames` inference frames. The name is one of MediaPipe's
+ *   canned gestures (Closed_Fist, Open_Palm, Pointing_Up, Thumb_Down, Thumb_Up, Victory,
+ *   ILoveYou) or 'None'.
+ * - `hand:lost` - Fired with (slot) when a tracked hand disappears.
+ */
 export class HandGestureController extends Script {
     static scriptName = 'handGestureController';
 
     /**
-     * Maximum number of hands to detect
+     * The maximum number of hands to track.
      * @type {number}
      * @attribute
      */
     maxNumHands = 2;
 
     /**
-     * Whether to mirror the input
+     * Whether the camera feed is displayed mirrored. Landmark coordinates and handedness
+     * are flipped to match.
      * @type {boolean}
      * @attribute
      */
     mirror = true;
 
     /**
-     * @type {HandLandmarker}
-     * @private
+     * The minimum classification score for a gesture to be considered.
+     * @type {number}
+     * @attribute
      */
-    handLandmarker;
+    minScore = 0.6;
 
     /**
-     * @type {GestureRecognizer}
-     * @private
+     * The number of consecutive inference frames a gesture must persist before it is reported.
+     * @type {number}
+     * @attribute
      */
-    gestureRecognizer;
+    stableFrames = 3;
 
     /**
-     * @type {HTMLCanvasElement}
+     * The exponential smoothing rate applied to landmark positions. Higher is more responsive.
+     * @type {number}
+     * @attribute
+     */
+    smoothing = 18;
+
+    /**
+     * @type {GestureRecognizer|null}
      * @private
      */
-    offscreenCanvas = null;
+    recognizer = null;
+
+    /**
+     * @type {HTMLVideoElement|null}
+     * @private
+     */
+    video = null;
+
+    /** @private */
+    _slots = [];
+
+    /** @private */
+    _activeHands = [];
+
+    /** @private */
+    _lastVideoTime = -1;
+
+    /** @private */
+    _lastTimestamp = 0;
+
+    /** @private */
+    _destroyed = false;
 
     async initialize() {
+        for (let i = 0; i < this.maxNumHands; i++) {
+            this._slots.push(this._createSlot(i));
+        }
+
+        // The cameraFeed script announces its video element; fall back to querying the DOM
+        const onCameraReady = (video) => {
+            this.video = video;
+        };
+        this.app.on('camera:ready', onCameraReady);
+
+        this.on('destroy', () => {
+            this._destroyed = true;
+            this.app.off('camera:ready', onCameraReady);
+            this.recognizer?.close();
+            this.recognizer = null;
+        });
+
         const wasmFileset = await FilesetResolver.forVisionTasks(
             '../node_modules/@mediapipe/tasks-vision/wasm'
         );
+        if (this._destroyed) return;
 
-        // Initialize hand landmarker
-        this.handLandmarker = await HandLandmarker.createFromOptions(wasmFileset, {
+        const recognizer = await GestureRecognizer.createFromOptions(wasmFileset, {
             baseOptions: {
-                modelAssetPath: 'https://storage.googleapis.com/mediapipe-models/hand_landmarker/hand_landmarker/float16/1/hand_landmarker.task',
+                modelAssetPath: 'https://storage.googleapis.com/mediapipe-models/gesture_recognizer/gesture_recognizer/float16/1/gesture_recognizer.task',
                 delegate: 'GPU'
             },
             numHands: this.maxNumHands,
             runningMode: 'VIDEO'
         });
+        if (this._destroyed) {
+            recognizer.close();
+            return;
+        }
 
-        // Initialize gesture recognizer
-        this.gestureRecognizer = await GestureRecognizer.createFromOptions(wasmFileset, {
-            baseOptions: {
-                modelAssetPath: 'https://storage.googleapis.com/mediapipe-models/gesture_recognizer/gesture_recognizer/float16/1/gesture_recognizer.task',
-                delegate: 'GPU'
-            },
-            runningMode: 'VIDEO'
-        });
+        // Warm up the recognizer on a blank frame so that the first real inference (which
+        // compiles GPU shaders) does not stall the experience once hands appear
+        const warmup = document.createElement('canvas');
+        warmup.width = 64;
+        warmup.height = 64;
+        warmup.getContext('2d').fillRect(0, 0, 64, 64);
+        recognizer.recognizeForVideo(warmup, this._nextTimestamp());
+
+        this.recognizer = recognizer;
+        this.app.fire('hands:ready');
     }
 
+    /**
+     * @param {number} dt - The delta time since the last frame in seconds.
+     */
     update(dt) {
-        if (!this.handLandmarker || !this.gestureRecognizer) return;
+        if (!this.recognizer) return;
 
-        const video = document.querySelector('video');
-        if (!video || video.readyState < HTMLMediaElement.HAVE_ENOUGH_DATA) return;
-
-        const inputElement = this.prepareInputElement(video);
-
-        // Detect hand landmarks
-        const handResults = this.handLandmarker.detectForVideo(inputElement, Date.now());
-
-        // Recognize gestures
-        const gestureResults = this.gestureRecognizer.recognizeForVideo(inputElement, Date.now());
-
-        this.processResults(handResults, gestureResults);
-    }
-
-    prepareInputElement(video) {
-        // Mirror handling code similar to face-detection.mjs
-        if (this.mirror) {
-            if (!this.offscreenCanvas) {
-                this.offscreenCanvas = document.createElement('canvas');
-                this.offscreenCtx = this.offscreenCanvas.getContext('2d');
-            }
-
-            this.offscreenCanvas.width = video.videoWidth;
-            this.offscreenCanvas.height = video.videoHeight;
-
-            this.offscreenCtx.save();
-            this.offscreenCtx.scale(-1, 1);
-            this.offscreenCtx.drawImage(video, -video.videoWidth, 0, video.videoWidth, video.videoHeight);
-            this.offscreenCtx.restore();
-
-            return this.offscreenCanvas;
+        if (!this.video) {
+            this.video = document.querySelector('video');
+            if (!this.video) return;
         }
 
-        return video;
-    }
+        const video = this.video;
+        if (video.readyState < HTMLMediaElement.HAVE_ENOUGH_DATA || !video.videoWidth) return;
 
-    processResults(handResults, gestureResults) {
-        // Fire events for hand landmarks
-        if (handResults.landmarks) {
-            this.app.fire('hands:landmarks', handResults.landmarks);
-
-            // Calculate hand position in 3D space
-            handResults.landmarks.forEach((landmarks, handIndex) => {
-                // Use wrist position (landmark 0) as hand position
-                const wrist = landmarks[0];
-                const handPosition = new Vec3(
-                    (wrist.x - 0.5) * 2, // Convert 0-1 to -1 to 1
-                    (0.5 - wrist.y) * 2, // Flip Y and convert to -1 to 1
-                    -wrist.z * 5 // Scale Z for better depth perception
-                );
-
-                this.app.fire('hand:position', { handIndex, position: handPosition });
-            });
+        // Run inference only when the video has produced a new frame (webcams typically run
+        // at ~30Hz while the app renders at 60Hz or more)
+        if (video.currentTime !== this._lastVideoTime) {
+            this._lastVideoTime = video.currentTime;
+            this._processResults(this.recognizer.recognizeForVideo(video, this._nextTimestamp()));
         }
 
-        // Process gestures
-        if (gestureResults.gestures && gestureResults.gestures.length > 0) {
-            gestureResults.gestures.forEach((gestureArray, handIndex) => {
-                if (gestureArray.length > 0) {
-                    // Get the most confident gesture
-                    const { categoryName, score } = gestureArray[0];
+        // Smooth landmarks at render rate and publish the active hands
+        const k = 1 - Math.exp(-this.smoothing * dt);
+        this._activeHands.length = 0;
 
-                    // Fire event with gesture info
-                    this.app.fire('hand:gesture', handIndex, categoryName, score);
+        for (const slot of this._slots) {
+            if (!slot.active) continue;
+
+            for (let i = 0; i < NUM_LANDMARKS; i++) {
+                const raw = slot.raw[i];
+                const smooth = slot.smooth[i];
+                if (slot.seeded) {
+                    smooth.x += (raw.x - smooth.x) * k;
+                    smooth.y += (raw.y - smooth.y) * k;
+                    smooth.z += (raw.z - smooth.z) * k;
+                } else {
+                    smooth.x = raw.x;
+                    smooth.y = raw.y;
+                    smooth.z = raw.z;
                 }
-            });
+                this._toScreen(smooth, slot.payload.screenLandmarks[i]);
+            }
+            slot.seeded = true;
+            slot.payload.handedness = slot.handedness;
+            this._activeHands.push(slot.payload);
+        }
+
+        this.app.fire('hands:update', this._activeHands);
+    }
+
+    /**
+     * Returns a strictly increasing timestamp in milliseconds, as required by MediaPipe's
+     * VIDEO running mode.
+     * @returns {number} The timestamp.
+     * @private
+     */
+    _nextTimestamp() {
+        const now = performance.now();
+        this._lastTimestamp = now > this._lastTimestamp ? now : this._lastTimestamp + 1;
+        return this._lastTimestamp;
+    }
+
+    /**
+     * Creates an empty tracking slot with preallocated, reusable landmark storage.
+     * @param {number} index - The slot index.
+     * @returns {object} The slot.
+     * @private
+     */
+    _createSlot(index) {
+        const raw = [];
+        const smooth = [];
+        const screenLandmarks = [];
+        for (let i = 0; i < NUM_LANDMARKS; i++) {
+            raw.push({ x: 0, y: 0, z: 0 });
+            smooth.push({ x: 0, y: 0, z: 0 });
+            screenLandmarks.push({ x: 0, y: 0, z: 0 });
+        }
+        const gesture = { name: 'None', score: 0 };
+        return {
+            active: false,
+            seeded: false,
+            missed: 0,
+            handedness: '',
+            pendingName: null,
+            pendingCount: 0,
+            raw,
+            smooth,
+            gesture,
+            payload: { slot: index, handedness: '', gesture, screenLandmarks, landmarks: raw }
+        };
+    }
+
+    /**
+     * Converts a normalized landmark to viewport pixels, accounting for the cover-fit
+     * cropping of the full-viewport video element.
+     * @param {{ x: number, y: number, z: number }} lm - The normalized landmark.
+     * @param {{ x: number, y: number, z: number }} out - The screen-space result.
+     * @private
+     */
+    _toScreen(lm, out) {
+        const canvas = this.app.graphicsDevice.canvas;
+        const width = canvas.clientWidth;
+        const height = canvas.clientHeight;
+        const scale = Math.max(width / this.video.videoWidth, height / this.video.videoHeight);
+        const displayWidth = this.video.videoWidth * scale;
+        const displayHeight = this.video.videoHeight * scale;
+        out.x = (width - displayWidth) * 0.5 + lm.x * displayWidth;
+        out.y = (height - displayHeight) * 0.5 + lm.y * displayHeight;
+        out.z = lm.z;
+    }
+
+    /**
+     * Assigns detections to tracking slots and updates them.
+     * @param {import('@mediapipe/tasks-vision').GestureRecognizerResult} results - The
+     * recognition results for the latest video frame.
+     * @private
+     */
+    _processResults(results) {
+        const detections = results.landmarks || [];
+        const slots = this._slots;
+        const slotTaken = slots.map(() => false);
+        const detectionSlot = detections.map(() => -1);
+
+        // Greedily match detections to active slots by wrist proximity
+        const pairs = [];
+        for (let s = 0; s < slots.length; s++) {
+            if (!slots[s].active) continue;
+            for (let d = 0; d < detections.length; d++) {
+                const wrist = detections[d][0];
+                const wx = this.mirror ? 1 - wrist.x : wrist.x;
+                const dx = wx - slots[s].raw[0].x;
+                const dy = wrist.y - slots[s].raw[0].y;
+                const dist = Math.sqrt(dx * dx + dy * dy);
+                if (dist < MAX_JUMP) {
+                    pairs.push({ s, d, dist });
+                }
+            }
+        }
+        pairs.sort((a, b) => a.dist - b.dist);
+        for (const pair of pairs) {
+            if (slotTaken[pair.s] || detectionSlot[pair.d] !== -1) continue;
+            slotTaken[pair.s] = true;
+            detectionSlot[pair.d] = pair.s;
+        }
+
+        // Unmatched detections claim a free slot (preferring inactive ones)
+        for (let d = 0; d < detections.length; d++) {
+            if (detectionSlot[d] !== -1) continue;
+            let free = slots.findIndex((slot, s) => !slot.active && !slotTaken[s]);
+            if (free === -1) free = slotTaken.findIndex(taken => !taken);
+            if (free === -1) continue;
+            slotTaken[free] = true;
+            detectionSlot[d] = free;
+            this._activateSlot(slots[free]);
+        }
+
+        // Update matched slots and age out the rest
+        for (let d = 0; d < detections.length; d++) {
+            if (detectionSlot[d] !== -1) {
+                this._updateSlot(detectionSlot[d], results, d);
+            }
+        }
+        for (let s = 0; s < slots.length; s++) {
+            if (!slots[s].active || slotTaken[s]) continue;
+            slots[s].missed++;
+            if (slots[s].missed > MAX_MISSED_FRAMES) {
+                slots[s].active = false;
+                this.app.fire('hand:lost', s);
+            }
+        }
+    }
+
+    /**
+     * Resets a slot for a newly acquired hand.
+     * @param {object} slot - The slot to reset.
+     * @private
+     */
+    _activateSlot(slot) {
+        slot.active = true;
+        slot.seeded = false;
+        slot.missed = 0;
+        slot.handedness = '';
+        slot.gesture.name = 'None';
+        slot.gesture.score = 0;
+        slot.pendingName = null;
+        slot.pendingCount = 0;
+    }
+
+    /**
+     * Copies a detection into a slot and steps its gesture hysteresis.
+     * @param {number} s - The slot index.
+     * @param {import('@mediapipe/tasks-vision').GestureRecognizerResult} results - The
+     * recognition results.
+     * @param {number} d - The detection index within the results.
+     * @private
+     */
+    _updateSlot(s, results, d) {
+        const slot = this._slots[s];
+        slot.missed = 0;
+
+        // Copy the landmarks, flipping x when mirrored
+        const landmarks = results.landmarks[d];
+        for (let i = 0; i < NUM_LANDMARKS; i++) {
+            const lm = landmarks[i];
+            const raw = slot.raw[i];
+            raw.x = this.mirror ? 1 - lm.x : lm.x;
+            raw.y = lm.y;
+            raw.z = lm.z;
+        }
+
+        // MediaPipe's handedness assumes a pre-mirrored (selfie) input image; ours is the
+        // raw camera frame, so the label is swapped to reflect the user's actual hand
+        const handedness = results.handedness[d]?.[0]?.categoryName;
+        if (handedness) {
+            slot.handedness = handedness === 'Left' ? 'Right' : 'Left';
+        }
+
+        // Report a gesture change only once it has been stable for stableFrames inferences
+        const top = results.gestures[d]?.[0];
+        const name = (top && top.score >= this.minScore) ? top.categoryName : 'None';
+        const score = name === 'None' ? 0 : top.score;
+
+        if (name === slot.gesture.name) {
+            slot.gesture.score = score;
+            slot.pendingName = null;
+            slot.pendingCount = 0;
+        } else if (name === slot.pendingName) {
+            slot.pendingCount++;
+            if (slot.pendingCount >= this.stableFrames) {
+                slot.gesture.name = name;
+                slot.gesture.score = score;
+                slot.pendingName = null;
+                slot.pendingCount = 0;
+                this.app.fire('hand:gesture', s, name, score);
+            }
+        } else {
+            slot.pendingName = name;
+            slot.pendingCount = 1;
         }
     }
 }

--- a/examples/assets/scripts/hand-visuals.mjs
+++ b/examples/assets/scripts/hand-visuals.mjs
@@ -1,0 +1,846 @@
+import { GestureRecognizer } from '@mediapipe/tasks-vision';
+import {
+    BLEND_ADDITIVEALPHA,
+    CULLFACE_NONE,
+    Entity,
+    PIXELFORMAT_RGBA8,
+    Script,
+    StandardMaterial,
+    Texture,
+    Vec3
+} from 'playcanvas';
+
+/** The number of landmarks that MediaPipe reports for each hand. */
+const NUM_LANDMARKS = 21;
+
+/** The distance in front of the camera, in world units, at which visuals are placed. */
+const DEPTH = 2;
+
+/** The z scale of the flat glow quads (the camera never rotates, so no billboarding). */
+const QUAD_DEPTH = 0.001;
+
+/** Landmark indices. */
+const WRIST = 0;
+const INDEX_TIP = 8;
+const MIDDLE_TIP = 12;
+const FINGERTIPS = [4, 8, 12, 16, 20];
+const PALM = [0, 5, 9, 13, 17];
+
+/** Skeleton sizing in CSS pixels. */
+const JOINT_PX = 13;
+const TIP_PX = 20;
+const BONE_PX = 5;
+
+/** Per-slot hand colors: cyan and magenta. */
+const HAND_COLORS = [
+    [0.1, 0.85, 1],
+    [1, 0.25, 0.85]
+];
+
+/** Accent colors for gesture bursts. */
+const GESTURE_COLORS = {
+    Thumb_Up: [1, 0.65, 0.15],
+    Thumb_Down: [0.4, 0.5, 1],
+    Victory: [0.3, 1, 0.5],
+    ILoveYou: [1, 0.25, 0.45],
+    Pointing_Up: [1, 1, 1]
+};
+
+/** The overbright tint of the index fingertip while Pointing_Up is held. */
+const COMET_COLOR = [4.5, 4.5, 4.5];
+
+/** Orb layer sizes (CSS pixels), base opacities and pulse amplitudes. */
+const ORB_SIZES = [44, 100, 210];
+const ORB_ALPHAS = [0.95, 0.5, 0.2];
+const ORB_PULSES = [0.08, 0.06, 0.04];
+
+function rand(scale) {
+    return (Math.random() - 0.5) * scale;
+}
+
+function easeOutCubic(t) {
+    return 1 - Math.pow(1 - t, 3);
+}
+
+function easeInQuad(t) {
+    return t * t;
+}
+
+/**
+ * Writes an intensity-scaled RGB color into a Float32Array uniform.
+ * @param {Float32Array} target - The destination array.
+ * @param {number[]} rgb - The base color.
+ * @param {number} intensity - The brightness multiplier.
+ */
+function setGlowColor(target, rgb, intensity) {
+    target[0] = rgb[0] * intensity;
+    target[1] = rgb[1] * intensity;
+    target[2] = rgb[2] * intensity;
+}
+
+/**
+ * Lerps a Float32Array color towards a target color in place.
+ * @param {Float32Array} color - The color to modify.
+ * @param {Float32Array|number[]} to - The target color.
+ * @param {number} k - The interpolation factor.
+ */
+function lerpColor(color, to, k) {
+    color[0] += (to[0] - color[0]) * k;
+    color[1] += (to[1] - color[1]) * k;
+    color[2] += (to[2] - color[2]) * k;
+}
+
+/**
+ * Renders neon visuals for hands tracked by the `handGestureController` script:
+ *
+ * - A glowing skeleton (joints and bones) per hand, colored per slot.
+ * - A sparkle trail streaming from the index fingertip (boosted into a comet by the
+ *   Pointing_Up gesture).
+ * - An energy orb that charges above the palm on Open_Palm and is crushed into a burst
+ *   by Closed_Fist.
+ * - A color-coded particle burst for each recognized gesture.
+ * - A multicolored celebration burst when the application fires `gestures:complete`.
+ *
+ * Everything is drawn with a single additive material and a procedural glow texture,
+ * positioned in world space via `screenToWorld` so it aligns with the camera feed behind
+ * the transparent canvas. Attach this script to the camera entity, after the
+ * `handGestureController` script.
+ */
+export class HandVisuals extends Script {
+    static scriptName = 'handVisuals';
+
+    /** @private */
+    _root = null;
+
+    /** @private */
+    _texture = null;
+
+    /** @private */
+    _material = null;
+
+    /** @private */
+    _states = [];
+
+    /** @private */
+    _fx = [];
+
+    /** @private */
+    _fxNext = 0;
+
+    /** @private */
+    _hands = [];
+
+    /** @private */
+    _worldPerPixel = 0.001;
+
+    /** @private */
+    _tmpA = new Vec3();
+
+    /** @private */
+    _tmpB = new Vec3();
+
+    /** @private */
+    _tmpC = new Vec3();
+
+    initialize() {
+        this._root = new Entity('hand-visuals');
+        this.app.root.addChild(this._root);
+
+        this._texture = this._createGlowTexture();
+        this._material = this._createGlowMaterial(this._texture);
+
+        for (let i = 0; i < HAND_COLORS.length; i++) {
+            this._states.push(this._createHandState(i));
+        }
+        for (let i = 0; i < 160; i++) {
+            this._fx.push(this._createFxSprite(i));
+        }
+
+        const onHandsUpdate = (hands) => {
+            this._hands = hands;
+        };
+        const onGesture = (slot, name) => this._onGesture(slot, name);
+        const onHandLost = slot => this._onHandLost(slot);
+        const onCelebrate = () => this._celebrate();
+
+        this.app.on('hands:update', onHandsUpdate);
+        this.app.on('hand:gesture', onGesture);
+        this.app.on('hand:lost', onHandLost);
+        this.app.on('gestures:complete', onCelebrate);
+
+        this.on('destroy', () => {
+            this.app.off('hands:update', onHandsUpdate);
+            this.app.off('hand:gesture', onGesture);
+            this.app.off('hand:lost', onHandLost);
+            this.app.off('gestures:complete', onCelebrate);
+            this._root.destroy();
+            this._material.destroy();
+            this._texture.destroy();
+        });
+    }
+
+    /**
+     * @param {number} dt - The delta time since the last frame in seconds.
+     */
+    update(dt) {
+        const camera = this.entity.camera;
+        if (!camera) return;
+
+        // World units per CSS pixel at the working depth (fov is vertical)
+        const canvas = this.app.graphicsDevice.canvas;
+        this._worldPerPixel = 2 * DEPTH * Math.tan(camera.fov * Math.PI / 360) / canvas.clientHeight;
+
+        for (const state of this._states) {
+            state.payload = null;
+        }
+        for (const hand of this._hands) {
+            const state = this._states[hand.slot];
+            if (state) state.payload = hand;
+        }
+
+        for (const state of this._states) {
+            this._updateHand(state, dt, camera);
+        }
+        this._updateFx(dt);
+    }
+
+    /**
+     * Creates a soft radial glow texture.
+     * @returns {Texture} The texture.
+     * @private
+     */
+    _createGlowTexture() {
+        const size = 128;
+        const canvas = document.createElement('canvas');
+        canvas.width = size;
+        canvas.height = size;
+
+        const ctx = canvas.getContext('2d');
+        const gradient = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
+        gradient.addColorStop(0, 'rgba(255, 255, 255, 1)');
+        gradient.addColorStop(0.3, 'rgba(255, 255, 255, 0.6)');
+        gradient.addColorStop(0.65, 'rgba(255, 255, 255, 0.15)');
+        gradient.addColorStop(1, 'rgba(255, 255, 255, 0)');
+        ctx.fillStyle = gradient;
+        ctx.fillRect(0, 0, size, size);
+
+        const texture = new Texture(this.app.graphicsDevice, {
+            width: size,
+            height: size,
+            format: PIXELFORMAT_RGBA8,
+            mipmaps: false
+        });
+        texture.setSource(canvas);
+        texture.upload();
+
+        return texture;
+    }
+
+    /**
+     * Creates the shared additive glow material. Individual mesh instances tint and fade
+     * it through the `material_emissive` and `material_opacity` uniform overrides.
+     * @param {Texture} texture - The glow texture.
+     * @returns {StandardMaterial} The material.
+     * @private
+     */
+    _createGlowMaterial(texture) {
+        const material = new StandardMaterial();
+        material.useLighting = false;
+        material.diffuse.set(0, 0, 0);
+        material.emissive.set(1, 1, 1);
+        material.emissiveMap = texture;
+        material.opacityMap = texture;
+        material.blendType = BLEND_ADDITIVEALPHA;
+        material.depthWrite = false;
+        material.cull = CULLFACE_NONE;
+        material.update();
+        return material;
+    }
+
+    /**
+     * Creates a pooled glow quad with its own color and opacity uniform overrides.
+     * @param {string} name - The entity name.
+     * @returns {object} The quad record.
+     * @private
+     */
+    _createQuad(name) {
+        const entity = new Entity(name);
+        entity.addComponent('render', {
+            type: 'box',
+            material: this._material,
+            castShadows: false,
+            receiveShadows: false
+        });
+        entity.enabled = false;
+        this._root.addChild(entity);
+
+        const mi = entity.render.meshInstances[0];
+        const color = new Float32Array([1, 1, 1]);
+        mi.setParameter('material_emissive', color);
+        mi.setParameter('material_opacity', 0);
+
+        return { entity, mi, color };
+    }
+
+    /**
+     * Creates the pooled visuals and bookkeeping for one hand slot.
+     * @param {number} slot - The slot index.
+     * @returns {object} The hand state.
+     * @private
+     */
+    _createHandState(slot) {
+        const rgb = HAND_COLORS[slot];
+
+        const joints = [];
+        for (let i = 0; i < NUM_LANDMARKS; i++) {
+            const record = this._createQuad(`joint-${slot}-${i}`);
+            record.tip = FINGERTIPS.includes(i);
+            setGlowColor(record.color, rgb, record.tip ? 3 : 1.9);
+            joints.push(record);
+        }
+
+        const bones = GestureRecognizer.HAND_CONNECTIONS.map((connection, i) => {
+            const record = this._createQuad(`bone-${slot}-${i}`);
+            setGlowColor(record.color, rgb, 1.1);
+            return record;
+        });
+
+        const layers = [];
+        for (let i = 0; i < ORB_SIZES.length; i++) {
+            const record = this._createQuad(`orb-${slot}-${i}`);
+            setGlowColor(record.color, rgb, i === 0 ? 3.5 : 1.4);
+            if (i === 0) lerpColor(record.color, [4, 4, 4], 0.45);
+            layers.push(record);
+        }
+
+        const world = [];
+        for (let i = 0; i < NUM_LANDMARKS; i++) {
+            world.push(new Vec3());
+        }
+
+        const tipColor = new Float32Array(3);
+        setGlowColor(tipColor, rgb, 3);
+
+        return {
+            slot,
+            rgb,
+            payload: null,
+            wasPresent: false,
+            alpha: 0,
+            visible: false,
+            joints,
+            bones,
+            world,
+            tipColor,
+            comet: false,
+            trailAccum: 0,
+            prevTip: new Vec3(),
+            tipVel: new Vec3(),
+            hasPrevTip: false,
+            orb: {
+                state: 'idle',
+                t: 0,
+                phase: 0,
+                seeded: false,
+                emitAccum: 0,
+                pos: new Vec3(),
+                layers
+            }
+        };
+    }
+
+    /**
+     * Creates one pooled particle sprite.
+     * @param {number} i - The sprite index.
+     * @returns {object} The sprite record.
+     * @private
+     */
+    _createFxSprite(i) {
+        const record = this._createQuad(`fx-${i}`);
+        record.active = false;
+        record.age = 0;
+        record.life = 1;
+        record.size = 10;
+        record.alpha = 1;
+        record.gravity = 0;
+        record.drag = 0;
+        record.pos = new Vec3();
+        record.vel = new Vec3();
+        return record;
+    }
+
+    /**
+     * Updates the skeleton, trail and orb of one hand slot.
+     * @param {object} state - The hand state.
+     * @param {number} dt - The delta time in seconds.
+     * @param {import('playcanvas').CameraComponent} camera - The camera component.
+     * @private
+     */
+    _updateHand(state, dt, camera) {
+        const present = !!state.payload;
+
+        // Ease overall visibility so hands fade in and out
+        const target = present ? 1 : 0;
+        state.alpha += (target - state.alpha) * Math.min(1, 1 - Math.exp(-10 * dt));
+
+        const visible = state.alpha > 0.01;
+        if (visible !== state.visible) {
+            state.visible = visible;
+            for (const joint of state.joints) joint.entity.enabled = visible;
+            for (const bone of state.bones) bone.entity.enabled = visible;
+        }
+
+        if (present) {
+            const landmarks = state.payload.screenLandmarks;
+
+            // Project the smoothed screen-space landmarks into world space
+            for (let i = 0; i < NUM_LANDMARKS; i++) {
+                camera.screenToWorld(landmarks[i].x, landmarks[i].y, DEPTH, state.world[i]);
+            }
+
+            // A little radial poof to greet a newly acquired hand
+            if (!state.wasPresent) {
+                this._burstRadial(state.world[WRIST], state.rgb, 12, 1.2, 2.2);
+            }
+
+            // The index fingertip glows white-hot while Pointing_Up is held
+            lerpColor(state.joints[INDEX_TIP].color, state.comet ? COMET_COLOR : state.tipColor, Math.min(1, 1 - Math.exp(-8 * dt)));
+
+            this._updateTrail(state, dt);
+        } else {
+            state.hasPrevTip = false;
+        }
+
+        if (visible) {
+            const wpp = this._worldPerPixel;
+            const landmarks = present ? state.payload.screenLandmarks : null;
+
+            for (let i = 0; i < NUM_LANDMARKS; i++) {
+                const joint = state.joints[i];
+                joint.entity.setLocalPosition(state.world[i]);
+
+                // MediaPipe z is negative towards the camera - use it to swell nearer joints
+                const zBoost = landmarks ? Math.max(0.7, Math.min(1.7, 1 - landmarks[i].z * 5)) : 1;
+                const s = (joint.tip ? TIP_PX : JOINT_PX) * zBoost * wpp;
+                joint.entity.setLocalScale(s, s, QUAD_DEPTH);
+                joint.mi.setParameter('material_opacity', state.alpha * 0.95);
+            }
+
+            const connections = GestureRecognizer.HAND_CONNECTIONS;
+            for (let i = 0; i < connections.length; i++) {
+                const bone = state.bones[i];
+                const a = state.world[connections[i].start];
+                const b = state.world[connections[i].end];
+
+                this._tmpA.add2(a, b).mulScalar(0.5);
+                bone.entity.setLocalPosition(this._tmpA);
+
+                const dx = b.x - a.x;
+                const dy = b.y - a.y;
+                const length = Math.sqrt(dx * dx + dy * dy);
+                bone.entity.setLocalEulerAngles(0, 0, Math.atan2(dy, dx) * 180 / Math.PI);
+                bone.entity.setLocalScale(length, BONE_PX * wpp, QUAD_DEPTH);
+                bone.mi.setParameter('material_opacity', state.alpha * 0.55);
+            }
+        }
+
+        this._updateOrb(state, dt);
+        state.wasPresent = present;
+    }
+
+    /**
+     * Emits trail sparkles from the index fingertip.
+     * @param {object} state - The hand state.
+     * @param {number} dt - The delta time in seconds.
+     * @private
+     */
+    _updateTrail(state, dt) {
+        const tip = state.world[INDEX_TIP];
+
+        if (state.hasPrevTip && dt > 0) {
+            this._tmpA.sub2(tip, state.prevTip).mulScalar(1 / dt);
+            state.tipVel.lerp(state.tipVel, this._tmpA, 0.5);
+        }
+        state.prevTip.copy(tip);
+        state.hasPrevTip = true;
+
+        state.trailAccum += dt * (state.comet ? 90 : 26);
+        let count = Math.floor(state.trailAccum);
+        state.trailAccum -= count;
+        count = Math.min(count, 5);
+
+        for (let i = 0; i < count; i++) {
+            this._tmpA.set(tip.x + rand(0.04), tip.y + rand(0.04), tip.z);
+            this._tmpB.set(
+                state.tipVel.x * 0.2 + rand(0.3),
+                state.tipVel.y * 0.2 + rand(0.3) + 0.15,
+                0
+            );
+            if (state.comet) {
+                this._spawn(this._tmpA, this._tmpB, GESTURE_COLORS.Pointing_Up, 3.2, {
+                    life: 0.45, size: 15, gravity: 0.2, drag: 2
+                });
+            } else {
+                this._spawn(this._tmpA, this._tmpB, state.rgb, 2.2, {
+                    life: 0.6, size: 9, gravity: 0.25, drag: 2.5
+                });
+            }
+        }
+    }
+
+    /**
+     * Updates the energy orb of one hand slot.
+     * @param {object} state - The hand state.
+     * @param {number} dt - The delta time in seconds.
+     * @private
+     */
+    _updateOrb(state, dt) {
+        const orb = state.orb;
+        const active = orb.state !== 'idle';
+
+        for (const layer of orb.layers) {
+            if (layer.entity.enabled !== active) layer.entity.enabled = active;
+        }
+        if (!active) return;
+
+        // The orb hovers above the palm and chases it softly
+        if (state.payload) {
+            this._palmCenter(state, this._tmpA);
+            this._tmpA.y += 0.42;
+            if (!orb.seeded) {
+                orb.pos.copy(this._tmpA);
+                orb.seeded = true;
+            } else {
+                orb.pos.lerp(orb.pos, this._tmpA, Math.min(1, 1 - Math.exp(-12 * dt)));
+            }
+        }
+
+        orb.phase += dt * 4.5;
+
+        let scale = 1;
+        let alpha = 1;
+        let boost = 1;
+
+        switch (orb.state) {
+            case 'in':
+                orb.t = Math.min(1, orb.t + dt / 0.35);
+                scale = easeOutCubic(orb.t);
+                if (orb.t >= 1) orb.state = 'active';
+                break;
+            case 'out':
+                orb.t = Math.min(1, orb.t + dt / 0.45);
+                alpha = 1 - easeInQuad(orb.t);
+                scale = 1 - 0.25 * orb.t;
+                if (orb.t >= 1) orb.state = 'idle';
+                break;
+            case 'crush':
+                orb.t = Math.min(1, orb.t + dt / 0.22);
+                scale = 1 - 0.85 * easeInQuad(orb.t);
+                boost = 1 + orb.t * 2.5;
+                if (orb.t >= 1) {
+                    orb.state = 'idle';
+                    this._burstRadial(orb.pos, state.rgb, 30, 2.6, 3, { life: 0.75, size: 13, gravity: -0.6, drag: 1.2 });
+                }
+                break;
+            default:
+                break;
+        }
+
+        // Sparkles drift up from an active orb
+        if (orb.state === 'active') {
+            orb.emitAccum += dt * 9;
+            let count = Math.floor(orb.emitAccum);
+            orb.emitAccum -= count;
+            count = Math.min(count, 3);
+            for (let i = 0; i < count; i++) {
+                this._tmpA.set(orb.pos.x + rand(0.3), orb.pos.y + rand(0.3), orb.pos.z);
+                this._tmpB.set(rand(0.4), 0.4 + Math.random() * 0.4, 0);
+                this._spawn(this._tmpA, this._tmpB, state.rgb, 2.4, { life: 0.9, size: 7, drag: 0.5 });
+            }
+        }
+
+        const a = alpha * state.alpha;
+        for (let i = 0; i < orb.layers.length; i++) {
+            const layer = orb.layers[i];
+            const pulse = 1 + ORB_PULSES[i] * Math.sin(orb.phase + i * 1.3);
+            const s = ORB_SIZES[i] * scale * pulse * this._worldPerPixel;
+            layer.entity.setLocalPosition(orb.pos);
+            layer.entity.setLocalScale(s, s, QUAD_DEPTH);
+            layer.mi.setParameter('material_opacity', ORB_ALPHAS[i] * a * boost);
+        }
+    }
+
+    /**
+     * Integrates and fades the active particle sprites.
+     * @param {number} dt - The delta time in seconds.
+     * @private
+     */
+    _updateFx(dt) {
+        const wpp = this._worldPerPixel;
+
+        for (const record of this._fx) {
+            if (!record.active) continue;
+
+            record.age += dt;
+            if (record.age >= record.life) {
+                record.active = false;
+                record.entity.enabled = false;
+                continue;
+            }
+
+            record.vel.y += record.gravity * dt;
+            if (record.drag > 0) {
+                record.vel.mulScalar(Math.max(0, 1 - record.drag * dt));
+            }
+            record.pos.x += record.vel.x * dt;
+            record.pos.y += record.vel.y * dt;
+            record.pos.z += record.vel.z * dt;
+            record.entity.setLocalPosition(record.pos);
+
+            const t = record.age / record.life;
+            const fade = (1 - t) * (1 - t);
+            const s = record.size * (1 - 0.7 * t) * wpp;
+            record.entity.setLocalScale(s, s, QUAD_DEPTH);
+            record.mi.setParameter('material_opacity', record.alpha * fade);
+        }
+    }
+
+    /**
+     * Spawns one particle sprite from the pool.
+     * @param {Vec3} pos - The spawn position.
+     * @param {Vec3} vel - The initial velocity.
+     * @param {number[]} rgb - The base color.
+     * @param {number} intensity - The brightness multiplier.
+     * @param {object} [opts] - The sprite options.
+     * @param {number} [opts.life] - The lifetime in seconds.
+     * @param {number} [opts.size] - The starting size in CSS pixels.
+     * @param {number} [opts.alpha] - The base opacity.
+     * @param {number} [opts.gravity] - The vertical acceleration in world units per second squared.
+     * @param {number} [opts.drag] - The velocity damping factor.
+     * @private
+     */
+    _spawn(pos, vel, rgb, intensity, { life = 0.7, size = 10, alpha = 1, gravity = 0, drag = 0 } = {}) {
+        const record = this._fx[this._fxNext];
+        this._fxNext = (this._fxNext + 1) % this._fx.length;
+
+        record.active = true;
+        record.age = 0;
+        record.life = life;
+        record.size = size;
+        record.alpha = alpha;
+        record.gravity = gravity;
+        record.drag = drag;
+        record.pos.copy(pos);
+        record.vel.copy(vel);
+        setGlowColor(record.color, rgb, intensity);
+        record.entity.setLocalPosition(record.pos);
+        record.entity.enabled = true;
+    }
+
+    /**
+     * Computes the palm center of a hand in world space.
+     * @param {object} state - The hand state.
+     * @param {Vec3} out - The result.
+     * @returns {Vec3} The palm center.
+     * @private
+     */
+    _palmCenter(state, out) {
+        out.set(0, 0, 0);
+        for (const i of PALM) {
+            out.add(state.world[i]);
+        }
+        return out.mulScalar(1 / PALM.length);
+    }
+
+    /**
+     * Spawns a radial burst of sprites.
+     * @param {Vec3} pos - The burst origin.
+     * @param {number[]} rgb - The base color.
+     * @param {number} count - The number of sprites.
+     * @param {number} speed - The base outward speed.
+     * @param {number} intensity - The brightness multiplier.
+     * @param {object} [opts] - Overrides for the sprite options.
+     * @private
+     */
+    _burstRadial(pos, rgb, count, speed, intensity, opts = { life: 0.55, size: 10, gravity: -0.8, drag: 1 }) {
+        for (let i = 0; i < count; i++) {
+            const angle = (i / count) * Math.PI * 2 + rand(0.5);
+            const v = speed * (0.7 + Math.random() * 0.6);
+            this._tmpB.set(Math.cos(angle) * v, Math.sin(angle) * v + 0.2, 0);
+            this._spawn(pos, this._tmpB, rgb, intensity, opts);
+        }
+    }
+
+    /**
+     * Reacts to a stable gesture change on a hand.
+     * @param {number} slot - The hand slot.
+     * @param {string} name - The gesture name.
+     * @private
+     */
+    _onGesture(slot, name) {
+        const state = this._states[slot];
+        if (!state) return;
+
+        state.comet = name === 'Pointing_Up';
+
+        const orb = state.orb;
+
+        if (name === 'Open_Palm') {
+            if (orb.state === 'idle' || orb.state === 'out') {
+                orb.state = 'in';
+                orb.t = 0;
+                orb.seeded = false;
+            }
+            return;
+        }
+
+        if (name === 'Closed_Fist') {
+            if (orb.state === 'in' || orb.state === 'active') {
+                // Crush the orb - the burst fires when the collapse completes
+                orb.state = 'crush';
+                orb.t = 0;
+            } else if (state.payload) {
+                this._burstImplosion(state);
+            }
+            return;
+        }
+
+        // Any other gesture releases the orb gently
+        if (orb.state === 'in' || orb.state === 'active') {
+            orb.state = 'out';
+            orb.t = 0;
+        }
+
+        if (!state.payload) return;
+
+        switch (name) {
+            case 'Thumb_Up':
+                this._burstColumn(state, GESTURE_COLORS.Thumb_Up, 1);
+                break;
+            case 'Thumb_Down':
+                this._burstColumn(state, GESTURE_COLORS.Thumb_Down, -1);
+                break;
+            case 'Victory':
+                this._burstFountain(state.world[INDEX_TIP]);
+                this._burstFountain(state.world[MIDDLE_TIP]);
+                break;
+            case 'ILoveYou':
+                this._palmCenter(state, this._tmpA);
+                this._burstRadial(this._tmpA, GESTURE_COLORS.ILoveYou, 30, 2, 2.8, { life: 0.8, size: 12, gravity: -1, drag: 1.2 });
+                break;
+            case 'Pointing_Up':
+                this._burstRadial(state.world[INDEX_TIP], GESTURE_COLORS.Pointing_Up, 8, 0.9, 3, { life: 0.4, size: 8, drag: 2 });
+                break;
+            default:
+                break;
+        }
+    }
+
+    /**
+     * Spawns a rising or falling column burst from the palm.
+     * @param {object} state - The hand state.
+     * @param {number[]} rgb - The base color.
+     * @param {number} dir - 1 for up, -1 for down.
+     * @private
+     */
+    _burstColumn(state, rgb, dir) {
+        this._palmCenter(state, this._tmpA);
+        for (let i = 0; i < 24; i++) {
+            this._tmpB.set(rand(0.9), dir * (1.5 + Math.random() * 1.5), 0);
+            this._spawn(this._tmpA, this._tmpB, rgb, 2.6, {
+                life: 0.8 + Math.random() * 0.4,
+                size: 11,
+                gravity: dir * -1.6,
+                drag: 0.4
+            });
+        }
+    }
+
+    /**
+     * Spawns an upward fountain burst from a fingertip.
+     * @param {Vec3} tip - The fingertip position.
+     * @private
+     */
+    _burstFountain(tip) {
+        for (let i = 0; i < 14; i++) {
+            this._tmpB.set(rand(1.4), 1.4 + Math.random() * 1.4, 0);
+            this._spawn(tip, this._tmpB, GESTURE_COLORS.Victory, 2.8, {
+                life: 0.7 + Math.random() * 0.3,
+                size: 10,
+                gravity: -1.8,
+                drag: 0.4
+            });
+        }
+    }
+
+    /**
+     * Spawns sprites that converge on the fist, ending in a small flash.
+     * @param {object} state - The hand state.
+     * @private
+     */
+    _burstImplosion(state) {
+        const center = this._palmCenter(state, this._tmpA);
+        const life = 0.32;
+        for (let i = 0; i < 16; i++) {
+            const angle = (i / 16) * Math.PI * 2 + rand(0.4);
+            const radius = 0.5 + Math.random() * 0.15;
+            const dx = Math.cos(angle);
+            const dy = Math.sin(angle);
+            this._tmpB.set(center.x + dx * radius, center.y + dy * radius, center.z);
+            this._tmpC.set(-dx * radius / life, -dy * radius / life, 0);
+            this._spawn(this._tmpB, this._tmpC, state.rgb, 2.4, { life, size: 9, alpha: 0.9 });
+        }
+        // A brief flash at the center
+        this._tmpC.set(0, 0, 0);
+        this._spawn(center, this._tmpC, state.rgb, 3.5, { life: 0.28, size: 42, alpha: 0.85 });
+    }
+
+    /**
+     * Fires a large multicolored burst at the center of the screen.
+     * @private
+     */
+    _celebrate() {
+        const camera = this.entity.camera;
+        if (!camera) return;
+
+        const canvas = this.app.graphicsDevice.canvas;
+        camera.screenToWorld(canvas.clientWidth * 0.5, canvas.clientHeight * 0.45, DEPTH, this._tmpA);
+
+        const palette = [
+            GESTURE_COLORS.Thumb_Up,
+            GESTURE_COLORS.Victory,
+            GESTURE_COLORS.ILoveYou,
+            GESTURE_COLORS.Thumb_Down,
+            HAND_COLORS[0],
+            HAND_COLORS[1]
+        ];
+
+        for (let i = 0; i < 90; i++) {
+            const angle = Math.random() * Math.PI * 2;
+            const speed = 1.4 + Math.random() * 2.2;
+            this._tmpB.set(Math.cos(angle) * speed, Math.sin(angle) * speed + 0.4, 0);
+            this._spawn(this._tmpA, this._tmpB, palette[i % palette.length], 2.8, {
+                life: 0.9 + Math.random() * 0.7,
+                size: 10 + Math.random() * 6,
+                gravity: -0.9,
+                drag: 0.6
+            });
+        }
+    }
+
+    /**
+     * Reacts to a hand disappearing.
+     * @param {number} slot - The hand slot.
+     * @private
+     */
+    _onHandLost(slot) {
+        const state = this._states[slot];
+        if (!state) return;
+
+        state.comet = false;
+        if (state.orb.state === 'in' || state.orb.state === 'active') {
+            state.orb.state = 'out';
+            state.orb.t = 0;
+        }
+    }
+}


### PR DESCRIPTION
## What

The AR Hand Gestures example previously ran MediaPipe hand tracking but only logged results to the console. This rebuilds it into a visual showcase in the spirit of the recent Solar System rework:

- **Neon hand skeletons** - 21 glowing joints + 21 bone beams per hand (cyan / magenta per slot), aligned with the mirrored camera feed, with depth-reactive joint sizing and render-rate smoothing
- **Fingertip light trails** from the index finger; holding Pointing_Up ☝️ turns the trail into a white-hot comet
- **Energy orb interaction** - Open_Palm 🖐️ charges a pulsing three-layer orb above the palm; Closed_Fist ✊ crushes it into a radial burst
- **Color-coded particle bursts** per gesture (gold rising column for 👍, blue falling column for 👎, twin fountains for ✌️, pink radial burst for 🤟, implosion for a bare fist)
- **HUD** - frosted-glass chips that follow each wrist (emoji, gesture, handedness, confidence bar), a status banner (loading → "Show your hands" → camera-error), and a 7-gesture collection legend that triggers a multicolor celebration when completed (the page fires `gestures:complete` back into the engine - a small bidirectional-events demo)

All engine-side rendering lives in a new `hand-visuals.mjs` script: one shared additive-alpha `StandardMaterial` + a procedural radial glow texture, tinted/faded per instance via `meshInstance.setParameter('material_emissive' / 'material_opacity')` overrides - 250 pooled entities, no material clones, no post-processing.

## Why

The example is the repo's main demonstration of wiring engine events to the page, and console logging undersold it. It now shows what the event API can drive while also fixing several latent issues (below).

## Fixes made in passing

- Dropped the redundant `HandLandmarker` - `GestureRecognizer` already returns landmarks + handedness, halving per-frame inference and saving a ~7.5MB model download
- Removed the 25MB HDR sky asset that was loaded for IBL on a scene with zero lit meshes
- Replaced the per-frame full-res offscreen mirror copy with an `x' = 1 - x` coordinate flip (handedness label swapped to match)
- Fixed the broken `hand:position` event (fired as an object, listened to positionally) by redesigning the event API: `hands:ready`, `hands:update`, `hand:gesture` (hysteresis-debounced stable changes only), `hand:lost`
- `Date.now()` → monotonic `performance.now()` timestamps, inference gated on `video.currentTime` advancing (MediaPipe VIDEO mode requires strictly increasing timestamps)
- Hands now keep a **persistent slot identity** via wrist-proximity matching (MediaPipe detection order is not stable across frames), so per-hand coloring/trails/orbs never swap
- Landmark screen mapping compensates for the `object-fit: cover` crop of the video element (verified pixel-exact for 16:9 and 4:3 feeds)
- `camera-feed.mjs` now requests `facingMode: 'user'` (deterministic front camera on mobile) and fires `camera:ready` / `camera:error` app events (additive; `ar-avatar.html` regression-checked)

## Reviewer notes

- ESLint passes (`npm run lint`)
- Verified in-browser with synthetic hand data: skeleton/trails/orb/bursts/legend/celebration, slot matching under detection-order swaps, hysteresis firing exactly once per stable gesture, and the cover-crop math against independent references. The one thing that needs a human is real-webcam feel - tuning constants (colors, sizes, smoothing rate) are grouped at the top of `hand-visuals.mjs`
- MediaPipe handedness assumes selfie (pre-mirrored) input; since the raw frame is now fed to the recognizer, the label is swapped in the controller. Worth a quick sanity check on a real webcam
- The gesture model still loads from `storage.googleapis.com` (unchanged from before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
