### PR TITLE
Drop the browser field

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "main": "dist/pwc.cjs",
   "module": "dist/pwc.mjs",
-  "browser": "dist/pwc.js",
   "unpkg": "dist/pwc.min.js",
   "jsdelivr": "dist/pwc.min.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
`"browser": "dist/pwc.js"` pointed at the UMD bundle. It isn't broken, but it earns nothing and where it *is* honored it steers consumers to the worst output.

## Why remove it

**It's inert for modern tooling.** Because `exports` is present, webpack 5, Vite, esbuild, Parcel 2 and Node all resolve through `exports["."]` — which declares only `types`/`import`/`require` — and never consult `browser`.

**Where it is honored, it downgrades.** Webpack 4 defaults `resolve.mainFields` to `['browser', 'module', 'main']` for web targets, so `browser` came *first*. Those consumers got the UMD bundle instead of the tree-shakeable `pwc.mjs` that `module` would have given them. It still worked — a bundler takes the UMD file's CommonJS branch, so `require('playcanvas')` resolves normally and the `globals: { playcanvas: 'pc' }` mapping never came into play — but it was a downgrade.

**It has no semantic basis.** The field exists to substitute a browser variant for Node-specific code. This package has no Node build; all five rollup outputs are browser-targeted. The field asserted a distinction that doesn't exist.

## Impact

Consumers that relied on it fall through to `module` (`pwc.mjs`) — a resolution change, but to the better artifact. publint labels removing a resolution field as potentially breaking, so it's a judgement call about how much pre-`exports` bundler support matters; nothing published changes.

Direct `<script>` and CDN use is untouched:

- `unpkg` and `jsdelivr` still point at `dist/pwc.min.js`
- `examples/spinning-cube-umd.html` loads `../dist/pwc.js` by path, not by bare specifier
- both UMD bundles are still built and still published

Resolution fields after this change:

| field | value |
|---|---|
| `main` | `dist/pwc.cjs` |
| `module` | `dist/pwc.mjs` |
| `unpkg` / `jsdelivr` | `dist/pwc.min.js` |
| `types` | `dist/index.d.ts` |
| `exports["."]` | `types` / `import` / `require` |

## Verification

`npm run publint` passes and no longer raises the `pkg.browser` suggestion — the remaining warning (`exports["."].types` under the `require` condition) and two suggestions (`engines.node`, `sideEffects`) all pre-date this change. `npm pack --dry-run` confirms `pwc.js`, `pwc.min.js`, `pwc.mjs` and `pwc.cjs` all still ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
