### PR TITLE
Fix pc-script name identity

### DIFF
--- a/src/components/script-component.ts
+++ b/src/components/script-component.ts
@@ -90,11 +90,16 @@ interface ScriptEnableChangeEvent extends CustomEvent {
     detail: { enabled: boolean };
 }
 
+interface ScriptNameChangeEvent extends CustomEvent {
+    detail: { oldName: string, newName: string };
+}
+
 // Add this interface before the ScriptComponentElement class
 declare global {
     interface HTMLElementEventMap {
         'scriptattributeschange': ScriptAttributesChangeEvent;
         'scriptenablechange': ScriptEnableChangeEvent;
+        'scriptnamechange': ScriptNameChangeEvent;
     }
 }
 
@@ -116,9 +121,10 @@ class ScriptComponentElement extends ComponentElement {
         // Create mutation observer to watch for child script elements
         this.observer = new MutationObserver(this.handleMutations.bind(this));
 
-        // Listen for script attribute and enable changes
+        // Listen for script attribute, enable and name changes
         this.addEventListener('scriptattributeschange', this.handleScriptAttributesChange.bind(this));
         this.addEventListener('scriptenablechange', this.handleScriptEnableChange.bind(this));
+        this.addEventListener('scriptnamechange', this.handleScriptNameChange.bind(this));
     }
 
     connectedCallback() {
@@ -360,6 +366,38 @@ class ScriptComponentElement extends ComponentElement {
         if (script) {
             script.enabled = event.detail.enabled;
         }
+    }
+
+    /**
+     * Handles a runtime `name` change on a child `pc-script`, swapping the engine script instance
+     * to match. Without this the element would keep pointing at the old-name instance: the old
+     * script would go on running while every subsequent update (attribute changes, enable
+     * changes, destruction on removal) resolved the new name and silently no-opped.
+     *
+     * The new instance is built by the normal creation path, so both attribute channels are
+     * re-applied to it and the declared enabled state is restored.
+     * @param event - The name change event.
+     */
+    private handleScriptNameChange(event: ScriptNameChangeEvent) {
+        const scriptElement = event.target as ScriptElement;
+
+        // Only direct children are managed, matching initComponent's ':scope > pc-script'
+        // contract - the event bubbles, so a deeper pc-script must not be created here
+        if (scriptElement.parentElement !== this) return;
+
+        // Before the component exists there is nothing to swap: initComponent creates from
+        // whatever the name is by then
+        if (!this.component) return;
+
+        // Only tear down the old-name script if this element actually owns it - a duplicate-named
+        // element whose own create() failed must not take down the live script on rename
+        const { oldName } = event.detail;
+        if (oldName && scriptElement._script && this.component.get(oldName) === scriptElement._script) {
+            this.destroyScript(oldName);
+        }
+        scriptElement._script = null;
+
+        this.createScript(scriptElement);
     }
 
     /**

--- a/src/components/script.ts
+++ b/src/components/script.ts
@@ -23,6 +23,9 @@ import { parseBool } from '../utils';
  * whenever either channel changes at runtime. The element's own `name` and `enabled`
  * attributes configure the element itself and are not script attributes.
  *
+ * Changing `name` on a live element destroys the old-name script instance and creates the
+ * new-name one, re-applying both attribute channels to it.
+ *
  * The element becomes ready once its script instance has been created by the parent
  * `<pc-scripts>` element.
  */
@@ -31,7 +34,12 @@ class ScriptElement extends AsyncElement {
 
     private _enabled: boolean = true;
 
-    private _name: string = '';
+    /**
+     * Whether readiness has been signalled. Creation can happen more than once over an
+     * element's life (a runtime `name` change recreates the instance), but `ready` is a
+     * one-shot signal, so only the first successful creation fires it.
+     */
+    private _readySignalled: boolean = false;
 
     /**
      * The Script instance created for this element by its parent `<pc-scripts>` element.
@@ -84,11 +92,20 @@ class ScriptElement extends AsyncElement {
     }
 
     /**
-     * Sets the name of the script to create.
+     * Sets the name of the script to create. The `name` attribute is the single source of truth
+     * (it is what the parent `<pc-scripts>` element reads when creating the instance), so the
+     * property writes through to it — assigning before insertion works as expected:
+     *
+     * ```js
+     * const script = document.createElement('pc-script');
+     * script.name = 'rotate';
+     * scriptsElement.appendChild(script);
+     * await script.ready();
+     * ```
      * @param value - The name.
      */
     set name(value: string) {
-        this._name = value;
+        this.setAttribute('name', value);
     }
 
     /**
@@ -96,7 +113,7 @@ class ScriptElement extends AsyncElement {
      * @returns The name.
      */
     get name() {
-        return this._name;
+        return this.getAttribute('name') ?? '';
     }
 
     /**
@@ -114,6 +131,8 @@ class ScriptElement extends AsyncElement {
      * @ignore
      */
     _onScriptCreated() {
+        if (this._readySignalled) return;
+        this._readySignalled = true;
         this._onReady();
     }
 
@@ -121,7 +140,7 @@ class ScriptElement extends AsyncElement {
         return ['attributes', 'enabled', 'name'];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, oldValue: string, newValue: string) {
         switch (name) {
             case 'attributes':
                 if (newValue === null) {
@@ -138,7 +157,15 @@ class ScriptElement extends AsyncElement {
                 this.enabled = parseBool(newValue, true);
                 break;
             case 'name':
-                this.name = newValue;
+                // The first set is handled by the parent's creation paths (the boot query and
+                // the added-node mutation), so only a genuine rename is signalled here. Note
+                // that setAttribute fires this callback even when the value is unchanged.
+                if (oldValue !== null && oldValue !== newValue) {
+                    this.dispatchEvent(new CustomEvent('scriptnamechange', {
+                        detail: { oldName: oldValue, newName: newValue },
+                        bubbles: true
+                    }));
+                }
                 break;
         }
     }


### PR DESCRIPTION
Fixes #280 — two defects in `pc-script`'s `name` handling.

## 1. Renaming a live element leaked a zombie script

`name` handling only stored the new value. The engine script stayed registered under the old name and kept running `update()`, while every subsequent path (attribute changes, JSON changes, enable changes, `destroyScript` on removal) resolved the *new* name and silently no-opped:

```js
el.setAttribute('name', 'spin');   // engine script 'rotate' keeps running
el.setAttribute('speed', '10');    // silently dropped
el.remove();                       // destroy('spin') no-ops; 'rotate' leaks
```

A runtime rename now dispatches `scriptnamechange`, and `pc-scripts` destroys the old-name instance and creates the new one through the normal creation path — so both attribute channels and the declared enabled state are re-applied to the new instance. Only a genuine rename is signalled (`setAttribute` fires `attributeChangedCallback` even for an unchanged value), and the old instance is torn down only when the element actually owns it, reusing the ownership tracking from #279.

## 2. The `name` property didn't reflect to the attribute

`createScript` reads `getAttribute('name')`, so this created nothing and hung forever:

```js
const s = document.createElement('pc-script');
s.name = 'rotate';
scriptsEl.appendChild(s);
await s.ready();              // never resolved
```

Rather than mirror two fields, the attribute is now the single source of truth — it is what `createScript` reads — and the property writes through to it. That removes the divergence class instead of patching one instance of it.

Since creation can now happen more than once over an element's life, readiness is signalled only on the first successful creation, keeping `ready` a one-shot.

## Verification

This repo has no test harness (`npm test` is a stub), so I verified with a temporary page driving a real `pc-app` with two scripts to rename between, asserting on tick counts, instance identity, the component registry, and `destroy` events. 25 assertions, run against this branch and against `main` as a control:

| | `main` | this branch |
|---|---|---|
| assertions failing | 16 of 25 | **0 of 25** |

The zombie leak reproduced exactly as reported on `main` — after `el.remove()` the old script was still ticking (`spinA +6`) and still registered on the component. Both defects also block each other on `main`: since property-only naming never created a script there, the rename assertions had to be repeated over the attribute path to isolate defect 1 from defect 2.

Regression-checked `fps-controller` (per-property attributes, incl. `entity:` resolution) and `video-texture` (the `attributes` JSON blob) — both still create every script and apply both channels. `npm run lint` and `npm run type-check` clean.

The harness was removed before committing; the diff is source-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
