### PR TITLE
Add a Vitest testing framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,22 @@ jobs:
 
       - name: Type check
         run: npm run type-check
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # No build step: the unit, elements and integration projects all run against src/ directly.
+      # Vitest detects GitHub Actions and annotates failures on the diff without configuration.
+      - name: Run tests
+        run: npm test

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,7 +31,11 @@ export default [
         },
         settings: {
             'import/resolver': {
-                typescript: {}
+                typescript: {
+                    // tsconfig.test.json is the program that covers test/, so without it here
+                    // import/no-unresolved fails on every ../../src/... import from a test file
+                    project: ['./tsconfig.json', './tsconfig.test.json']
+                }
             }
         },
         rules: {
@@ -43,6 +47,18 @@ export default [
             '@typescript-eslint/no-unused-vars': 'off',
             'jsdoc/require-param-type': 'off',
             'jsdoc/require-returns-type': 'off'
+        }
+    },
+    {
+        // The '**/*.ts' block above already gives test files the TypeScript parser and browser
+        // globals. This adds only the delta. Note there are no test-framework globals to declare:
+        // vitest.config.ts sets `globals: false`, so every test imports describe/it/expect/vi
+        // explicitly.
+        files: ['test/**/*.ts', 'vitest.config.ts'],
+        languageOptions: {
+            globals: {
+                ...globals.node
+            }
         }
     }
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@tweenjs/tween.js": "25.0.0",
         "@typescript-eslint/eslint-plugin": "8.65.0",
         "@typescript-eslint/parser": "8.65.0",
+        "@vitest/coverage-v8": "4.1.10",
         "concurrently": "10.0.4",
         "custom-element-jet-brains-integration": "1.7.0",
         "custom-element-vs-code-integration": "1.5.0",
@@ -26,6 +27,7 @@
         "eslint": "9.39.5",
         "eslint-import-resolver-typescript": "4.4.5",
         "globals": "17.8.0",
+        "jsdom": "29.1.1",
         "mediabunny": "1.52.1",
         "opentype.js": "2.0.0",
         "playcanvas": "2.21.3",
@@ -35,10 +37,275 @@
         "tslib": "2.8.1",
         "typedoc": "0.28.20",
         "typedoc-plugin-mdn-links": "5.1.1",
