### PR TITLE
Raise TypeScript target from es2017 to es2022

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target": "es2022",
     "module": "ESNext",
     "lib": [
-      "ES2017",
+      "ES2022",
       "DOM",
       "DOM.Iterable"
     ],


### PR DESCRIPTION
### What

Raises the TypeScript `target` (and matching `lib`) in `tsconfig.json` from `es2017` to `es2022`.

### Why

At `es2017`, TypeScript downlevels optional chaining, nullish coalescing and class fields into transpiled equivalents plus helper code. Every browser that can run WebGL2 or WebGPU supports `es2022` natively, so that downleveling was buying no real compatibility — just larger output and less readable shipped code.

The emitted bundles now use native syntax (32 `?.` sites, 27 `??` sites) with zero downlevel helpers (`__spreadArray` / `__assign` / `_a === void 0` all gone).

| Bundle | Before | After | Change |
|---|---|---|---|
| `pwc.mjs` | 278,027 | 271,935 | −6,092 (−2.2%) |
| `pwc.cjs` | 279,468 | 273,376 | −6,092 (−2.2%) |
| `pwc.js` (UMD) | 310,300 | 303,968 | −6,332 (−2.0%) |
| `pwc.min.js` | 111,713 | 108,609 | −3,104 (−2.8%) |

This also aligns the target with `supersplat`, which already uses `es2022`. (`engine` is still `es6` and `pcui` `es2020` — out of scope here.)

### Reviewer note: `useDefineForClassFields`

This is the part worth a careful look. Targeting `es2022` flips `useDefineForClassFields` to `true` by default, switching class fields from `[[Set]]` to `[[Define]]` semantics. That can silently shadow an inherited accessor with an `undefined` own property, and `tsc` does not catch it. Given the hierarchies here (`ComponentElement` → `AsyncElement` → `HTMLElement`), I verified it at runtime rather than assuming.

`npm run type-check`, `npm run build` and `npm run lint` are all clean. Beyond that, three examples were exercised in a browser:

- **spinning-cube** — all 9 element types registered; accessors (`clearColor`, `type`) resolve correctly through the chain; script asset loaded and `Rotate` advanced the entity at exactly the authored 10/20/30 deg/s.
- **ui-scroll-view** — the deepest chain (`pc-element` → screen / scrollview / scrollbar / layoutgroup). Every accessor returned its correct value, no exceptions thrown.
- **physics** — Ammo WASM initialized, dynamic rigidbody fell y=4 → y=2.04 under gravity.

No console errors on any of them.

Two caveats on that verification, for transparency:

- `pc-screen.scaleMode` reads back `undefined`, which I confirmed is **pre-existing and correct** — there is no such accessor, it is derived from `blend` at `src/components/screen-component.ts:38`.
- Verification was programmatic, not visual. The browser pane was not compositing frames, so `requestAnimationFrame` was throttled to zero and screenshots/GPU pixel readback were unavailable; the render loop was driven via explicit `app.update()` calls instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
