### PR TITLE
Use US spelling consistently

### DIFF
--- a/examples/basic-shapes.html
+++ b/examples/basic-shapes.html
@@ -30,7 +30,7 @@
             <pc-material id="steelblue" diffuse="steelblue"></pc-material>
             <pc-material id="hotpink" diffuse="hotpink"></pc-material>
             <pc-material id="goldenrod" diffuse="goldenrod"></pc-material>
-            <pc-material id="lightgrey" diffuse="lightgrey"></pc-material>
+            <pc-material id="lightgray" diffuse="lightgray"></pc-material>
             <!-- Scene -->
             <pc-scene>
                 <!-- Camera (with XR support) -->
@@ -90,7 +90,7 @@
                 </pc-entity>
                 <!-- Plane -->
                 <pc-entity name="plane" position="0 0 0" scale="7 1 7">
-                    <pc-render type="plane" material="lightgrey"></pc-render>
+                    <pc-render type="plane" material="lightgray"></pc-render>
                 </pc-entity>
             </pc-scene>
         </pc-app>

--- a/src/components/script-component.ts
+++ b/src/components/script-component.ts
@@ -131,7 +131,7 @@ const colorConversion: Conversion = (rest, raw) => {
 };
 
 /**
- * The conversion prefixes recognised in script attribute values, mapped to the conversion each
+ * The conversion prefixes recognized in script attribute values, mapped to the conversion each
  * performs. These keys are the single source of truth for the prefix vocabulary: they drive both
  * the conversion in `convertAttributes` and the has-a-prefix test in `setScriptProperty`, so a
  * prefix added here is automatically known to both.
@@ -148,10 +148,10 @@ const CONVERSIONS = new Map<string, Conversion>([
 /**
  * Matches a value against the conversion prefixes. A prefix is the text before the first colon,
  * so a value whose remainder itself contains colons (`asset:a:b`) still resolves, and a value
- * with an unrecognised prefix (`https://...`) or no colon does not match.
+ * with an unrecognized prefix (`https://...`) or no colon does not match.
  * @param value - The value to inspect.
  * @returns The matching converter and the text after the prefix, or `null` if the value carries
- * no recognised prefix.
+ * no recognized prefix.
  */
 const matchConversion = (value: string) => {
     const index = value.indexOf(':');


### PR DESCRIPTION
Switches the repo to US spelling throughout.

There turned out to be very little to change in the source — a full sweep found only three British spellings in our own code, all JSDoc prose in `script-component.ts` (`recognised` ×2, `unrecognised`), plus the `lightgrey` material in the basic-shapes example.

## Two things deliberately left alone

**`src/colors.ts` keeps its `grey` entries.** These aren't prose — they're the CSS named-color table, and CSS defines `grey` and `gray` as official aliases. The table already carries both spellings for all seven pairs (`grey`/`gray`, `darkgrey`/`darkgray`, `dimgrey`/`dimgray`, `lightgrey`/`lightgray`, `slategrey`/`slategray`, `darkslategrey`/`darkslategray`, `lightslategrey`/`lightslategray`), so dropping either side would start rejecting valid user markup. That's an API surface, not a style choice.

**The `grey-panel` / `grey-cross` asset ids in `ui-scroll-view.html` stay.** They mirror frame names embedded in the third-party Kenney spritesheet atlas data (`grey_panel`, `grey_boxCross`), which the example references by name. Renaming only our ids would leave them pointing at differently-spelled frames — more confusing than the inconsistency it would fix. Happy to rename both sides if you'd rather, but it means editing the atlas frame data.

## Verification

`npm run lint`, `npm run type-check` and `npm run build` clean. A residual sweep across `src` and `examples` (excluding the vendored draco/basis modules) for ~35 British forms comes back empty.

The example rename touches an `id` and its two references, so I checked it resolves rather than silently falling back to an untextured plane — the `lightgray` material is created, the plane's `material="lightgray"` resolves to that exact instance, and its diffuse is `0.827` = `0xd3/255`, confirming the CSS keyword maps correctly through the color table.

## Outside this PR

I've also corrected the same words in the v0.9.0 release notes (`colour`, `honoured`) and in the descriptions of #293, #294 and #295. The commit messages on those merged PRs still contain `behaviour`/`behavioural`/`initialiser` — those are immutable without rewriting `main`'s history, which isn't worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
