### PR TITLE
Stop element tooltips rendering a paragraph as a heading

### DIFF
--- a/utils/cem/cleanup-plugin.mjs
+++ b/utils/cem/cleanup-plugin.mjs
@@ -175,5 +175,15 @@ export const manifestCleanupPlugin = () => ({
         }
 
         rewriteDescriptions(customElementsManifest);
+
+        // The editor integrations append their own `---` separated sections directly after the
+        // class description. In markdown, a `---` line immediately below a paragraph makes that
+        // paragraph a heading, which renders the last paragraph of every element's tooltip at
+        // heading size. A trailing blank line keeps the separator a separator.
+        for (const { declaration } of declarations.values()) {
+            if (declaration.customElement && declaration.description) {
+                declaration.description = `${declaration.description.trimEnd()}\n`;
+            }
+        }
     }
 });

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -212,6 +212,14 @@ if (vsCode) {
         ?.find(item => item.name === 'tonemap');
     check(tonemap?.values?.length === 7,
         `VS Code custom data should offer 7 values for pc-camera[tonemap], found ${tonemap?.values?.length}`);
+
+    // A `---` directly below a paragraph is markdown for "make that paragraph a heading", which
+    // would render the last paragraph of the tooltip at heading size
+    const setext = (vsCode.tags ?? [])
+        .filter(tag => /[^\n]\n---/.test(typeof tag.description === 'string' ? tag.description : tag.description?.value ?? ''))
+        .map(tag => tag.name);
+    check(setext.length === 0,
+        `${setext.length} VS Code tooltip(s) would render a paragraph as a heading: ${setext.join(', ')}`);
 }
 
 const webTypes = readJson('web-types.json');


### PR DESCRIPTION
Follow-up to #303, caught by actually hovering `<pc-entity>` in VS Code.

## The bug

`custom-element-vs-code-integration` appends its `Events:`/`Methods:` sections after the class description, separated by a `---` line placed directly beneath it:

```
...with the matching inline `onpointer*` attribute.
---


### **Events:**
```

In markdown, a `---` line immediately below a paragraph is [setext heading](https://spec.commonmark.org/0.31.2/#setext-headings) syntax — it makes the paragraph above it an `<h2>`. So the final paragraph of **all 27 elements'** tooltips rendered at heading size. For `pc-entity` that was the entire paragraph explaining how pointer events are dispatched; for `pc-camera` it was "…also inherits the properties and methods of the HTMLElement interface."

## The fix

End each custom element description with a blank line, so the separator reads as a separator:

```
...with the matching inline `onpointer*` attribute.

---
```

Two lines in `cleanup-plugin.mjs`. `web-types.json` was unaffected — it structures its sections differently, and was checked.

Also adds a check to `validate.mjs` for the setext shape, so this cannot come back unnoticed. I confirmed the check fires on the old string and passes on the new one, rather than trusting that it would.

## Note for review

The underlying cause is arguably upstream — the integration ought to emit `\n\n---`. Fixing it here is the pragmatic choice since we already post-process descriptions in that plugin, and the comment explains why the trailing newline exists so it does not look like stray whitespace to a future reader.

## Verification

`npm run build` (which now includes the new check), `lint`, `type-check` and `publint` all pass. All 27 tooltips confirmed free of the setext shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
