### PR TITLE
Add a minified ESM build

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -12,6 +12,12 @@ export default {
             sourcemap: true
         },
         {
+            file: 'dist/pwc.min.mjs',
+            format: 'esm',
+            sourcemap: true,
+            plugins: [terser()]
+        },
+        {
             file: 'dist/pwc.cjs',
             format: 'cjs',
             sourcemap: true


### PR DESCRIPTION
### What

Adds a `dist/pwc.min.mjs` output to the Rollup config, mirroring the existing `pwc.js` / `pwc.min.js` UMD pair.

### Why

`pwc.min.js` (UMD) was the only minified bundle. The ESM path had just `pwc.mjs` at 272 KB unminified — despite import maps being the documented way to consume the library. Anyone following the getting-started guide against a CDN was pulling the unminified bundle.

| Bundle | Raw | Gzipped |
|---|---|---|
| `pwc.mjs` | 271,935 | 50,838 |
| `pwc.min.mjs` | **108,540** | **27,361** |
| | −60% | −46% |

`pwc.mjs` stays the `"import"` entry in the exports map, so bundler consumers keep getting unminified input to minify themselves. The minified file is for direct `<script type="module">` / import-map / CDN use.

No `package.json` change is needed: `exports` already contains `"./dist/*": "./dist/*"`, so the file is immediately reachable as `@playcanvas/web-components/dist/pwc.min.mjs` and over a CDN at the same path.

### Verification

Confirmed the output is genuine ESM, not a mislabelled UMD: it opens with `import{basisInitialize as e,...}`, contains an `export` statement, has zero `define.amd` occurrences, and carries a valid `//# sourceMappingURL=pwc.min.mjs.map`.

Then loaded it in a browser via an import map (a throwaway page pointing at `../dist/pwc.min.mjs`, since no committed example uses the minified build) and compared against the unminified build:

- All 9 element types registered; engine live on `webgl2`; canvas created.
- Accessors resolve correctly through the class hierarchy (`pc-camera.clearColor`, `pc-render.type`) — confirming terser's mangling doesn't disturb the getter/setter wiring.
- Script component attached and executed, advancing the cube to `[6.051840515105138, 9.381618800590143, 15.455202345864324]` — identical to the unminified build to 13 decimal places.
- No console errors.

`npm run lint` is clean. The only `constructor.name` reference in the codebase is inside a `console.warn` message at `src/components/script-component.ts:345`, and it reads an engine-supplied value rather than a pwc class, so mangling has no functional impact there.

### Tradeoff worth noting

The published tarball grows from 374.1 kB to 435.5 kB (+61 kB) for the new file and its sourcemap. That is more than offset by dropping `src` from `files` — the source is currently shipped twice, since all sourcemaps already embed `sourcesContent` — but that is a separate change and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