-        "typescript": "6.0.3"
+        "typescript": "6.0.3",
+        "vitest": "4.1.10"
       },
       "peerDependencies": {
         "playcanvas": "^2.20.1"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@custom-elements-manifest/analyzer": {
@@ -106,7 +373,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "2.0.1",
         "tslib": "^2.4.0"
@@ -119,7 +385,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -131,7 +396,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -369,6 +633,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@gerrit0/mini-shiki": {
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
@@ -571,6 +853,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@oxc-resolver/binding-android-arm-eabi": {
@@ -948,6 +1240,285 @@
       "funding": {
         "url": "https://bjornlu.com/sponsor"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.1.tgz",
+      "integrity": "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.1.tgz",
+      "integrity": "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.1.tgz",
+      "integrity": "sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.1.tgz",
+      "integrity": "sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.1.tgz",
+      "integrity": "sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.1.tgz",
+      "integrity": "sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.1.tgz",
+      "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.1.tgz",
+      "integrity": "sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.1.tgz",
+      "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.1.tgz",
+      "integrity": "sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.1.tgz",
+      "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.1.tgz",
+      "integrity": "sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.1.tgz",
+      "integrity": "sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "2.0.0-alpha.3",
+        "@emnapi/runtime": "2.0.0-alpha.3",
+        "@napi-rs/wasm-runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.1.tgz",
+      "integrity": "sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.1.tgz",
+      "integrity": "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "29.0.3",
@@ -1519,6 +2090,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tweenjs/tween.js": {
       "version": "25.0.0",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
@@ -1536,6 +2114,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/dom-mediacapture-transform": {
       "version": "0.1.12",
@@ -2216,6 +2812,160 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@web/config-loader": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@web/config-loader/-/config-loader-0.1.3.tgz",
@@ -2731,6 +3481,38 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -2765,6 +3547,16 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -2917,6 +3709,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -3269,6 +4071,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3282,6 +4091,20 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/custom-element-jet-brains-integration": {
@@ -3310,6 +4133,20 @@
       "integrity": "sha512-j59k0ExGCKA8T6Mzaq+7axc+KVHwpEphEERU7VZ99260npu/p/9kd+Db+I3cGKxHkM5y6q5gnlXn00mzRQkX2A==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -3390,6 +4227,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -3451,6 +4295,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dir-glob": {
@@ -3635,6 +4489,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -4286,6 +5147,16 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4841,6 +5712,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -5242,6 +6133,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-reference": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -5437,6 +6335,65 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
@@ -5468,6 +6425,47 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -5528,6 +6526,279 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/linkify-it": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
@@ -5578,6 +6849,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/lunr": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
@@ -5593,6 +6874,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-synchronized": {
@@ -5642,6 +6951,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mdurl": {
       "version": "2.1.0",
@@ -5798,6 +7114,25 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
@@ -5997,6 +7332,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/on-headers": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
@@ -6170,6 +7519,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6221,6 +7596,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6263,6 +7645,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -6575,6 +7986,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.1.tgz",
+      "integrity": "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.142.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.1",
+        "@rolldown/binding-darwin-arm64": "1.2.1",
+        "@rolldown/binding-darwin-x64": "1.2.1",
+        "@rolldown/binding-freebsd-x64": "1.2.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.1",
+        "@rolldown/binding-linux-arm64-musl": "1.2.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-musl": "1.2.1",
+        "@rolldown/binding-openharmony-arm64": "1.2.1",
+        "@rolldown/binding-wasm32-wasi": "1.2.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.1",
+        "@rolldown/binding-win32-x64-msvc": "1.2.1"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.62.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
@@ -6763,6 +8208,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scslre": {
@@ -7084,6 +8542,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -7115,6 +8580,16 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -7166,6 +8641,20 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -7334,6 +8823,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/terser": {
       "version": "5.49.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
@@ -7352,6 +8848,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.2.4",
@@ -7380,6 +8883,36 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7391,6 +8924,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tree-kill": {
@@ -7624,6 +9183,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
@@ -7691,6 +9260,222 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
+      "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.23",
+        "rolldown": "~1.2.0",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -7798,6 +9583,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/widest-line": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
@@ -7841,6 +9643,23 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -51,12 +51,19 @@
     "cem": "cem analyze && node utils/cem/validate.mjs",
     "dev": "concurrently \"npm run watch\" \"npm run serve\"",
     "docs": "typedoc",
-    "lint": "eslint examples/js examples/assets/scripts src",
+    "lint": "eslint examples/js examples/assets/scripts src test vitest.config.ts",
     "serve": "serve",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "test:unit": "vitest run --project unit",
+    "test:elements": "vitest run --project elements",
+    "test:integration": "vitest run --project integration",
     "publint": "publint",
-    "type-check": "tsc --noEmit",
-    "type-check:watch": "npm run type-check -- --watch",
+    "type-check": "npm run type-check:src && npm run type-check:test",
+    "type-check:src": "tsc --noEmit -p tsconfig.json",
+    "type-check:test": "tsc --noEmit -p tsconfig.test.json",
+    "type-check:watch": "npm run type-check:src -- --watch",
     "watch": "rollup -c -w"
   },
   "peerDependencies": {
@@ -73,6 +80,7 @@
     "@tweenjs/tween.js": "25.0.0",
     "@typescript-eslint/eslint-plugin": "8.65.0",
     "@typescript-eslint/parser": "8.65.0",
+    "@vitest/coverage-v8": "4.1.10",
     "concurrently": "10.0.4",
     "custom-element-jet-brains-integration": "1.7.0",
     "custom-element-vs-code-integration": "1.5.0",
@@ -80,6 +88,7 @@
     "eslint": "9.39.5",
     "eslint-import-resolver-typescript": "4.4.5",
     "globals": "17.8.0",
+    "jsdom": "29.1.1",
     "mediabunny": "1.52.1",
     "opentype.js": "2.0.0",
     "playcanvas": "2.21.3",
@@ -89,6 +98,7 @@
     "tslib": "2.8.1",
     "typedoc": "0.28.20",
     "typedoc-plugin-mdn-links": "5.1.1",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "vitest": "4.1.10"
   }
 }

--- a/test/README.md
+++ b/test/README.md
@@ -47,6 +47,16 @@ custom element reactions are *reported*, not propagated, so `guard.uncaught` is 
 them. Do not install a global handler that swallows them — one such rejection is how the
 `sound-slot.ts` teardown bug was found.
 
+**The guard asserts from a cleanup function returned by `beforeEach`, not from an `afterEach`. Do
+not "simplify" that.** Vitest's measured hook order is: test body → `afterEach` registered in the
+describe → `afterEach` registered at module scope (where `dom.ts` unmounts the DOM and destroys the
+app) → cleanup functions returned from `beforeEach`. An `afterEach` would therefore assert *before*
+teardown, so anything teardown emits would escape — and since `beforeEach` resets the recorders, a
+teardown warning would vanish silently rather than fail. Teardown is where this library is most
+fragile, so the assertion has to come last. Spy restoration is left to `restoreMocks: true` in
+`vitest.config.ts`, which Vitest applies after the cleanup, keeping the spies live throughout
+teardown.
+
 **Mount detached, insert once.** `mount()` builds the subtree on a detached container and appends it
 in a single operation, so every `connectedCallback` runs with the full subtree present. That matches
 production, where `pwc.mjs` is a deferred module script and elements upgrade with their children

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,121 @@
+# Tests
+
+Four tiers, three of which run in Node with jsdom and need neither a build nor a browser.
+
+| Tier | Command | Environment | Covers |
+|---|---|---|---|
+| Unit | `npm run test:unit` | `node` | The pure parsers in `src/utils.ts` and the `CSS_COLORS` table |
+| Elements | `npm run test:elements` | `jsdom` | Attribute and property surface, with no engine created |
+| Integration | `npm run test:integration` | `jsdom` | A real `AppBase` on `NullGraphicsDevice`, via `<pc-app backend="null">` |
+| Browser | *(not yet implemented)* | Chromium | The built `dist/` bundle and the example pages |
+
+`npm test` runs the three Node tiers. `npm run test:watch` watches them, and
+`npm run test:coverage` adds a v8 report under `coverage/`.
+
+## Why the library is testable headlessly
+
+`<pc-app>` accepts `backend="null"`, which `src/app.ts` maps to PlayCanvas's `NullGraphicsDevice` —
+a pure-JS `GraphicsDevice` that never calls `getContext`. A complete application, entity hierarchy
+and component set therefore boots in jsdom in a few milliseconds with no GPU.
+
+**Always use `backend="null"`.** Any other backend makes `createGraphicsDevice` construct a
+`WebglGraphicsDevice`, which throws synchronously because jsdom's `getContext` returns `null`. That
+throw escapes the engine's per-attempt `.catch()` (the attempt is invoked as the *argument* to
+`Promise.resolve`, before the handler is attached), so the promise rejects instead of falling back to
+the null device, and `connectedCallback` turns it into an unhandled rejection. `bootApp()` enforces
+this.
+
+## Rules that come from how the library behaves
+
+**Nothing ever rejects.** No `AsyncElement` rejects its ready promise. A misplaced element logs a
+`console.warn` and returns a promise that *never settles*. Two consequences:
+
+- Every wait goes through `readyWithin()`, never a bare `await element.ready()`. On timeout it
+  reports connection state, `closestApp`, `closestEntity`, `hierarchyReady` and every warning seen
+  so far, instead of a bare 10-second timeout.
+- Negative cases are asserted with the console guard or `expectNeverReady()`, never with
+  `expect(...).toThrow()`.
+
+**Warnings are assertions.** Every suite that mounts anything calls `useGuard()`. Tests *claim* the
+messages they expect with `warnings.expect(pattern)`; anything left unclaimed fails the test. This is
+what makes the misuse paths a contract — add a warning to the library and exactly the tests that
+walk that path break. Use `warnings.allow(...)` for messages that are expected but not the point of
+the test, and `ignoreRest()` only with a comment saying why.
+
+The guard also records uncaught exceptions and unhandled rejections. Async `connectedCallback`s and
+custom element reactions are *reported*, not propagated, so `guard.uncaught` is the only way to see
+them. Do not install a global handler that swallows them — one such rejection is how the
+`sound-slot.ts` teardown bug was found.
+
+**Mount detached, insert once.** `mount()` builds the subtree on a detached container and appends it
+in a single operation, so every `connectedCallback` runs with the full subtree present. That matches
+production, where `pwc.mjs` is a deferred module script and elements upgrade with their children
+already parsed. Filling an already-connected container would connect `<pc-app>` before its children
+and its boot queries would find nothing.
+
+**Settle before tearing down.** `<pc-app>` resolves its own ready promise from inside the
+`app.preload()` callback, *before* its descendants' async `connectedCallback`s have finished. So
+`bootApp()` awaits `settle()` over the whole subtree, not just the app. Removing a tree in that
+window makes `addComponent` and `addSlot` dereference nulls.
+
+**Per-file isolation is mandatory.** `src/` performs 27 `customElements.define()` calls at module
+scope and a second define for the same tag throws. Vitest's default per-file isolation gives each
+file a fresh realm and module graph; never run with `--no-isolate`. Isolation *between tests* is by
+fresh DOM subtree, which `test/helpers/dom.ts` handles in `afterEach`.
+
+**Clean up completely.** `AssetElement.get`, `MaterialElement.get`, `getEntity` and the picker's
+`pc-entity[name=...]` reverse lookup are all document-global and string-keyed, so a leaked element
+silently changes another test's result. `mount()` calls `assertDocumentClean()` on entry so a leak is
+attributed to the test that caused it.
+
+## Known bugs
+
+When a test documents a defect, pin the **actual** behaviour in an `it(...)` whose title ends
+`(known bug #NNN)`, with a comment naming the file, line and root cause, and add an `it.todo(...)`
+stating the intended behaviour beside it.
+
+Do **not** use `it.fails()` — it passes for *any* failure, so it silently absorbs an unrelated
+regression on the same path, and it cannot see errors that are reported rather than thrown. Do not
+use bare `it.skip` either; it rots invisibly. This convention keeps the suite green, describes the
+defect executably, and makes the fix a one-line flip.
+
+## Style
+
+- One test module per source module, mirroring the path: `src/components/camera-component.ts` →
+  `test/integration/components/camera-component.test.ts`.
+- Outer `describe` is the **tag** in angle brackets — `describe('<pc-camera>')` — because that is how
+  users refer to it. Use the class name only for tests of the TypeScript API surface.
+- Second level is the member as the user writes it: `describe('[clear-color]')` for attributes,
+  `describe('#component')` for properties and methods.
+- `it` reads as a sentence: *"falls back to the default when the value is not a finite number"*, not
+  *"default is returned"*.
+- Explicit imports from `vitest` — `globals` is off in `vitest.config.ts`, matching `src/`'s style.
+- Arrow functions in `describe`/`it` are fine. The engine repo forbids them because Mocha exposes
+  `this`; Vitest does not, so the ban would be cargo cult here. This is a deliberate divergence.
+- `test.for` over `test.each`, so the case arrives typed.
+- `expect.soft` inside table-driven cases, so one broken attribute reports every finding in a single
+  run. Fail fast everywhere else.
+- Alphabetise members, except in table-driven suites where the order comes from
+  `observedAttributes` — the source of truth. Re-sorting would make failures harder to correlate.
+
+## Environment notes
+
+`test/setup/dom.ts` fixes exactly one real jsdom gap and deliberately leaves others alone.
+
+jsdom has no layout engine, so `clientWidth`, `clientHeight` and `getBoundingClientRect` are
+constant zeros. `AppElement` feeds `clientWidth` to `setCanvasResolution(RESOLUTION_AUTO)`, so
+without a stub the device comes up 0×0 and every derived aspect ratio is `NaN` — which passes a
+naive `toBeDefined()` assertion. The stub goes on `HTMLCanvasElement.prototype` rather than per
+canvas (as the engine's own tests do) because `AppElement` creates its canvas internally, so no test
+can reach it first. `test/integration/environment.test.ts` asserts the exact resulting dimensions; if
+that file is red, treat every other integration result as unreliable.
+
+Not polyfilled, on purpose: `ResizeObserver` (unused by the engine and by `src/`), `navigator.xr`
+(absent is the correct headless answer; a stub sends `XrManager` down paths jsdom cannot honour), and
+`AudioContext` (absent means `SoundManager.context` is `null`, and sound slots still work). The
+`canvas` npm package is **not** a dependency — it implements 2D drawing, not layout, and the null
+device never asks for a context.
+
+Integration tests use **no preload assets**. `app.preload()` short-circuits synchronously when the
+asset list is empty, so `bootApp()` performs no I/O. An unreachable asset URL does not fail, it hangs
+`<pc-app>` forever. When a real load is needed, use a `data:` URI.

--- a/test/elements/registration.test.ts
+++ b/test/elements/registration.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { AsyncElement, ComponentElement } from '../../src/index';
+import { COMPONENT_TAGS, READY_TAGS, TAGS } from '../helpers/tags';
+
+/**
+ * The runtime twin of validate.mjs's manifest checks. It catches a case the manifest cannot see: an
+ * element defined under src/ but omitted from src/index.ts's dependency-ordered import list. The
+ * analyzer reads source files, so such an element still appears in the manifest while never being
+ * registered in a browser.
+ */
+describe('customElements registration', () => {
+    it('defines every tag in the golden list', () => {
+        const missing = TAGS.filter(tag => !customElements.get(tag));
+        expect(missing).toEqual([]);
+    });
+
+    it('defines nothing outside the golden list', () => {
+        // The library only ever defines pc-* tags, so this is the observable surface to police.
+        const defined = TAGS.filter(tag => customElements.get(tag));
+        expect(defined.sort()).toEqual([...TAGS].sort());
+    });
+
+    it.for(READY_TAGS)('%s extends AsyncElement, so it has a ready promise', (tag) => {
+        expect(document.createElement(tag)).toBeInstanceOf(AsyncElement);
+    });
+
+    it.for(['pc-material', 'pc-module'])('%s extends HTMLElement directly, so it never becomes ready', (tag) => {
+        const element = document.createElement(tag);
+        expect(element).toBeInstanceOf(HTMLElement);
+        expect(element).not.toBeInstanceOf(AsyncElement);
+    });
+
+    it.for(COMPONENT_TAGS)('%s extends ComponentElement', (tag) => {
+        expect(document.createElement(tag)).toBeInstanceOf(ComponentElement);
+    });
+
+    it.for(COMPONENT_TAGS)('%s inherits the enabled attribute from ComponentElement', (tag) => {
+        const observed = (customElements.get(tag) as unknown as { observedAttributes?: string[] })?.observedAttributes;
+        expect(observed).toContain('enabled');
+    });
+});

--- a/test/helpers/app.ts
+++ b/test/helpers/app.ts
@@ -1,0 +1,93 @@
+import type { AppBase } from 'playcanvas';
+import { expect } from 'vitest';
+
+import { mount, type Mounted } from './dom';
+import { describeElement, readyWithin, READY_TIMEOUT } from './ready';
+// Importing the barrel is deliberate: it runs all 27 customElements.define() calls in the
+// dependency order the library itself relies on, and gives us AsyncElement as a value for the
+// instanceof check in settle().
+import type { AppElement } from '../../src/app';
+import { AsyncElement } from '../../src/index';
+
+
+export interface BootedApp extends Mounted {
+    readonly appElement: AppElement;
+    readonly app: AppBase;
+    /** Advances one simulation frame without rendering. */
+    step(dt?: number): void;
+    /** Renders one frame. Only for tests that specifically need the render path. */
+    render(): void;
+}
+
+export interface BootOptions {
+    /** Extra attributes for the `<pc-app>` element, for example `high-resolution="false"`. */
+    appAttributes?: string;
+    /** Per-element ready deadline in milliseconds. */
+    timeout?: number;
+}
+
+/**
+ * Waits for every AsyncElement under `root` to become ready, throwing a message that names the
+ * offenders if any of them do not.
+ *
+ * This is load bearing rather than convenient. <pc-app> resolves its own ready promise from inside
+ * the app.preload() callback, which is BEFORE its descendants' async connectedCallbacks have run to
+ * completion. Tearing the tree down in that window makes ComponentElement.addComponent()
+ * dereference an entity that is already null, and SoundSlotElement.connectedCallback() dereference
+ * a component that is already null - both surfacing as unhandled rejections that fail the whole
+ * file. Measured: removing the tree immediately after `await appElement.ready()` produces 2-3 such
+ * rejections; settling first produces none across repeated mount/teardown cycles.
+ *
+ * @param root - The subtree to settle.
+ * @param timeout - Per-element deadline in milliseconds.
+ */
+export const settle = async (root: ParentNode = document.body, timeout = READY_TIMEOUT) => {
+    const pending = Array.from(root.querySelectorAll('*'))
+    .filter((element): element is AsyncElement => element instanceof AsyncElement);
+
+    const stuck = (await Promise.all(pending.map(async (element) => {
+        try {
+            await readyWithin(element, timeout);
+            return null;
+        } catch {
+            return describeElement(element);
+        }
+    }))).filter(description => description !== null);
+
+    if (stuck.length > 0) {
+        throw new Error(`settle: ${stuck.length} element(s) never became ready: ${stuck.join(', ')}. ` +
+            'A ready promise that never settles means the element is misplaced - check the ' +
+            'console.warn output for the parent it requires.');
+    }
+};
+
+/**
+ * Mounts `<pc-app backend="null">` around `html` and returns once the whole tree has settled.
+ *
+ * @param html - The markup to place inside the `<pc-app>`.
+ * @param options - Boot options.
+ * @returns The booted app handle.
+ */
+export const bootApp = async (html = '', options: BootOptions = {}): Promise<BootedApp> => {
+    const attributes = options.appAttributes ? ` ${options.appAttributes}` : '';
+    const handle = mount(`<pc-app backend="null"${attributes}>${html}</pc-app>`);
+    const appElement = handle.get<AppElement>('pc-app');
+
+    await readyWithin(appElement, options.timeout);
+    await settle(handle.container, options.timeout);
+
+    const app = appElement.app;
+    expect(app, 'pc-app became ready without an application').toBeTruthy();
+    expect(app.graphicsDevice.isNull, 'expected the null graphics device').toBe(true);
+
+    // app.start() has already requested a frame. Frames are stepped explicitly from here so that
+    // one test's simulation cannot bleed into the next, and so no test depends on wall-clock time.
+    app.autoRender = false;
+
+    return Object.assign(handle, {
+        appElement,
+        app,
+        step: (dt = 1 / 60) => app.update(dt),
+        render: () => app.render()
+    });
+};

--- a/test/helpers/dom.ts
+++ b/test/helpers/dom.ts
@@ -1,0 +1,88 @@
+import { afterEach, expect } from 'vitest';
+
+export interface Mounted {
+    /** The wrapper the markup was mounted into. */
+    readonly container: HTMLElement;
+    /** Queries within the mounted subtree, asserting exactly one match. */
+    get<K extends keyof HTMLElementTagNameMap>(selector: K): HTMLElementTagNameMap[K];
+    get<T extends Element>(selector: string): T;
+    /** Queries within the mounted subtree, returning every match. */
+    all<T extends Element>(selector: string): T[];
+    /** Removes the subtree from the document. Called automatically after each test. */
+    unmount(): void;
+}
+
+const mounted = new Set<Mounted>();
+
+const LIBRARY_SELECTOR = 'pc-app, pc-asset, pc-entity, pc-material, pc-module, pc-scene, pc-sky';
+
+/**
+ * Fails if a previous test left library elements in the document.
+ *
+ * Several of the library's lookups are document-global and keyed by string - AssetElement.get,
+ * MaterialElement.get, getEntity, and AppElement's `pc-entity[name=...]` reverse lookup - so a
+ * leak silently changes an unrelated test's result. Failing loudly on entry attributes the leak to
+ * the test that caused it.
+ */
+export const assertDocumentClean = () => {
+    const strays = Array.from(document.querySelectorAll(LIBRARY_SELECTOR))
+    .map(element => element.tagName.toLowerCase());
+    expect(strays, 'a previous test leaked library elements into the document').toEqual([]);
+};
+
+/**
+ * Mounts an HTML subtree into the document and returns typed handles.
+ *
+ * The subtree is built detached and inserted in a single operation, so every element's
+ * connectedCallback runs with the complete subtree already in place. That matches how the library
+ * is actually used: pwc.mjs is a deferred module script, so customElements.define runs after the
+ * parser has finished and every element upgrades with its children already present. Assigning
+ * innerHTML on an already-connected container would instead connect <pc-app> before its children,
+ * and its boot queries (`:scope > pc-asset`, `pc-entity`) would find nothing.
+ *
+ * @param html - The markup to mount.
+ * @returns The mount handle.
+ */
+export const mount = (html: string): Mounted => {
+    assertDocumentClean();
+
+    const container = document.createElement('div');
+    container.innerHTML = html;
+
+    const handle: Mounted = {
+        container,
+        get: ((selector: string) => {
+            const found = container.querySelectorAll(selector);
+            expect(found.length, `expected exactly one '${selector}' in the mounted subtree`).toBe(1);
+            return found[0];
+        }) as Mounted['get'],
+        all: <T extends Element>(selector: string) => Array.from(container.querySelectorAll<T>(selector)),
+        unmount: () => {
+            container.remove();
+            container.innerHTML = '';
+            mounted.delete(handle);
+        }
+    };
+
+    mounted.add(handle);
+    document.body.appendChild(container);
+
+    return handle;
+};
+
+afterEach(async () => {
+    // Removing the container disconnects <pc-app> first, because parents disconnect before their
+    // children - which is exactly the teardown ordering the library's disconnectedCallback guards
+    // are written for. Destroying the app also cancels its rAF ticker and removes its window
+    // resize listener; both were verified to return to zero afterwards.
+    for (const handle of [...mounted]) {
+        handle.unmount();
+    }
+
+    // Let the disconnectedCallbacks - and any connectedCallback still suspended on an await - run
+    // to completion inside the test that created them rather than the next one. A macrotask turn is
+    // required here; a microtask flush is not enough.
+    await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+    });
+});

