### PR TITLE
Declare explicit unpkg and jsdelivr entry points

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
   "main": "dist/pwc.cjs",
   "module": "dist/pwc.mjs",
   "browser": "dist/pwc.js",
+  "unpkg": "dist/pwc.min.js",
+  "jsdelivr": "dist/pwc.min.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
### What

Adds explicit `unpkg` and `jsdelivr` entry-point fields to `package.json`, both pointing at `dist/pwc.min.js`.

### Why

Neither field was set, so both CDNs guessed from the remaining entry-point fields — and reached different answers. Measured against the published `0.9.0`:

| CDN | Bare URL resolved to | Result |
|---|---|---|
| unpkg | `301 → /dist/pwc.cjs` | **Broken** — CommonJS, `require('playcanvas')`, throws in a browser |
| jsdelivr | `/dist/pwc.min.js` | Works, but only incidentally |

unpkg follows `main`, which is `dist/pwc.cjs`. jsdelivr followed `browser` and preferred the minified sibling, landing on `dist/pwc.min.js` (its API reports `"guessed": false`). That happens to be correct today but is not pinned by anything — repointing `browser` would silently change it.

Naming both fields explicitly fixes unpkg and makes jsdelivr deterministic.

### Why the UMD build and not ESM

The bare CDN URL is overwhelmingly consumed as a plain `<script src="…"></script>`. That needs UMD: no `type="module"`, no import map, engine read off the `pc` global. Pointing these fields at `pwc.min.mjs` would break exactly the usage the bare URL exists to serve. Anyone wanting the ESM build addresses `dist/pwc.min.mjs` by its explicit path.

### Verification

`dist/pwc.min.js` was loaded in a browser through plain classic script tags with **no import map and no module scripts** — the precise shape the bare CDN URL produces:

- `usedImportMap: false`, `moduleScripts: 0`, scripts loaded as `playcanvas.js` + `pwc.min.js`.
- All 8 element types registered; engine live on `webgl2`.
- Accessors correct (`pc-camera.clearColor` → `#8099e6`, `pc-render.type` → `box`).
- Script component ran, cube reached `[6.051840515105138, 9.381618800590143, 15.455202345864324]` — matching the ESM builds exactly.
- No console errors.

All six entry-point fields were also confirmed to resolve to files that exist and are included in the published tarball, and `publint` reports no new findings (the pre-existing `types`-under-`require` warning and the three suggestions are unchanged and out of scope here).

One limitation worth stating plainly: the CDN resolution itself cannot be verified until this ships to npm, since both CDNs serve published tarballs rather than a working tree. What is verified here is that the fields are well-formed, resolve to published files, and that the chosen target genuinely works in the plain-script-tag scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
