### PR TITLE
pc-render: remove the unusable 'asset' type

### DIFF
--- a/src/components/render-component.ts
+++ b/src/components/render-component.ts
@@ -10,6 +10,10 @@ import { parseBool, parseEnum } from '../utils';
  * The RenderComponentElement interface also inherits the properties and methods of the
  * {@link HTMLElement} interface.
  *
+ * This element renders one of the engine's built-in primitives, selected with `type` (defaulting
+ * to `box`). It does not cover the engine's `asset` render type, since there is no way to supply
+ * a render asset here — use `pc-model` for glTF content instead.
+ *
  * @category Components
  */
 class RenderComponentElement extends ComponentElement {
@@ -19,7 +23,7 @@ class RenderComponentElement extends ComponentElement {
 
     private _receiveShadows = true;
 
-    private _type: 'asset' | 'box' | 'capsule' | 'cone' | 'cylinder' | 'plane' | 'sphere' = 'asset';
+    private _type: 'box' | 'capsule' | 'cone' | 'cylinder' | 'plane' | 'sphere' = 'box';
 
     /** @ignore */
     constructor() {
@@ -47,7 +51,7 @@ class RenderComponentElement extends ComponentElement {
      * Sets the type of the render component.
      * @param value - The type.
      */
-    set type(value: 'asset' | 'box' | 'capsule' | 'cone' | 'cylinder' | 'plane' | 'sphere') {
+    set type(value: 'box' | 'capsule' | 'cone' | 'cylinder' | 'plane' | 'sphere') {
         this._type = value;
         if (this.component) {
             this.component.type = value;
@@ -58,7 +62,7 @@ class RenderComponentElement extends ComponentElement {
      * Gets the type of the render component.
      * @returns The type.
      */
-    get type(): 'asset' | 'box' | 'capsule' | 'cone' | 'cylinder' | 'plane' | 'sphere' {
+    get type(): 'box' | 'capsule' | 'cone' | 'cylinder' | 'plane' | 'sphere' {
         return this._type;
     }
 
@@ -137,7 +141,7 @@ class RenderComponentElement extends ComponentElement {
                 this.receiveShadows = parseBool(newValue, true);
                 break;
             case 'type':
-                this.type = parseEnum(newValue, ['asset', 'box', 'capsule', 'cone', 'cylinder', 'plane', 'sphere'], 'asset', name);
+                this.type = parseEnum(newValue, ['box', 'capsule', 'cone', 'cylinder', 'plane', 'sphere'], 'box', name);
                 break;
         }
     }


### PR DESCRIPTION
Fixes #282, taking the "drop it" option.

`type` accepted `'asset'`, mirroring the engine's `RenderComponent`, but `pc-render` exposes no way to supply a render asset — so the value could never do anything. Removed from the type union, from the `parseEnum` valid-name list, and documented as out of scope with a pointer to `pc-model`.

Worth noting the issue's premise checks out: render components *with* assets do exist at runtime — `examples/assets/scripts/static-body.mjs` reads `render.asset` to build a mesh collider — but those components are created by the engine's container handler via `pc-model`, never by `pc-render type="asset"`.

## One behavioral change

`'asset'` wasn't only in the union, it was also the **default** (both the `_type` field initializer and the `parseEnum` fallback). Dropping it forces a new default, which is now `'box'`.

So a `pc-render` with no `type` changes from "creates an asset-typed component with no asset and renders nothing" to "renders a box". Every `pc-render` in this repo sets `type` explicitly, so nothing here is affected, and I'd argue a bare `<pc-render>` rendering something beats it silently rendering nothing.

An existing `type="asset"` also stops being silently inert — `parseEnum` now reports it:

```
Invalid value 'asset' for attribute 'type'. Valid values: box, capsule, cone, cylinder, plane, sphere. Using 'box'.
```

## Verification

9 assertions on a live app — the new default resolves to `box` and actually produces mesh instances, explicit types are unaffected, and `type="asset"` warns with the right valid-value list and falls back to `box` with geometry. All pass:

```
PASS  no type defaults to box                    type=box
PASS  default renders geometry                   meshInstances=1
PASS  explicit type honored                     type=sphere
PASS  explicit renders geometry                  meshInstances=1
PASS  type="asset" warns
PASS  warning lists valid values without asset
PASS  type="asset" falls back to box             type=box
PASS  fallback renders geometry                  meshInstances=1
PASS  asset absent from runtime enum list
```

Also re-checked `basic-shapes`, which exercises all six primitives — every one still resolves to its declared type with geometry and material intact. `npm run lint` and `npm run type-check` clean. Harness removed before committing; the diff is source-only.

Note the union is still spelled out in three places (field, setter, getter) alongside the separate `parseEnum` list, so the two can still drift — the same hazard as item 1 of #281's sibling issue #283. I left that alone to keep this change minimal, but it'd be a natural thing to fold into #283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

