### PR TITLE
Warn on misplaced elements and create runtime-inserted pc-material

### DIFF
--- a/src/async-element.ts
+++ b/src/async-element.ts
@@ -55,8 +55,10 @@ type AsyncElementTagName = {
 
 /**
  * Waits for the first element matching the given tag name to be fully initialized. Note that the
- * promise never settles if the element cannot finish initializing (for example, a component
- * element that is not inside a `<pc-app>`).
+ * promise never settles if the element cannot finish initializing (for example, a `<pc-script>`
+ * that is not a direct child of `<pc-scripts>`). A component element outside a `<pc-entity>` is
+ * the exception: it still becomes ready, but its `component` is `null`. Either way, a misplaced
+ * element logs a warning naming the parent it requires.
  * @param target - The tag name of the element to wait for (e.g. `'pc-app'`).
  * @returns A promise that resolves with the element once it's ready.
  * @example
@@ -77,8 +79,10 @@ function whenReady<K extends AsyncElementTagName>(target: K): Promise<HTMLElemen
 function whenReady<T extends AsyncElement>(target: T): Promise<T>;
 /**
  * Waits for the first element matching the given CSS selector to be fully initialized. Note that
- * the promise never settles if the element cannot finish initializing (for example, a component
- * element that is not inside a `<pc-app>`).
+ * the promise never settles if the element cannot finish initializing (for example, a `<pc-script>`
+ * that is not a direct child of `<pc-scripts>`). A component element outside a `<pc-entity>` is
+ * the exception: it still becomes ready, but its `component` is `null`. Either way, a misplaced
+ * element logs a warning naming the parent it requires.
  * @param target - A CSS selector matching the element to wait for (e.g. `'#my-app'`).
  * @returns A promise that resolves with the element once it's ready.
  * @example

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -37,12 +37,18 @@ class ComponentElement extends AsyncElement {
 
     async addComponent() {
         const entityElement = this.closestEntity;
-        if (entityElement) {
-            await entityElement.ready();
-            // Add the component to the entity
-            const data = this.getInitialComponentData();
-            this._component = entityElement.entity!.addComponent(this._componentName, data);
+        if (!entityElement) {
+            // A component can only exist on an entity, so an element placed outside one is inert.
+            // It still becomes ready (with a null `component`), so warn rather than fail silently
+            const label = this.id ? ` '${this.id}'` : '';
+            console.warn(`${this.tagName.toLowerCase()}${label} must be a descendant of pc-entity - component not added`);
+            return;
         }
+
+        await entityElement.ready();
+        // Add the component to the entity
+        const data = this.getInitialComponentData();
+        this._component = entityElement.entity!.addComponent(this._componentName, data);
     }
 
     initComponent() {}

--- a/src/components/script.ts
+++ b/src/components/script.ts
@@ -126,6 +126,14 @@ class ScriptElement extends AsyncElement {
         return this._script;
     }
 
+    connectedCallback() {
+        // Script instances are created by the parent pc-scripts element, so an element placed
+        // anywhere else is inert and never becomes ready - warn rather than hang silently
+        if (this.parentElement?.tagName !== 'PC-SCRIPTS') {
+            console.warn(`pc-script '${this.getAttribute('name')}' must be a direct child of pc-scripts - script not created`);
+        }
+    }
+
     /**
      * Called by the parent `<pc-scripts>` element when the script instance has been created.
      * @ignore

--- a/src/material.ts
+++ b/src/material.ts
@@ -1,5 +1,6 @@
 import { Color, StandardMaterial, Texture } from 'playcanvas';
 
+import { AppElement } from './app';
 import { AssetElement } from './asset';
 import { parseColor } from './utils';
 
@@ -8,6 +9,10 @@ import { parseColor } from './utils';
  * {@link https://developer.playcanvas.com/user-manual/web-components/tags/pc-material/ | `<pc-material>`} elements.
  * The MaterialElement interface also inherits the properties and methods of the
  * {@link HTMLElement} interface.
+ *
+ * A `pc-material` must be a direct child of `pc-app` — elements placed elsewhere log a warning
+ * and never create a material. Elements inserted while the application is already running are
+ * created on insertion.
  */
 class MaterialElement extends HTMLElement {
     private _diffuse = new Color(1, 1, 1);
@@ -21,6 +26,28 @@ class MaterialElement extends HTMLElement {
     private _roughnessMap = '';
 
     material: StandardMaterial | null = null;
+
+    async connectedCallback() {
+        const appElement = this.parentElement?.closest('pc-app') as AppElement | null ?? null;
+
+        // Materials must be direct children of pc-app (matches the boot query ':scope > pc-material')
+        if (!appElement || this.parentElement !== appElement) {
+            console.warn(`pc-material '${this.id}' must be a direct child of pc-app - material not created`);
+            return;
+        }
+
+        await appElement.ready();
+
+        // The element may have been removed or re-parented while waiting for the app
+        if (!this.isConnected || this.parentElement !== appElement) return;
+
+        // Materials present at startup are created by AppElement's boot; this branch handles
+        // elements inserted (or re-inserted) after the app is already running
+        if (!this.material) {
+            if (!appElement.app) return; // pc-app is re-connecting; its own boot will create this
+            this.createMaterial();
+        }
+    }
 
     createMaterial() {
         this.material = new StandardMaterial();


### PR DESCRIPTION
Fixes #281.

## Placement warnings

Placement rules existed but only `pc-asset` enforced them out loud. Each placement-constrained element now warns, naming itself and the parent it requires, in `pc-asset`'s existing message format:

```
pc-material 'nested-mat' must be a direct child of pc-app - material not created
pc-script 'spinA' must be a direct child of pc-scripts - script not created
pc-render 'orphan-render' must be a descendant of pc-entity - component not added
```

The component warning includes the element's `id` when it has one, since unlike the others there's no name attribute to identify it by.

## Runtime-inserted `pc-material`

`createMaterial()` was only reachable from `AppElement`'s boot, so a `pc-material` inserted after startup never created a material. It now mirrors the lifecycle `pc-asset` gained in #267 — created on insertion once the app is running — with the same guards: bail if the element was removed or re-parented while awaiting the app, and skip when `pc-app` is mid-reconnect so its own boot does the creation.

## One claim in the issue didn't hold up

The issue stated that a component element outside a `pc-entity` "silently never becomes ready — `whenReady()` just hangs with no signal." It doesn't hang. `ComponentElement.connectedCallback` calls `_onReady()` unconditionally, so the element **does** become ready — with a null `component`, which is arguably worse, since `await whenReady(el)` then `el.component.x` throws rather than waiting.

While checking that, I found the JSDoc on `whenReady` asserts the opposite, citing that exact case as its example of a promise that never settles. So the docs were wrong too. They now describe the real behavior and use `pc-script` outside `pc-scripts` — which genuinely never settles — as the example.

I left the `ready` behavior alone rather than making it match the old docs: not firing `ready` would be a cleaner contract but a behavior change beyond this issue, and with the warning in place the case is now debuggable either way. Happy to do it as a follow-up if you'd prefer `ready` to mean "component available".

## Verification

No test harness in this repo, so this was verified with a temporary page: 21 assertions covering each misplaced element (warns, and stays uncreated), each correctly-placed equivalent (works, and does **not** warn), runtime material insertion, misplaced runtime insertion, and remove/re-insert. All 21 pass, with exactly 4 warnings logged for exactly 4 misplaced elements — the count is what proves correctly-placed siblings stay quiet.

False positives were the main risk here, so I also swept 18 example pages in an iframe harness, capturing `console.warn` per page:

```
offenders=0 of 18
 ok  basic-shapes            ok  physics                ok  solar-system
 ok  first-person-teleport   ok  screen                 ok  basic-particles
 ok  physics-cluster         ok  ui-scroll-view         ok  positional-sound
 ok  vibe-falling-blocks     ok  text                   ok  splat-simple
 ok  spinning-cube           ok  animation
 ok  fps-controller          ok  glb
 ok  car-configurator        ok  shoe-configurator
```

`npm run lint` and `npm run type-check` clean. The harness was removed before committing; the diff is source-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