--- a/test/helpers/guard.ts
+++ b/test/helpers/guard.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, expect, vi } from 'vitest';
+
+type Pattern = string | RegExp;
+
+const matches = (text: string, pattern: Pattern) => {
+    return typeof pattern === 'string' ? text.includes(pattern) : pattern.test(text);
+};
+
+/**
+ * Joins console arguments the way the library produces them (a single template string).
+ *
+ * @param args - The arguments the console method was called with.
+ * @returns The joined message.
+ */
+const format = (args: unknown[]) => args.map(arg => String(arg)).join(' ');
+
+/**
+ * Records messages on one channel and lets a test claim the ones it expects. Anything left
+ * unclaimed when the test ends is a failure.
+ */
+class Recorder {
+    /** Every message seen, in order. Never drained - kept for diagnostics. */
+    readonly seen: string[] = [];
+
+    /** Messages not yet accounted for. Drained as they are claimed. */
+    private pending: string[] = [];
+
+    constructor(private readonly channel: string) {}
+
+    /**
+     * Clears both lists, keeping this instance's identity.
+     *
+     * Identity matters: suites destructure the guard once at collection time
+     * (`const { warnings } = useGuard()`), so replacing the recorder objects between tests would
+     * leave the suite holding a stale one - writing to one instance and asserting against another.
+     */
+    reset() {
+        this.seen.length = 0;
+        this.pending.length = 0;
+    }
+
+    /** @param message - The message to record. */
+    record(message: string) {
+        this.seen.push(message);
+        this.pending.push(message);
+    }
+
+    /**
+     * Claims the messages matching `pattern`, asserting exactly `count` of them occurred.
+     *
+     * @param pattern - A substring or regular expression to match.
+     * @param count - The exact number expected.
+     * @returns The claimed messages.
+     */
+    expect(pattern: Pattern, count = 1): string[] {
+        const claimed = this.pending.filter(message => matches(message, pattern));
+        expect(
+            claimed.length,
+            `expected ${count} ${this.channel} message(s) matching ${String(pattern)}, saw ${claimed.length}.\n` +
+            `All ${this.channel} messages:\n${this.seen.map(message => `  - ${message}`).join('\n') || '  (none)'}`
+        ).toBe(count);
+        this.pending = this.pending.filter(message => !matches(message, pattern));
+        return claimed;
+    }
+
+    /**
+     * Claims messages matching `pattern` without asserting that any occurred.
+     *
+     * @param pattern - A substring or regular expression to match.
+     */
+    allow(pattern: Pattern) {
+        this.pending = this.pending.filter(message => !matches(message, pattern));
+    }
+
+    /** Claims everything remaining. Always accompany with a comment saying why. */
+    ignoreRest() {
+        this.pending = [];
+    }
+
+    /** Fails the test if anything was left unclaimed. */
+    assertDrained() {
+        expect(
+            this.pending,
+            `unexpected ${this.channel} output. Claim it with .expect(...) or explain it with .allow(...)`
+        ).toEqual([]);
+    }
+}
+
+export interface Guard {
+    /** console.warn - the library's entire negative-path surface. */
+    readonly warnings: Recorder;
+    /** console.error. */
+    readonly errors: Recorder;
+    /** Uncaught exceptions and unhandled rejections. Async connectedCallbacks land here. */
+    readonly uncaught: Recorder;
+}
+
+let active: Guard | null = null;
+
+/**
+ * The guard installed for the running test, so other helpers can enrich a diagnostic.
+ *
+ * @returns The active guard, or `null` outside a guarded test.
+ */
+export const currentGuard = () => active;
+
+/**
+ * Installs the console and error guard for the surrounding suite. Any `console.warn`,
+ * `console.error`, uncaught exception or unhandled rejection that a test does not explicitly claim
+ * fails that test.
+ *
+ * This is load bearing rather than convenient. The library reports every misuse through
+ * console.warn - it never throws and never rejects - so the warning IS the assertion for a whole
+ * class of behaviour, and an unclaimed warning is how a test silently stops meaning anything.
+ * Three examples that are untestable without it:
+ *
+ * - A component element outside <pc-entity>: the only observable difference from correct placement
+ *   is one warning plus `component === null`.
+ * - <pc-scene> inside a <div> throws from an async connectedCallback, so expect().toThrow() cannot
+ *   see it. Custom element reactions are reported, not propagated.
+ * - ScriptRegistry.add warns from a setTimeout on a duplicate script name, i.e. during a LATER
+ *   test. Draining attributes the leak to the test that caused it.
+ *
+ * @returns The guard. Its recorders are replaced before each test.
+ */
+export const useGuard = (): Guard => {
+    const warnings = new Recorder('warn');
+    const errors = new Recorder('error');
+    const uncaught = new Recorder('uncaught');
+
+    const guard: Guard = { warnings, errors, uncaught };
+
+    let onError: ((event: ErrorEvent) => void) | undefined;
+    let onRejection: ((event: PromiseRejectionEvent) => void) | undefined;
+
+    beforeEach(() => {
+        warnings.reset();
+        errors.reset();
+        uncaught.reset();
+        active = guard;
+
+        vi.spyOn(console, 'warn').mockImplementation((...args) => warnings.record(format(args)));
+        vi.spyOn(console, 'error').mockImplementation((...args) => errors.record(format(args)));
+
+        // The unit project runs in the node environment, where there is no window to listen on.
+        if (typeof window === 'undefined') {
+            return;
+        }
+
+        onError = (event) => {
+            event.preventDefault();
+            uncaught.record(event.error?.message ?? event.message);
+        };
+        onRejection = (event) => {
+            event.preventDefault();
+            uncaught.record((event.reason as Error)?.message ?? String(event.reason));
+        };
+        window.addEventListener('error', onError);
+        window.addEventListener('unhandledrejection', onRejection);
+    });
+
+    afterEach(() => {
+        if (typeof window !== 'undefined') {
+            if (onError) {
+                window.removeEventListener('error', onError);
+            }
+            if (onRejection) {
+                window.removeEventListener('unhandledrejection', onRejection);
+            }
+        }
+        active = null;
+
+        warnings.assertDrained();
+        errors.assertDrained();
+        uncaught.assertDrained();
+    });
+
+    return guard;
+};

--- a/test/helpers/guard.ts
+++ b/test/helpers/guard.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, vi } from 'vitest';
+import { beforeEach, expect, vi } from 'vitest';
 
 type Pattern = string | RegExp;
 
@@ -133,33 +133,31 @@ export const useGuard = (): Guard => {
     let onError: ((event: ErrorEvent) => void) | undefined;
     let onRejection: ((event: PromiseRejectionEvent) => void) | undefined;
 
-    beforeEach(() => {
-        warnings.reset();
-        errors.reset();
-        uncaught.reset();
-        active = guard;
-
-        vi.spyOn(console, 'warn').mockImplementation((...args) => warnings.record(format(args)));
-        vi.spyOn(console, 'error').mockImplementation((...args) => errors.record(format(args)));
-
-        // The unit project runs in the node environment, where there is no window to listen on.
-        if (typeof window === 'undefined') {
-            return;
-        }
-
-        onError = (event) => {
-            event.preventDefault();
-            uncaught.record(event.error?.message ?? event.message);
-        };
-        onRejection = (event) => {
-            event.preventDefault();
-            uncaught.record((event.reason as Error)?.message ?? String(event.reason));
-        };
-        window.addEventListener('error', onError);
-        window.addEventListener('unhandledrejection', onRejection);
-    });
-
-    afterEach(() => {
+    /**
+     * Teardown runs as a cleanup function returned from beforeEach, NOT as an afterEach.
+     *
+     * This is load bearing. Vitest runs hooks in this order (measured):
+     *
+     *   1. the test body
+     *   2. afterEach registered in this describe
+     *   3. afterEach registered at module scope - which is where test/helpers/dom.ts unmounts
+     *      the DOM, and therefore where <pc-app> is disconnected and destroyed
+     *   4. cleanup functions returned from beforeEach
+     *
+     * An afterEach here would assert at step 2, before anything is torn down, so every warning
+     * and unhandled rejection produced BY teardown would escape - and because beforeEach resets
+     * the recorders, it would vanish silently rather than failing anything. Teardown is exactly
+     * where this library is most fragile: disconnecting a <pc-app> before its children is what
+     * makes an in-flight connectedCallback dereference a destroyed app.
+     *
+     * Returning the cleanup from beforeEach moves the assertion to step 4, after teardown, so the
+     * console spies and window listeners are still installed while the DOM is being dismantled.
+     * Verified: a warning emitted during step 3 is invisible at step 2 and recorded at step 4.
+     *
+     * Restoration of the spies themselves is left to `restoreMocks: true` in vitest.config.ts,
+     * which Vitest applies after this cleanup - so the spies stay live for the whole teardown.
+     */
+    const teardown = () => {
         if (typeof window !== 'undefined') {
             if (onError) {
                 window.removeEventListener('error', onError);
@@ -173,6 +171,34 @@ export const useGuard = (): Guard => {
         warnings.assertDrained();
         errors.assertDrained();
         uncaught.assertDrained();
+    };
+
+    beforeEach(() => {
+        warnings.reset();
+        errors.reset();
+        uncaught.reset();
+        active = guard;
+
+        vi.spyOn(console, 'warn').mockImplementation((...args) => warnings.record(format(args)));
+        vi.spyOn(console, 'error').mockImplementation((...args) => errors.record(format(args)));
+
+        // The unit project runs in the node environment, where there is no window to listen on.
+        if (typeof window === 'undefined') {
+            return teardown;
+        }
+
+        onError = (event) => {
+            event.preventDefault();
+            uncaught.record(event.error?.message ?? event.message);
+        };
+        onRejection = (event) => {
+            event.preventDefault();
+            uncaught.record((event.reason as Error)?.message ?? String(event.reason));
+        };
+        window.addEventListener('error', onError);
+        window.addEventListener('unhandledrejection', onRejection);
+
+        return teardown;
     });
 
     return guard;

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -1,0 +1,11 @@
+export { bootApp, settle, type BootedApp, type BootOptions } from './app';
+export { assertDocumentClean, mount, type Mounted } from './dom';
+export { currentGuard, useGuard, type Guard } from './guard';
+export {
+    describeElement,
+    expectNeverReady,
+    readyOrder,
+    readyWithin,
+    NEVER_READY_WINDOW,
+    READY_TIMEOUT
+} from './ready';

--- a/test/helpers/ready.ts
+++ b/test/helpers/ready.ts
@@ -1,0 +1,112 @@
+import { expect } from 'vitest';
+
+import { currentGuard } from './guard';
+import type { AsyncElement } from '../../src/async-element';
+
+/** No ready promise in this library ever rejects, so every wait needs a deadline. */
+export const READY_TIMEOUT = 5000;
+
+/** How long to observe an element that is expected never to settle. */
+export const NEVER_READY_WINDOW = 150;
+
+/**
+ * Renders an element's position in the tree, for diagnostics.
+ *
+ * @param element - The element to describe.
+ * @returns A `parent > child` style path.
+ */
+export const describeElement = (element: Element | null | undefined): string => {
+    if (!element) {
+        return '<none>';
+    }
+    const path: string[] = [];
+    for (let node: Element | null = element; node && node !== document.body; node = node.parentElement) {
+        const id = node.id ? `#${node.id}` : '';
+        const name = node.getAttribute('name');
+        path.unshift(`${node.tagName.toLowerCase()}${id}${name === null ? '' : `[name="${name}"]`}`);
+    }
+    return path.join(' > ');
+};
+
+const TIMED_OUT = Symbol('timed out');
+
+const expire = (ms: number) => {
+    let timer: ReturnType<typeof setTimeout>;
+    const promise = new Promise<typeof TIMED_OUT>((resolve) => {
+        timer = setTimeout(() => resolve(TIMED_OUT), ms);
+    });
+    return { promise, cancel: () => clearTimeout(timer) };
+};
+
+/**
+ * Awaits an element's ready promise, failing with a diagnosis rather than a bare timeout.
+ *
+ * Nothing here rejects: a misplaced element logs a warning and its ready promise never settles. So
+ * the only useful thing a timeout can do is report WHY, which is almost always one of the warnings
+ * the guard has already captured.
+ *
+ * @param element - The element to await.
+ * @param timeout - Milliseconds to wait.
+ * @returns The element.
+ */
+export const readyWithin = async <T extends AsyncElement>(element: T, timeout = READY_TIMEOUT): Promise<T> => {
+    const deadline = expire(timeout);
+    const result = await Promise.race([element.ready(), deadline.promise]);
+    deadline.cancel();
+
+    if (result !== TIMED_OUT) {
+        return result as T;
+    }
+
+    const guard = currentGuard();
+    const warnings = guard?.warnings.seen ?? [];
+    const uncaught = guard?.uncaught.seen ?? [];
+
+    throw new Error([
+        `readyWithin: ${describeElement(element)} did not become ready within ${timeout}ms.`,
+        `  connected:      ${element.isConnected}`,
+        `  closestApp:     ${describeElement(element.closestApp)}`,
+        `  closestEntity:  ${describeElement(element.closestEntity)}`,
+        `  app created:    ${Boolean(element.closestApp?.app)}`,
+        `  hierarchyReady: ${element.closestApp?.hierarchyReady ?? 'n/a'}`,
+        warnings.length ?
+            `  warnings so far:\n${warnings.map(message => `    - ${message}`).join('\n')}` :
+            '  warnings so far: (none)',
+        uncaught.length ?
+            `  uncaught so far:\n${uncaught.map(message => `    - ${message}`).join('\n')}` :
+            '',
+        'A misplaced element warns and never settles; check the warnings above first.'
+    ].filter(Boolean).join('\n'));
+};
+
+/**
+ * Asserts an element does NOT become ready, for the documented never-settles cases (for example a
+ * `<pc-entity>` with no `<pc-app>` ancestor).
+ *
+ * A false pass is impossible - a settled promise wins the race immediately - and these paths
+ * perform no I/O, so the observation window cannot be lost to a slow machine.
+ *
+ * @param element - The element that must stay pending.
+ * @param window - Milliseconds to observe.
+ */
+export const expectNeverReady = async (element: AsyncElement, window = NEVER_READY_WINDOW) => {
+    const deadline = expire(window);
+    const result = await Promise.race([element.ready().then(() => 'ready' as const), deadline.promise]);
+    deadline.cancel();
+    expect(result, `${describeElement(element)} became ready but should never settle`).toBe(TIMED_OUT);
+};
+
+/**
+ * Records the order in which elements under `root` fire their `ready` event. Works because `ready`
+ * bubbles and is composed, so one listener observes the whole subtree.
+ *
+ * @param root - The element to listen on.
+ * @returns A function returning the ordered element descriptions.
+ */
+export const readyOrder = (root: Element) => {
+    const order: string[] = [];
+    root.addEventListener('ready', (event) => {
+        order.push(describeElement(event.target as Element));
+    });
+    return () => order;
+};

--- a/test/helpers/tags.ts
+++ b/test/helpers/tags.ts
@@ -1,0 +1,11 @@
+/**
+ * Re-exports the golden tag lists so the TypeScript suite has one place where the boundary to
+ * `utils/cem/tags.mjs` is crossed.
+ *
+ * The runtime module is `.mjs` (validate.mjs, a plain Node script, is its other consumer) with a
+ * hand-written `.d.mts` beside it for types. That pairing makes the TypeScript import resolver ask
+ * for a `.mts` specifier, which would not exist at runtime - hence the single exception here rather
+ * than one at every call site.
+ */
+// eslint-disable-next-line import/extensions
+export { COMPONENT_TAGS, READY_TAGS, TAGS } from '../../utils/cem/tags.mjs';

--- a/test/integration/environment.test.ts
+++ b/test/integration/environment.test.ts
@@ -1,0 +1,113 @@
+import type { Entity } from 'playcanvas';
+import { describe, expect, it } from 'vitest';
+
+import { bootApp } from '../helpers/app';
+import { useGuard } from '../helpers/guard';
+
+/**
+ * Pins the headless environment itself.
+ *
+ * Every other integration test is only as meaningful as these assertions. jsdom reports a
+ * clientWidth of 0 for every element, and AppElement feeds that to
+ * `setCanvasResolution(RESOLUTION_AUTO)`, so without the canvas layout stubs in test/setup/dom.ts
+ * the graphics device comes up 0x0 and every derived aspect ratio and projection matrix is NaN. A
+ * test asserting `expect(matrix).toBeDefined()` would then pass on a matrix full of NaN. If this
+ * file goes red, treat every other integration result as unreliable until it is green again.
+ */
+describe('headless environment', () => {
+    const { warnings } = useGuard();
+
+    it('boots a real application on the null graphics device with no warnings', async () => {
+        const { app } = await bootApp();
+
+        expect(app.graphicsDevice.isNull).toBe(true);
+        expect(app.graphicsDevice.deviceType).toBe('null');
+        expect(warnings.seen).toEqual([]);
+    });
+
+    it('confirms jsdom layout is dead and the canvas stub is what replaces it', () => {
+        // A <div> gets no stub, so it reports jsdom's hardcoded 0 - which is exactly what <pc-app>'s
+        // internally-created canvas would report without test/setup/dom.ts. Asserting both halves
+        // means removing the stub fails here, with a message that explains itself, rather than
+        // silently turning every downstream aspect ratio into NaN.
+        expect(document.createElement('div').clientWidth).toBe(0);
+        expect(document.createElement('canvas').clientWidth).toBe(800);
+        expect(document.createElement('canvas').getBoundingClientRect().width).toBe(800);
+    });
+
+    it('gives the graphics device the stubbed canvas dimensions rather than 0x0', async () => {
+        const { app } = await bootApp();
+
+        // 800x600 is test/setup/dom.ts's DEFAULT_VIEWPORT, multiplied by a maxPixelRatio of 1.
+        // Asserting the exact numbers - not merely "greater than zero" - means a regression in
+        // either the stub or the pixel-ratio handling is caught here rather than downstream.
+        expect(app.graphicsDevice.width).toBe(800);
+        expect(app.graphicsDevice.height).toBe(600);
+    });
+
+    it('derives a finite camera aspect ratio, proving nothing is poisoned by a 0x0 device', async () => {
+        const { app } = await bootApp('<pc-entity name="camera"><pc-camera></pc-camera></pc-entity>');
+
+        // findByName is typed as returning a GraphNode, but every node this library creates for a
+        // <pc-entity> is an Entity, which is what carries the component accessors.
+        const camera = app.root.findByName('camera') as Entity | null;
+        expect(camera).toBeTruthy();
+        expect(camera!.camera).toBeTruthy();
+
+        expect(Number.isFinite(app.graphicsDevice.width / app.graphicsDevice.height)).toBe(true);
+        expect(Number.isFinite(camera!.camera!.aspectRatio)).toBe(true);
+    });
+
+    it('builds the declared entity hierarchy under app.root', async () => {
+        const { app } = await bootApp(`
+            <pc-entity name="parent">
+                <pc-entity name="child"></pc-entity>
+            </pc-entity>
+        `);
+
+        const parent = app.root.findByName('parent');
+        const child = app.root.findByName('child');
+
+        expect(parent).toBeTruthy();
+        expect(child).toBeTruthy();
+        expect(child!.parent).toBe(parent);
+        expect(parent!.parent).toBe(app.root);
+    });
+
+    it('mounts and tears down repeatedly without leaking unhandled rejections', async () => {
+        // Removing a <pc-app> disconnects it before its children, which is the ordering the
+        // library's disconnectedCallback guards exist for. Repeating it in one test is what
+        // surfaces an in-flight connectedCallback resuming against a destroyed app: the guard's
+        // `uncaught` recorder fails the test if any rejection escapes.
+        const cycle = async () => {
+            const { unmount } = await bootApp(
+                '<pc-entity name="e"><pc-camera></pc-camera><pc-render type="box"></pc-render></pc-entity>'
+            );
+            unmount();
+            // A macrotask turn, so suspended callbacks resume before the next cycle mounts.
+            await new Promise((resolve) => {
+                setTimeout(resolve, 0);
+            });
+        };
+
+        // Written out rather than looped, so each cycle is a distinct sequential await.
+        await cycle();
+        await cycle();
+        await cycle();
+
+        expect(warnings.seen).toEqual([]);
+    });
+
+    it('loads the release build of playcanvas, not the debug build', () => {
+        // Because playcanvas is valid ESM in node_modules, Vitest externalises it and Node resolves
+        // it with the node/import conditions, landing on the release build. Inlining it would pick
+        // the development condition and give the .dbg build with Debug.assert live - a real
+        // behavioural difference decided by externalisation heuristics rather than by our config,
+        // so a future Vitest upgrade could flip it silently. This pins it.
+        const resolve = (import.meta as unknown as { resolve?: (specifier: string) => string }).resolve;
+        if (!resolve) {
+            return;
+        }
+        expect(resolve('playcanvas')).not.toContain('.dbg.');
+    });
+});

--- a/test/integration/get-entity.test.ts
+++ b/test/integration/get-entity.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { getEntity } from '../../src/utils';
+import { bootApp } from '../helpers/app';
+import { useGuard } from '../helpers/guard';
+
+/**
+ * getEntity is the one export in src/utils.ts that touches the DOM, so it is covered here against a
+ * real hierarchy rather than in the pure-unit tier.
+ */
+describe('getEntity', () => {
+    useGuard();
+
+    const markup = `
+        <pc-entity id="cube-id" name="Cube"></pc-entity>
+        <pc-entity name="Spaced Name"></pc-entity>
+    `;
+
+    it('resolves a CSS id selector', async () => {
+        const { app } = await bootApp(markup);
+        expect(getEntity('#cube-id')).toBe(app.root.findByName('Cube'));
+    });
+
+    it('resolves an attribute selector', async () => {
+        const { app } = await bootApp(markup);
+        expect(getEntity('pc-entity[name="Cube"]')).toBe(app.root.findByName('Cube'));
+    });
+
+    it('resolves a bare element id', async () => {
+        const { app } = await bootApp(markup);
+        expect(getEntity('cube-id')).toBe(app.root.findByName('Cube'));
+    });
+
+    it('falls back to a name lookup for a valid selector that matches nothing', async () => {
+        const { app } = await bootApp(markup);
+        // 'Spaced Name' is a *valid* descendant selector, so querySelector returns null rather
+        // than throwing, and the id/name fallback is what resolves it. This path does not
+        // exercise the try/catch - see the malformed-selector test below for that.
+        expect(getEntity('Spaced Name')).toBe(app.root.findByName('Spaced Name'));
+    });
+
+    it('falls back to a name lookup for a malformed selector, exercising the try/catch', async () => {
+        const { app } = await bootApp('<pc-entity name="pc-entity["></pc-entity>');
+        // An unclosed attribute selector makes querySelector throw, which is the only way into
+        // getEntity's catch block.
+        expect(getEntity('pc-entity[')).toBe(app.root.findByName('pc-entity['));
+    });
+
+    it('returns null for an empty reference', async () => {
+        await bootApp(markup);
+        expect(getEntity('')).toBeNull();
+    });
+
+    it('returns null when nothing matches', async () => {
+        await bootApp(markup);
+        expect(getEntity('#nope')).toBeNull();
+    });
+
+    it('returns null when the match is not a pc-entity', async () => {
+        await bootApp('<div id="plain"></div>');
+        expect(getEntity('#plain')).toBeNull();
+    });
+
+    it('prefers an id match over a name match', async () => {
+        const { app } = await bootApp(`
+            <pc-entity id="target" name="ById"></pc-entity>
+            <pc-entity name="target"></pc-entity>
+        `);
+        expect(getEntity('target')).toBe(app.root.findByName('ById'));
+    });
+});

--- a/test/setup/dom.ts
+++ b/test/setup/dom.ts
@@ -1,0 +1,103 @@
+import { afterEach } from 'vitest';
+
+/**
+ * jsdom has no layout engine, so every element reports a clientWidth/clientHeight of 0 and an
+ * all-zero bounding rect. Those are constant getters in jsdom's own Element-impl - `clientWidth`
+ * and `clientHeight` are literally `return 0` - so no dependency choice can fix them. In
+ * particular the `canvas` npm package does not help: it implements the 2D drawing surface
+ * (getContext('2d'), toDataURL, pixel operations), not layout, and NullGraphicsDevice never asks
+ * for a context at all.
+ *
+ * For <pc-app> this is not cosmetic:
+ *
+ * - AppElement calls app.setCanvasResolution(RESOLUTION_AUTO), which reads canvas.clientWidth and
+ *   hands it to GraphicsDevice.resizeCanvas, leaving graphicsDevice.width/height at 0.
+ * - CameraComponent then derives aspectRatio as width / height, i.e. 0 / 0 = NaN, poisoning every
+ *   projection matrix built from it.
+ * - AppElement._pickerCreate() constructs `new Picker(app, 0, 0)` and allocates 0x0 textures.
+ * - AppElement._getPickerCoordinates() divides by canvasRect.width.
+ *
+ * Measured: without these accessors a <pc-app backend="null"> reports a 0x0 device and a camera
+ * aspectRatio of NaN; with them, 800x600 and 1.3333.
+ *
+ * The engine's own suite does exactly this where it needs real dimensions - see
+ * engine/test/platform/graphics/graphics-device.test.mjs, which assigns
+ * `canvas.getBoundingClientRect = () => ({ width: 640, height: 480 })`. The only difference here
+ * is placement: those tests own the canvas, whereas AppElement creates its canvas internally
+ * inside connectedCallback, so no test can get a handle on it before the read happens. Hence the
+ * prototype.
+ *
+ * Note that canvas.style.width IS set correctly by FILLMODE_FILL_WINDOW (jsdom's window is
+ * 1024x768) - it is only the layout read-back that is dead, so the stubs go on the layout
+ * accessors and not on style.
+ */
+interface Viewport {
+    width: number;
+    height: number;
+}
+
+const DEFAULT_VIEWPORT: Readonly<Viewport> = Object.freeze({ width: 800, height: 600 });
+
+let viewport: Viewport = { ...DEFAULT_VIEWPORT };
+
+/**
+ * Overrides the size every canvas reports, for the remainder of the current test. Reset
+ * automatically in afterEach.
+ *
+ * @param width - The width in CSS pixels.
+ * @param height - The height in CSS pixels.
+ */
+export const setViewportSize = (width: number, height: number) => {
+    viewport = { width, height };
+};
+
+const layoutAccessor = (read: () => number) => ({ configurable: true, get: read });
+
+Object.defineProperties(HTMLCanvasElement.prototype, {
+    clientWidth: layoutAccessor(() => viewport.width),
+    clientHeight: layoutAccessor(() => viewport.height),
+    offsetWidth: layoutAccessor(() => viewport.width),
+    offsetHeight: layoutAccessor(() => viewport.height)
+});
+
+HTMLCanvasElement.prototype.getBoundingClientRect = function getBoundingClientRect() {
+    const { width, height } = viewport;
+    const rect = { x: 0, y: 0, top: 0, left: 0, right: width, bottom: height, width, height };
+    return { ...rect, toJSON: () => rect } as DOMRect;
+};
+
+/**
+ * jsdom's getContext() returns null AND routes a "Not implemented" error to the virtual console,
+ * which Vitest then prints. backend="null" never reaches it, so this exists purely so that a test
+ * which forgets backend="null" fails with one legible error instead of that plus jsdom noise.
+ *
+ * @returns Always `null`, matching jsdom's own unimplemented behaviour.
+ */
+HTMLCanvasElement.prototype.getContext = function getContext() {
+    return null;
+};
+
+/**
+ * jsdom already reports 1, but AppElement maps the `high-resolution` attribute straight onto
+ * device.maxPixelRatio, so tests need to be able to move it.
+ */
+Object.defineProperty(window, 'devicePixelRatio', {
+    configurable: true,
+    writable: true,
+    value: 1
+});
+
+// Deliberately NOT polyfilled:
+//
+// - ResizeObserver: zero occurrences in the engine source and zero in src/. @playcanvas/react
+//   mocks it because its own Application component uses it; nothing here does.
+// - navigator.xr: absent means XrManager reports supported === false, which is the correct
+//   headless answer. A truthy stub would push it down paths jsdom cannot honour.
+// - AudioContext: absent means SoundManager's lazy context getter returns null. Verified that
+//   <pc-sounds>/<pc-sound> still create slots via addSlot() with no context.
+
+afterEach(() => {
+    viewport = { ...DEFAULT_VIEWPORT };
+    // Spies and stubbed globals are restored by restoreMocks/unstubGlobals in vitest.config.ts.
+    // DOM teardown belongs to test/helpers/dom.ts, which owns what it mounted.
+});

--- a/test/unit/colors.test.ts
+++ b/test/unit/colors.test.ts
@@ -1,0 +1,59 @@
+import { Color } from 'playcanvas';
+import { describe, expect, it } from 'vitest';
+
+import { CSS_COLORS } from '../../src/colors';
+
+describe('CSS_COLORS', () => {
+    const entries = Object.entries(CSS_COLORS);
+
+    it('contains the full CSS named-colour set', () => {
+        expect(entries).toHaveLength(148);
+    });
+
+    it('keys are lowercase letters only, so the toLowerCase() lookup in parseColor always hits', () => {
+        const malformed = entries.map(([name]) => name).filter(name => !/^[a-z]+$/.test(name));
+        expect(malformed).toEqual([]);
+    });
+
+    it('values are all 6-digit lowercase hex, which is what Color.fromString expects', () => {
+        const malformed = entries.filter(([, hex]) => !/^#[0-9a-f]{6}$/.test(hex));
+        expect(malformed).toEqual([]);
+    });
+
+    it('every value round-trips through Color.fromString without producing NaN', () => {
+        const broken = entries.filter(([, hex]) => {
+            const { r, g, b, a } = new Color().fromString(hex);
+            return ![r, g, b, a].every(Number.isFinite);
+        });
+        expect(broken).toEqual([]);
+    });
+
+    it.for([
+        ['aqua', 'cyan'],
+        ['fuchsia', 'magenta'],
+        ['gray', 'grey'],
+        ['darkgray', 'darkgrey'],
+        ['dimgray', 'dimgrey'],
+        ['lightgray', 'lightgrey'],
+        ['slategray', 'slategrey'],
+        ['darkslategray', 'darkslategrey'],
+        ['lightslategray', 'lightslategrey']
+    ])('%s and %s are the same colour', ([first, second]) => {
+        expect(CSS_COLORS[first]).toBe(CSS_COLORS[second]);
+    });
+
+    it.for([
+        ['black', '#000000'],
+        ['white', '#ffffff'],
+        ['red', '#ff0000'],
+        ['rebeccapurple', '#663399'],
+        ['tomato', '#ff6347'],
+        ['mediumspringgreen', '#00fa9a']
+    ])('%s is %s', ([name, hex]) => {
+        expect(CSS_COLORS[name]).toBe(hex);
+    });
+
+    it('omits transparent, which has no opaque hex equivalent', () => {
+        expect(CSS_COLORS.transparent).toBeUndefined();
+    });
+});

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1,0 +1,329 @@
+import { Color, Quat, Vec2, Vec3, Vec4 } from 'playcanvas';
+import { describe, expect, it } from 'vitest';
+
+import {
+    parseBool,
+    parseColor,
+    parseComponents,
+    parseEnum,
+    parseNumber,
+    parseQuat,
+    parseVec2,
+    parseVec3,
+    parseVec4
+} from '../../src/utils';
+import { useGuard } from '../helpers/guard';
+
+/**
+ * The exact warning text is asserted at this tier, because the message is what a user actually
+ * sees, and because the interpolated default is rendered by the engine's own toString():
+ * Vec2 '[x, y]', Vec3 '[x, y, z]', Vec4 and Quat '[x, y, z, w]', Color '#rrggbb'.
+ *
+ * getEntity() is the one export that touches the DOM, so it is covered by
+ * test/elements/get-entity.test.ts rather than here.
+ */
+describe('utils', () => {
+    const { warnings } = useGuard();
+
+    describe('parseBool', () => {
+        it.for([
+            [null, true, true],
+            [null, false, false],
+            ['false', true, false],
+            ['true', false, true],
+            // A bare boolean attribute, e.g. <pc-light cast-shadows>
+            ['', false, true],
+            // Case sensitive: only the exact string 'false' is falsy
+            ['False', false, true],
+            ['FALSE', false, true],
+            // Not truthiness - '0' is a non-'false' string, so it is true
+            ['0', false, true],
+            // Not trimmed either
+            [' false ', true, true],
+            ['no', false, true]
+        ] as [string | null, boolean, boolean][])('parses %o against default %o as %o', ([value, defaultValue, expected]) => {
+            expect(parseBool(value, defaultValue)).toBe(expected);
+        });
+
+        it('never warns, because every value is valid', () => {
+            parseBool('nonsense', false);
+            expect(warnings.seen).toEqual([]);
+        });
+    });
+
+    describe('parseComponents', () => {
+        it.for([
+            ['1 2 3', 3, [1, 2, 3]],
+            ['  1   2   3  ', 3, [1, 2, 3]],
+            ['1\t2\n3', 3, [1, 2, 3]],
+            ['.5 -2 +3', 3, [0.5, -2, 3]],
+            ['1e3 2 3', 3, [1000, 2, 3]],
+            // Number() accepts hex, so this is parsed rather than rejected
+            ['0x10 2 3', 3, [16, 2, 3]],
+            // Wrong arity in both directions
+            ['1 2', 3, null],
+            ['1 2 3 4', 3, null],
+            // Non-finite values are rejected, not passed through
+            ['1 Infinity 3', 3, null],
+            ['1 NaN 3', 3, null],
+            ['1,5', 1, null],
+            ['', 3, null],
+            // ''.trim().split(/\s+/) is [''], and Number('') is 0, so a single component parses
+            // as [0]. No caller asks for one component, so this documents rather than endorses.
+            ['', 1, [0]]
+        ] as [string, number, number[] | null][])('splits %o into %o components as %o', ([value, count, expected]) => {
+            expect(parseComponents(value, count)).toEqual(expected);
+        });
+
+        it('never warns, because reporting is left to the caller', () => {
+            parseComponents('nonsense', 3);
+            expect(warnings.seen).toEqual([]);
+        });
+    });
+
+    describe('parseNumber', () => {
+        it.for([
+            ['42', 42],
+            ['  7  ', 7],
+            ['-0.5', -0.5],
+            ['1e3', 1000],
+            ['0x10', 16]
+        ] as [string, number][])('parses %o as %o', ([value, expected]) => {
+            expect(parseNumber(value, 0, 'fov')).toBe(expected);
+        });
+
+        it('returns the default when the attribute is absent, without warning', () => {
+            expect(parseNumber(null, 45, 'fov')).toBe(45);
+            expect(warnings.seen).toEqual([]);
+        });
+
+        it('falls back for an empty string, which Number would otherwise coerce to 0', () => {
+            expect(parseNumber('', 45, 'fov')).toBe(45);
+            warnings.expect('Invalid value \'\' for attribute \'fov\'. Expected a finite number. Using \'45\'.');
+        });
+
+        it('falls back for whitespace only', () => {
+            expect(parseNumber('   ', 45, 'fov')).toBe(45);
+            warnings.expect('Invalid value \'   \' for attribute \'fov\'. Expected a finite number. Using \'45\'.');
+        });
+
+        it.for(['abc', 'Infinity', '-Infinity', 'NaN', '1,5'])('falls back and warns for %o', (value) => {
+            expect(parseNumber(value, 45, 'fov')).toBe(45);
+            warnings.expect(`Invalid value '${value}' for attribute 'fov'. Expected a finite number. Using '45'.`);
+        });
+
+        it('renders a null default in the warning', () => {
+            expect(parseNumber('abc', null, 'duration')).toBeNull();
+            warnings.expect('Invalid value \'abc\' for attribute \'duration\'. Expected a finite number. Using \'null\'.');
+        });
+    });
+
+    describe('parseEnum', () => {
+        const projections = ['perspective', 'orthographic'] as const;
+
+        it('returns the value when it is valid', () => {
+            expect(parseEnum('orthographic', projections, 'perspective', 'projection')).toBe('orthographic');
+        });
+
+        it('returns the default when the attribute is absent, without warning', () => {
+            expect(parseEnum(null, projections, 'perspective', 'projection')).toBe('perspective');
+            expect(warnings.seen).toEqual([]);
+        });
+
+        it('accepts a ReadonlyMap and validates against its keys', () => {
+            const tonemaps = new Map([['none', 0], ['filmic', 2], ['aces', 4]]);
+            expect(parseEnum('filmic', tonemaps, 'none', 'tonemap')).toBe('filmic');
+        });
+
+        it('lists a map\'s keys in insertion order when the value is invalid', () => {
+            const tonemaps = new Map([['none', 0], ['filmic', 2], ['aces', 4]]);
+            expect(parseEnum('bogus', tonemaps, 'none', 'tonemap')).toBe('none');
+            warnings.expect('Invalid value \'bogus\' for attribute \'tonemap\'. Valid values: none, filmic, aces. Using \'none\'.');
+        });
+
+        it('warns for an empty string, which is not the same as an absent attribute', () => {
+            expect(parseEnum('', projections, 'perspective', 'projection')).toBe('perspective');
+            warnings.expect('Invalid value \'\' for attribute \'projection\'. Valid values: perspective, orthographic. Using \'perspective\'.');
+        });
+
+        it('is case sensitive', () => {
+            expect(parseEnum('Orthographic', projections, 'perspective', 'projection')).toBe('perspective');
+            warnings.expect('Invalid value \'Orthographic\' for attribute \'projection\'.');
+        });
+    });
+
+    describe('parseColor', () => {
+        it.for([
+            // CSS colour names, matched case insensitively via toLowerCase()
+            ['red', [1, 0, 0, 1]],
+            ['REBECCAPURPLE', [0.4, 0.2, 0.6, 1]],
+            // Hex, including the 3- and 4-digit short forms
+            ['#f00', [1, 0, 0, 1]],
+            ['#f008', [1, 0, 0, 136 / 255]],
+            ['#ff0000', [1, 0, 0, 1]],
+            ['#FF0000', [1, 0, 0, 1]],
+            ['#ff000080', [1, 0, 0, 128 / 255]],
+            // 3 or 4 space-separated components
+            ['1 0.5 0.25', [1, 0.5, 0.25, 1]],
+            ['1 0.5 0.25 0.5', [1, 0.5, 0.25, 0.5]],
+            // Out-of-range components are not clamped. Pinned, not endorsed.
+            ['2 2 2', [2, 2, 2, 1]]
+        ] as [string, [number, number, number, number]][])('parses %o', ([value, [r, g, b, a]]) => {
+            const color = parseColor(value, Color.WHITE, 'diffuse');
+            expect(color.r).toBeCloseTo(r, 5);
+            expect(color.g).toBeCloseTo(g, 5);
+            expect(color.b).toBeCloseTo(b, 5);
+            expect(color.a).toBeCloseTo(a, 5);
+        });
+
+        it('returns the default when the attribute is absent, without warning', () => {
+            expect(parseColor(null, Color.WHITE, 'diffuse')).toEqual(Color.WHITE);
+            expect(warnings.seen).toEqual([]);
+        });
+
+        it.for([
+            'notacolor',
+            // CSS functional syntax is deliberately not supported
+            'rgb(255,0,0)',
+            '#ff',
+            '#12345',
+            '1 2',
+            '1 2 3 4 5'
+        ])('falls back and warns for %o', (value) => {
+            expect(parseColor(value, Color.WHITE, 'diffuse')).toEqual(Color.WHITE);
+            warnings.expect(
+                `Invalid value '${value}' for attribute 'diffuse'. ` +
+                'Expected a CSS color name, a hex color or 3 or 4 space-separated numbers. ' +
+                'Using \'#ffffff\'.'
+            );
+        });
+
+        it('renders a non-white default in the warning as a hex string', () => {
+            // pc-camera's real clear-color default. Math.round(0.75 * 255) is 191, i.e. 0xbf.
+            const clearColor = new Color(0.75, 0.75, 0.75, 1);
+            expect(parseColor('nope', clearColor, 'clear-color')).toEqual(clearColor);
+            warnings.expect('Using \'#bfbfbf\'.');
+        });
+    });
+
+    describe('parseVec2', () => {
+        it('parses 2 components', () => {
+            expect(parseVec2('1 2', Vec2.ZERO, 'anchor')).toEqual(new Vec2(1, 2));
+        });
+
+        it.for(['1', '1 2 3', 'bad'])('falls back and warns for %o', (value) => {
+            expect(parseVec2(value, Vec2.ZERO, 'anchor')).toEqual(Vec2.ZERO);
+            warnings.expect(
+                `Invalid value '${value}' for attribute 'anchor'. Expected 2 space-separated numbers. Using '[0, 0]'.`
+            );
+        });
+    });
+
+    describe('parseVec3', () => {
+        it('parses 3 components', () => {
+            expect(parseVec3('1 2 3', Vec3.ZERO, 'position')).toEqual(new Vec3(1, 2, 3));
+        });
+
+        it('returns the default when the attribute is absent, without warning', () => {
+            expect(parseVec3(null, Vec3.ONE, 'scale')).toEqual(Vec3.ONE);
+            expect(warnings.seen).toEqual([]);
+        });
+
+        it.for(['1 2', '1 2 3 4', 'bad'])('falls back and warns for %o', (value) => {
+            expect(parseVec3(value, Vec3.ZERO, 'position')).toEqual(Vec3.ZERO);
+            warnings.expect(
+                `Invalid value '${value}' for attribute 'position'. Expected 3 space-separated numbers. Using '[0, 0, 0]'.`
+            );
+        });
+
+        it('passes a null default through', () => {
+            expect(parseVec3(null, null, 'position')).toBeNull();
+        });
+    });
+
+    describe('parseVec4', () => {
+        it('parses 4 components', () => {
+            expect(parseVec4('1 2 3 4', Vec4.ZERO, 'rect')).toEqual(new Vec4(1, 2, 3, 4));
+        });
+
+        it.for(['1 2 3', '1 2 3 4 5', 'bad'])('falls back and warns for %o', (value) => {
+            expect(parseVec4(value, Vec4.ONE, 'rect')).toEqual(Vec4.ONE);
+            warnings.expect(
+                `Invalid value '${value}' for attribute 'rect'. Expected 4 space-separated numbers. Using '[1, 1, 1, 1]'.`
+            );
+        });
+    });
+
+    describe('parseQuat', () => {
+        it('interprets 3 components as Euler angles in degrees', () => {
+            const expected = new Quat().setFromEulerAngles(0, 90, 0);
+            const actual = parseQuat('0 90 0', Quat.IDENTITY, 'rotation') as Quat;
+            expect(actual.x).toBeCloseTo(expected.x, 5);
+            expect(actual.y).toBeCloseTo(expected.y, 5);
+            expect(actual.z).toBeCloseTo(expected.z, 5);
+            expect(actual.w).toBeCloseTo(expected.w, 5);
+        });
+
+        it('round-trips through getEulerAngles', () => {
+            const euler = (parseQuat('10 20 30', Quat.IDENTITY, 'rotation') as Quat).getEulerAngles();
+            expect(euler.x).toBeCloseTo(10, 4);
+            expect(euler.y).toBeCloseTo(20, 4);
+            expect(euler.z).toBeCloseTo(30, 4);
+        });
+
+        it.for(['0 90', '0 90 0 1', 'bad'])('falls back and warns for %o', (value) => {
+            expect(parseQuat(value, Quat.IDENTITY, 'rotation')).toEqual(Quat.IDENTITY);
+            warnings.expect(
+                `Invalid value '${value}' for attribute 'rotation'. Expected 3 space-separated numbers. Using '[0, 0, 0, 1]'.`
+            );
+        });
+    });
+
+    /**
+     * cloneDefault is module private, so it is exercised through the parsers. The engine's shared
+     * math constants are Object.freeze'd, which turns the aliasing invariant into a proof rather
+     * than an approximation: if a parser returned the default by reference, writing to the result
+     * would throw in strict mode.
+     */
+    describe('cloneDefault', () => {
+        it('confirms the engine constants really are frozen, so the proof below holds', () => {
+            expect(Object.isFrozen(Vec3.ZERO)).toBe(true);
+            expect(Object.isFrozen(Color.WHITE)).toBe(true);
+        });
+
+        it('never returns the caller default instance, on the absent path', () => {
+            expect(parseVec3(null, Vec3.ZERO, 'position')).not.toBe(Vec3.ZERO);
+        });
+
+        it('never returns the caller default instance, on the invalid path', () => {
+            expect(parseVec3('bad', Vec3.ZERO, 'position')).not.toBe(Vec3.ZERO);
+            warnings.expect('Expected 3 space-separated numbers');
+        });
+
+        it('returns a distinct instance on every call', () => {
+            const first = parseVec3(null, Vec3.ZERO, 'position');
+            const second = parseVec3(null, Vec3.ZERO, 'position');
+            expect(first).not.toBe(second);
+        });
+
+        it('returns a writable clone of a frozen engine constant', () => {
+            const result = parseVec3(null, Vec3.ZERO, 'position') as Vec3;
+            expect(() => {
+                result.x = 5;
+            }).not.toThrow();
+            expect(result.x).toBe(5);
+            expect(Vec3.ZERO.x).toBe(0);
+        });
+
+        it.for([
+            ['parseVec2', () => parseVec2(null, Vec2.ZERO, 'anchor'), Vec2.ZERO],
+            ['parseVec4', () => parseVec4(null, Vec4.ONE, 'rect'), Vec4.ONE],
+            ['parseQuat', () => parseQuat(null, Quat.IDENTITY, 'rotation'), Quat.IDENTITY],
+            ['parseColor', () => parseColor(null, Color.WHITE, 'diffuse'), Color.WHITE]
+        ] as [string, () => object, object][])('applies to %s too', ([, parse, constant]) => {
+            const result = parse();
+            expect(result).not.toBe(constant);
+            expect(result).toEqual(constant);
+        });
+    });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,26 @@
+{
+    // tsconfig.json cannot simply be widened to cover test/: its `rootDir: "./src"` makes every
+    // file outside src/ a TS6059 error, and both rollup and typedoc resolve to that file by
+    // default. This is a separate, check-only program over the same compiler options.
+    //
+    // `noEmit` rather than `declaration: false`: declarationDir is inherited and tsconfig has no
+    // way to unset an inherited string option, so turning declaration off on its own raises
+    // TS5069 (declarationDir cannot be specified without declaration).
+    //
+    // `moduleResolution: "bundler"` and `strict` are inherited, so tests resolve extensionless
+    // relative imports exactly as src/ does and are held to identical strictness.
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "."
+    },
+    "include": [
+        "src/**/*",
+        "test/**/*.ts",
+        "vitest.config.ts"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/utils/cem/tags.d.mts
+++ b/utils/cem/tags.d.mts
@@ -1,0 +1,6 @@
+// Hand-written declarations so the TypeScript test suite can import the golden lists that
+// validate.mjs uses. `allowJs` is deliberately off in tsconfig.test.json: enabling it alongside
+// the inherited `declaration: true` raises TS5053.
+export declare const TAGS: string[];
+export declare const COMPONENT_TAGS: string[];
+export declare const READY_TAGS: string[];

--- a/utils/cem/tags.mjs
+++ b/utils/cem/tags.mjs
@@ -1,0 +1,27 @@
+/**
+ * The golden lists of tag names the library registers.
+ *
+ * These live in their own module because two independent checks need them: `validate.mjs`, which
+ * gates the build on the generated manifest matching them, and the runtime test suite, which gates
+ * on `customElements` matching them. The runtime check catches a case the manifest cannot see - an
+ * element added under `src/` but omitted from `src/index.ts`'s dependency-ordered import list -
+ * because the analyzer reads source files rather than the barrel.
+ */
+
+/** Every tag the library registers. Kept explicit so adding or removing an element is deliberate. */
+export const TAGS = [
+    'pc-app', 'pc-asset', 'pc-button', 'pc-camera', 'pc-collision', 'pc-element', 'pc-entity',
+    'pc-gsplat', 'pc-layoutchild', 'pc-layoutgroup', 'pc-light', 'pc-listener', 'pc-material',
+    'pc-model', 'pc-module', 'pc-particles', 'pc-render', 'pc-rigidbody', 'pc-scene', 'pc-screen',
+    'pc-script', 'pc-scripts', 'pc-scrollbar', 'pc-scrollview', 'pc-sky', 'pc-sound', 'pc-sounds'
+];
+
+/** The tags whose elements extend `ComponentElement`, and so inherit its `enabled` attribute. */
+export const COMPONENT_TAGS = [
+    'pc-button', 'pc-camera', 'pc-collision', 'pc-element', 'pc-gsplat', 'pc-layoutchild',
+    'pc-layoutgroup', 'pc-light', 'pc-listener', 'pc-particles', 'pc-render', 'pc-rigidbody',
+    'pc-screen', 'pc-scripts', 'pc-scrollbar', 'pc-scrollview', 'pc-sounds'
+];
+
+/** `pc-material` and `pc-module` extend `HTMLElement`, so they never become ready. */
+export const READY_TAGS = TAGS.filter(tag => tag !== 'pc-material' && tag !== 'pc-module');

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -13,25 +13,9 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { COMPONENT_TAGS, READY_TAGS, TAGS } from './tags.mjs';
+
 const dist = fileURLToPath(new URL('../../dist/', import.meta.url));
-
-/** Every tag the library registers. Kept explicit so adding or removing an element is deliberate. */
-const TAGS = [
-    'pc-app', 'pc-asset', 'pc-button', 'pc-camera', 'pc-collision', 'pc-element', 'pc-entity',
-    'pc-gsplat', 'pc-layoutchild', 'pc-layoutgroup', 'pc-light', 'pc-listener', 'pc-material',
-    'pc-model', 'pc-module', 'pc-particles', 'pc-render', 'pc-rigidbody', 'pc-scene', 'pc-screen',
-    'pc-script', 'pc-scripts', 'pc-scrollbar', 'pc-scrollview', 'pc-sky', 'pc-sound', 'pc-sounds'
-];
-
-/** The tags whose elements extend `ComponentElement`, and so inherit its `enabled` attribute. */
-const COMPONENT_TAGS = [
-    'pc-button', 'pc-camera', 'pc-collision', 'pc-element', 'pc-gsplat', 'pc-layoutchild',
-    'pc-layoutgroup', 'pc-light', 'pc-listener', 'pc-particles', 'pc-render', 'pc-rigidbody',
-    'pc-screen', 'pc-scripts', 'pc-scrollbar', 'pc-scrollview', 'pc-sounds'
-];
-
-/** `pc-material` and `pc-module` extend `HTMLElement`, so they never become ready. */
-const READY_TAGS = TAGS.filter(tag => tag !== 'pc-material' && tag !== 'pc-module');
 
 const failures = [];
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,112 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Shared jsdom options for the two DOM-backed projects.
+ */
+const jsdom = {
+    /**
+     * AppBase.requestAnimationFrame() calls the global rAF whenever platform.browser is true,
+     * which it is under jsdom. Without pretendToBeVisual jsdom does not define rAF at all and
+     * app.start() throws from inside the app.preload() callback - i.e. from a resource loader
+     * callback, where nothing catches it. Vitest already defaults this to true; it is pinned
+     * here so that a Vitest or jsdom default change cannot silently break the integration tier.
+     */
+    pretendToBeVisual: true,
+
+    /**
+     * Asset URLs resolve against this origin. Nothing listens on it, which is deliberate: an
+     * unreachable asset does not fail, it hangs <pc-app> forever (measured: still pending after
+     * 8s, because app.preload() gates readiness on every non-lazy asset). Integration tests
+     * therefore use no preload assets at all, or data: URIs when a real load is required.
+     */
+    url: 'http://localhost:3000/'
+};
+
+export default defineConfig({
+    test: {
+        /**
+         * Explicit `import { describe, it, expect } from 'vitest'` in every test file, matching
+         * src/'s explicit-import style. Keeps the ESLint config honest (no injected globals to
+         * declare) and avoids a global type-augmentation entry in tsconfig.test.json.
+         */
+        globals: false,
+
+        /**
+         * No AsyncElement ready promise ever rejects. A misplaced element logs a console.warn and
+         * returns a promise that never settles, so a stuck element can only surface as a timeout.
+         * Kept well above the measured 4-9ms cost of a full <pc-app backend="null"> boot.
+         */
+        testTimeout: 10000,
+        hookTimeout: 10000,
+
+        /**
+         * src/ performs 27 customElements.define() calls at module scope, and a second define for
+         * the same tag throws NotSupportedError. Per-file isolation - the default - gives each
+         * test file a fresh realm AND a fresh module graph, which is the only thing that makes
+         * those defines testable. Never run this suite with --no-isolate.
+         */
+        isolate: true,
+
+        restoreMocks: true,
+        unstubGlobals: true,
+
+        projects: [
+            {
+                extends: true,
+                test: {
+                    /**
+                     * Pure functions: the parsers in src/utils.ts and the CSS_COLORS table. No DOM
+                     * at all - getEntity() touches document, so its tests live in `elements`.
+                     */
+                    name: 'unit',
+                    environment: 'node',
+                    include: ['test/unit/**/*.test.ts']
+                }
+            },
+            {
+                extends: true,
+                test: {
+                    /**
+                     * Attribute and property surface. These import src/index.ts (and so run all 27
+                     * defines) but never connect a <pc-app>, so no engine is ever created.
+                     */
+                    name: 'elements',
+                    environment: 'jsdom',
+                    environmentOptions: { jsdom },
+                    setupFiles: ['./test/setup/dom.ts'],
+                    include: ['test/elements/**/*.test.ts']
+                }
+            },
+            {
+                extends: true,
+                test: {
+                    /** Boots a real AppBase on NullGraphicsDevice via <pc-app backend="null">. */
+                    name: 'integration',
+                    environment: 'jsdom',
+                    environmentOptions: { jsdom },
+                    setupFiles: ['./test/setup/dom.ts'],
+                    include: ['test/integration/**/*.test.ts'],
+                    testTimeout: 15000
+                }
+            }
+        ],
+
+        coverage: {
+            provider: 'v8',
+            reporter: ['text', 'html', 'lcov'],
+            reportsDirectory: './coverage',
+
+            /**
+             * The v8 provider only reports files it actually loaded, so the source set has to be
+             * named explicitly - otherwise a module with no tests at all is simply absent from the
+             * report rather than showing 0%, and the headline number flatters.
+             */
+            include: ['src/**/*.ts'],
+
+            reportOnFailure: true
+
+            // thresholds: deliberately absent until the suite has enough content to measure a
+            // floor from. See the plan's coverage section for the ratchet strategy.
+        }
+    }
+});


### PR DESCRIPTION
## Why

The library has no automated tests. `npm test` is still the npm default stub, and CI runs only `build` and `lint`. QA today is lint + `tsc --noEmit` + a successful build + the `utils/cem/validate.mjs` manifest gate + manually opening `examples/*.html` in a browser — so the entire runtime surface (~230 attributes, element lifecycle, hierarchy construction, component add/remove, teardown ordering) is verified by eyeball.

This PR lands the foundation: tooling, a shared harness, and the first tier of tests. **190 tests run in ~2s**, with no build step and no browser.

## What makes this cheap

Two properties of the library, both confirmed by actually booting the bundle in jsdom rather than by reading code:

1. **`<pc-app backend="null">` already exists.** `src/app.ts` maps it to the engine's `NullGraphicsDevice`, whose constructor never calls `getContext`. A real `AppBase` with a real entity hierarchy boots in **4–9 ms** with no GPU — no source changes required.
2. **Every setter caches to a private field and writes through only if the engine object exists.** So `createElement('pc-camera')` → `setAttribute('fov','60')` → `expect(el.fov).toBe(60)` works on a disconnected element with no engine at all.

## Tooling

- **`vitest.config.ts`** — three projects: `unit` (node), `elements` (jsdom), `integration` (jsdom). Per-file isolation is *required*, not incidental: `src/` performs 27 `customElements.define()` calls at module scope and a second define for the same tag throws. Never run with `--no-isolate`.
- **`tsconfig.test.json`** — a check-only program. `tsconfig.json` cannot simply be widened: `rootDir: "./src"` makes every file outside `src/` a TS6059 error, and rollup and typedoc both resolve to it. `noEmit` sidesteps TS5069, since an inherited `declarationDir` cannot be unset.
- **Tests live in `test/`, not beside the source** — `package.json` has `"files": ["dist", "src"]`, so co-located tests would ship in the npm tarball. Also matches engine/pcui/observer.
- **A `test` job in CI**, matching the existing file's style. Vitest auto-detects GitHub Actions and annotates failures on the diff.
- **Vitest globals off** — every test imports `describe`/`it`/`expect` explicitly, matching `src/`.

Three devDeps, exact-pinned per Renovate policy: `vitest`, `@vitest/coverage-v8`, `jsdom`. Deliberately **not** added: `canvas` (it implements 2D drawing, not layout — see below), `eslint-plugin-vitest`, `@types/node`.

## Harness (`test/helpers/`)

- **The console guard.** The library reports every misuse through `console.warn` and never throws or rejects, so warnings *are* the assertion for a whole class of behaviour. Tests claim the messages they expect; anything unclaimed fails the test. It also records uncaught exceptions and unhandled rejections — the only way to observe a throwing async `connectedCallback`, since custom element reactions are reported rather than propagated.
- **`readyWithin()`.** No ready promise ever rejects: a misplaced element warns and *never settles*. A bare `await el.ready()` would hang until the global timeout and report nothing, so on timeout this dumps connection state, `closestApp`, `closestEntity`, `hierarchyReady` and every warning seen so far.
- **`mount()`** builds detached and inserts in one operation, so every `connectedCallback` sees a complete subtree. That matches production, where `pwc.mjs` is a deferred module script and elements upgrade with their children already parsed.
- **`bootApp()`** settles the whole subtree, not just the app. `<pc-app>` resolves its own ready promise from inside `app.preload()`, *before* its descendants finish — tearing down in that window makes `addComponent` and `addSlot` dereference nulls.

## Tests

- **`src/utils.ts`** — the full parser surface, including the documented rules that are easy to get wrong (`parseBool('')` is `true`; `parseNumber('')` falls back rather than coercing to `0`; `parseEnum` accepts a `Map`), and the `cloneDefault` non-aliasing invariant — which the engine's `Object.freeze`d math constants turn into a proof rather than an approximation.
- **`src/colors.ts`** — all 148 entries, including a `Color.fromString` round-trip that would catch any malformed value.
- **Registration** — the golden tag lists move to `utils/cem/tags.mjs`, now shared by `validate.mjs` and a runtime check. This catches an element added under `src/` but omitted from `index.ts`'s dependency-ordered import list, which the manifest check *structurally cannot see* (the analyzer reads source files, not the barrel).
- **`getEntity()`** against a real hierarchy, covering both the valid-selector-no-match and the genuinely-malformed-selector fallback paths.
- **`test/integration/environment.test.ts`** — pins the headless environment itself.

## Reviewer notes

**The environment test is load-bearing.** jsdom hardcodes `clientWidth`/`clientHeight` to `return 0` (constant getters in its own `Element-impl.js`) because it has no layout engine. `AppElement` feeds `clientWidth` to `setCanvasResolution(RESOLUTION_AUTO)`, so without the stubs in `test/setup/dom.ts` the graphics device comes up **0×0 and every derived aspect ratio is `NaN`** — which would pass a naive `expect(matrix).toBeDefined()`. The test asserts the exact resulting dimensions *and* that a `<div>` still reports 0, so removing the stub fails loudly with a self-explaining message. If that file is red, treat every other integration result as unreliable.

The `canvas` npm package does **not** fix this — it implements the 2D drawing surface, not layout. The engine has never needed a stub because `engine/test/app.mjs` never calls `setCanvasResolution`; where engine *does* need real dimensions it stubs `getBoundingClientRect` exactly like this, just per-canvas. The stub goes on the prototype here because `AppElement` creates its canvas internally, so no test can reach it first.

**Coverage baseline is 22.6% statements / 7.5% branches.** No thresholds are set: this is the honest post-foundation number, and landing a threshold you immediately weaken teaches the team the number is decorative. `coverage.include` is scoped to the source tree deliberately — the v8 provider only reports files it loaded, so without it an untested module is absent from the report rather than showing 0%.

**Bugs found while building this, not addressed here.** Designing the suite surfaced seven defects, including two worth flagging now:

- `createGraphicsDevice` invokes each device attempt as the *argument* to `Promise.resolve(...)`, so a synchronous throw from `new WebglGraphicsDevice()` escapes the per-attempt `.catch()`. The promise rejects instead of falling back to the null device, so a user with WebGL disabled gets an unhandled rejection and a `<pc-app>` that never fires `ready`. This is an upstream engine issue plus a robustness gap in `src/app.ts`; it is also why `bootApp()` enforces `backend="null"`.
- `src/components/sound-slot.ts` guards teardown in `disconnectedCallback` but not `connectedCallback`, so an in-flight connect resuming after teardown throws. Reproducible on rapid add/remove.

The remaining five (`pc-entity[tags]` removal `TypeError`, `<pc-app>` attach-then-detach leaking a live app, `<pc-app>` not being re-attachable, `<pc-scene>` throwing instead of warning, and a silently never-ready stray `pc-entity`) are pinned by the later phases described below.

## Follow-up phases

Foundation only. Planned next, each independently mergeable: the table-driven attribute suite (~700 assertions over 218 attributes, driven from runtime `observedAttributes` rather than the CEM manifest); tier-3 integration scenarios including the teardown-hazard regression; extracting the pure logic from `script-component.ts`; `data:`-URI asset fixtures plus a build-gated manifest cross-check; and a Playwright tier over the built `dist/` and the example pages.

`test/README.md` documents the conventions, including the known-bug convention those phases rely on (pin actual behaviour with a `(known bug #NNN)` title plus an `it.todo` for the intent — never `it.fails()`, which passes for any failure).

## Verification

- `npm test` — 190 passed, 5 files
- `npm run lint` — clean
- `npm run type-check` — clean, both programs
- `npm run build` — passes; the CEM gate still validates 27 elements after the `tags.mjs` extraction
- `npm run publint` — unchanged (only the 3 pre-existing warnings)
- `npm pack --dry-run` — no test files in the tarball

🤖 Generated with [Claude Code](https://claude.com/claude-code)
