### PR TITLE
Fix three teardown and attribute crashes, add integration tests

### DIFF
--- a/src/components/sound-slot.ts
+++ b/src/components/sound-slot.ts
@@ -30,12 +30,30 @@ class SoundSlotElement extends AsyncElement {
     private _volume: number = 1;
 
     /**
+     * The `<pc-sounds>` this slot was added to, captured at connect time.
+     *
+     * `disconnectedCallback` cannot rediscover it: by the time the element is disconnected its
+     * `parentElement` is already `null`, so a lookup would both fail to find the component and
+     * emit a misleading "must be a direct child" warning for what is an ordinary removal.
+     */
+    private _soundElement: SoundComponentElement | null = null;
+
+    /**
      * The sound slot.
      */
     soundSlot: SoundSlot | null = null;
 
     async connectedCallback() {
-        await this.soundElement?.ready();
+        const soundElement = this.soundElement;
+        await soundElement?.ready();
+
+        // The element may have been removed, or its parent torn down, while we were waiting. A
+        // <pc-app> disconnects before its children, so by the time we resume the component can
+        // already be gone - see the matching guard in disconnectedCallback below.
+        const component = soundElement?.component;
+        if (!this.isConnected || !component) {
+            return;
+        }
 
         const options = {
             autoPlay: this._autoPlay,
@@ -49,7 +67,8 @@ class SoundSlotElement extends AsyncElement {
             options.duration = this._duration;
         }
 
-        this.soundSlot = this.soundElement!.component!.addSlot(this._name, options);
+        this._soundElement = soundElement;
+        this.soundSlot = component.addSlot(this._name, options);
         this.asset = this._asset;
         if (this._autoPlay) {
             this.soundSlot!.play();
@@ -59,9 +78,12 @@ class SoundSlotElement extends AsyncElement {
     }
 
     disconnectedCallback() {
-        // The component is null if the parent <pc-sound> (or the whole <pc-app>) is being
-        // torn down — parents disconnect first and have already removed the component.
-        this.soundElement?.component?.removeSlot(this._name);
+        // Uses the cached parent rather than a fresh lookup, since parentElement is already null
+        // by now. The component itself is null if the parent <pc-sound> (or the whole <pc-app>) is
+        // being torn down — parents disconnect first and have already removed the component.
+        this._soundElement?.component?.removeSlot(this._name);
+        this._soundElement = null;
+        this.soundSlot = null;
     }
 
     protected get soundElement(): SoundComponentElement | null {

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -333,7 +333,10 @@ class EntityElement extends AsyncElement {
                 this.scale = parseVec3(newValue, Vec3.ONE, name);
                 break;
             case 'tags':
-                this.tags = newValue.split(',').map(tag => tag.trim());
+                // newValue is null when the attribute is removed, which must restore the default
+                // rather than throw. Every other case here routes through a null-tolerant parse*
+                // helper; this one has to do it itself.
+                this.tags = newValue === null ? [] : newValue.split(',').map(tag => tag.trim());
                 break;
             case 'onpointerenter':
             case 'onpointerleave':

--- a/test/README.md
+++ b/test/README.md
@@ -47,6 +47,16 @@ custom element reactions are *reported*, not propagated, so `guard.uncaught` is 
 them. Do not install a global handler that swallows them — one such rejection is how the
 `sound-slot.ts` teardown bug was found.
 
+**Rejections are captured on `process`, not on `window`.** jsdom does not dispatch
+`unhandledrejection` on `window` — measured: a rejected promise reaches
+`process.on('unhandledRejection')` and nothing else. A `window`-only listener records nothing, which
+silently turns `expect(uncaught.seen).toEqual([])` into a vacuous assertion. Synchronous throws
+inside a custom element reaction *are* reported on `window`, so the guard listens on both.
+
+One consequence: a test cannot *expect* an unhandled rejection. Vitest fails a file on any unhandled
+rejection whether or not a test claims it, so a defect that only manifests as one (#313) is recorded
+as an `it.todo` with an explanation rather than pinned executably.
+
 **The guard asserts from a cleanup function returned by `beforeEach`, not from an `afterEach`. Do
 not "simplify" that.** Vitest's measured hook order is: test body → `afterEach` registered in the
 describe → `afterEach` registered at module scope (where `dom.ts` unmounts the DOM and destroys the

--- a/test/elements/entity.test.ts
+++ b/test/elements/entity.test.ts
@@ -1,0 +1,99 @@
+import { Vec3 } from 'playcanvas';
+import { describe, expect, it } from 'vitest';
+
+import type { EntityElement } from '../../src/entity';
+import { mount } from '../helpers/dom';
+import { useGuard } from '../helpers/guard';
+
+
+/**
+ * Element-level behaviour, with no <pc-app> and therefore no engine. Every setter caches to a
+ * private field and only writes through when `this.entity` exists, so attribute handling is fully
+ * observable on a disconnected element.
+ */
+describe('<pc-entity>', () => {
+    const { warnings } = useGuard();
+
+    const create = () => document.createElement('pc-entity') as EntityElement;
+
+    describe('[tags]', () => {
+        it('parses a comma-separated list, trimming each entry', () => {
+            const element = create();
+            element.setAttribute('tags', 'alpha, beta ,gamma');
+            expect(element.tags).toEqual(['alpha', 'beta', 'gamma']);
+        });
+
+        it('restores the default when the attribute is removed', () => {
+            // Regression test for #309. attributeChangedCallback receives null on removal, and
+            // this case used to call newValue.split(',') unguarded - which threw a TypeError
+            // synchronously out of removeAttribute, because attribute reactions run in the
+            // caller's stack for an upgraded element.
+            const element = create();
+            element.setAttribute('tags', 'alpha,beta');
+            expect(element.tags).toEqual(['alpha', 'beta']);
+
+            expect(() => element.removeAttribute('tags')).not.toThrow();
+            expect(element.tags).toEqual([]);
+        });
+
+        it('treats an empty attribute as a single empty tag', () => {
+            // ''.split(',') is [''], so this is the documented consequence rather than a special
+            // case. Pinned so a future change to the parsing is deliberate.
+            const element = create();
+            element.setAttribute('tags', '');
+            expect(element.tags).toEqual(['']);
+        });
+
+        it('does not warn for any tags value, valid or not', () => {
+            const element = create();
+            element.setAttribute('tags', 'alpha');
+            element.removeAttribute('tags');
+            expect(warnings.seen).toEqual([]);
+        });
+    });
+
+    describe('[position]', () => {
+        it('round-trips a valid value and restores the default on removal', () => {
+            const element = create();
+            element.setAttribute('position', '1 2 3');
+            expect(element.position).toEqual(new Vec3(1, 2, 3));
+
+            element.removeAttribute('position');
+            expect(element.position).toEqual(Vec3.ZERO);
+        });
+
+        it('warns and falls back for a malformed value', () => {
+            const element = create();
+            element.setAttribute('position', '1 2');
+            expect(element.position).toEqual(Vec3.ZERO);
+            warnings.expect('Invalid value \'1 2\' for attribute \'position\'. Expected 3 space-separated numbers.');
+        });
+    });
+
+    describe('#closestEntity', () => {
+        // Deliberately no <pc-app> here: this tier must not create an engine, and closestEntity
+        // does not need one. The equivalent closestApp assertions live in the integration tier,
+        // where bootApp() can settle the tree properly.
+        it('resolves an ancestor entity through an intervening element', () => {
+            const handle = mount(`
+                <pc-entity name="outer">
+                    <div>
+                        <pc-entity name="inner"></pc-entity>
+                    </div>
+                </pc-entity>
+            `);
+            const [outer, inner] = handle.all<EntityElement>('pc-entity');
+
+            // Both getters start from parentElement, so an element never matches itself, and the
+            // lookup uses closest(), so a wrapper element does not break the relationship - which
+            // is what lets markup nest entities inside layout elements.
+            expect(inner.closestEntity).toBe(outer);
+            expect(outer.closestEntity).toBeNull();
+        });
+
+        it('is null when there is no app ancestor', () => {
+            const handle = mount('<pc-entity name="stray"></pc-entity>');
+            expect(handle.get<EntityElement>('pc-entity').closestApp).toBeNull();
+        });
+    });
+});

--- a/test/helpers/guard.ts
+++ b/test/helpers/guard.ts
@@ -98,6 +98,21 @@ export interface Guard {
 let active: Guard | null = null;
 
 /**
+ * Node's process object, reached through globalThis so this file needs no @types/node.
+ *
+ * jsdom does NOT dispatch `unhandledrejection` on window - measured: a rejected promise reaches
+ * `process.on('unhandledRejection')` and nothing else. Since an async connectedCallback that throws
+ * surfaces as exactly that, listening only on window would silently record nothing and make
+ * `expect(uncaught.seen).toEqual([])` a vacuous assertion.
+ */
+type NodeProcess = {
+    on(event: 'unhandledRejection', listener: (reason: unknown) => void): void;
+    off(event: 'unhandledRejection', listener: (reason: unknown) => void): void;
+};
+
+const nodeProcess = (globalThis as { process?: NodeProcess }).process;
+
+/**
  * The guard installed for the running test, so other helpers can enrich a diagnostic.
  *
  * @returns The active guard, or `null` outside a guarded test.
@@ -131,7 +146,7 @@ export const useGuard = (): Guard => {
     const guard: Guard = { warnings, errors, uncaught };
 
     let onError: ((event: ErrorEvent) => void) | undefined;
-    let onRejection: ((event: PromiseRejectionEvent) => void) | undefined;
+    let onRejection: ((reason: unknown) => void) | undefined;
 
     /**
      * Teardown runs as a cleanup function returned from beforeEach, NOT as an afterEach.
@@ -158,13 +173,11 @@ export const useGuard = (): Guard => {
      * which Vitest applies after this cleanup - so the spies stay live for the whole teardown.
      */
     const teardown = () => {
-        if (typeof window !== 'undefined') {
-            if (onError) {
-                window.removeEventListener('error', onError);
-            }
-            if (onRejection) {
-                window.removeEventListener('unhandledrejection', onRejection);
-            }
+        if (typeof window !== 'undefined' && onError) {
+            window.removeEventListener('error', onError);
+        }
+        if (onRejection) {
+            nodeProcess?.off('unhandledRejection', onRejection);
         }
         active = null;
 
@@ -182,21 +195,22 @@ export const useGuard = (): Guard => {
         vi.spyOn(console, 'warn').mockImplementation((...args) => warnings.record(format(args)));
         vi.spyOn(console, 'error').mockImplementation((...args) => errors.record(format(args)));
 
-        // The unit project runs in the node environment, where there is no window to listen on.
-        if (typeof window === 'undefined') {
-            return teardown;
-        }
+        // Rejections arrive on process, not on window - see the note on nodeProcess above. This is
+        // what an async connectedCallback that throws turns into.
+        onRejection = (reason) => {
+            uncaught.record((reason as Error)?.message ?? String(reason));
+        };
+        nodeProcess?.on('unhandledRejection', onRejection);
 
-        onError = (event) => {
-            event.preventDefault();
-            uncaught.record(event.error?.message ?? event.message);
-        };
-        onRejection = (event) => {
-            event.preventDefault();
-            uncaught.record((event.reason as Error)?.message ?? String(event.reason));
-        };
-        window.addEventListener('error', onError);
-        window.addEventListener('unhandledrejection', onRejection);
+        // A synchronous throw inside a custom element reaction IS reported on window, so both
+        // channels are needed. The unit project runs in node, where there is no window.
+        if (typeof window !== 'undefined') {
+            onError = (event) => {
+                event.preventDefault();
+                uncaught.record(event.error?.message ?? event.message);
+            };
+            window.addEventListener('error', onError);
+        }
 
         return teardown;
     });

--- a/test/integration/lifecycle.test.ts
+++ b/test/integration/lifecycle.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AppElement } from '../../src/app';
+import { bootApp } from '../helpers/app';
+import { mount } from '../helpers/dom';
+import { useGuard } from '../helpers/guard';
+import { readyWithin } from '../helpers/ready';
+
+
+/**
+ * <pc-app> boot and teardown state. Both cases here are known bugs, pinned as current behaviour
+ * with an it.todo beside them for the intent.
+ */
+describe('<pc-app> lifecycle', () => {
+    const { uncaught } = useGuard();
+
+    const settleTask = () => new Promise((resolve) => {
+        setTimeout(resolve, 0);
+    });
+
+    it('completes boot after being detached, leaking a live application', async () => {
+        // KNOWN BUG (#311): connectedCallback never re-checks isConnected after its awaits, unlike
+        // AssetElement and MaterialElement which both do. The first await happens BEFORE _canvas
+        // and _app are assigned, so a synchronous detach runs disconnectedCallback against all-null
+        // state - it cleans up nothing - and boot then completes on the detached element, starting
+        // an rAF ticker and adding a window resize listener that nothing ever removes.
+        const handle = mount('<pc-app backend="null"></pc-app>');
+        const appElement = handle.get<AppElement>('pc-app');
+
+        appElement.remove();
+
+        await readyWithin(appElement);
+
+        expect(appElement.isConnected, 'the element is detached').toBe(false);
+        expect(appElement.app, 'yet it owns a live application').toBeTruthy();
+        expect(uncaught.seen).toEqual([]);
+
+        // Clean up after the bug, so the leak does not follow us into the next test.
+        appElement.app.destroy();
+    });
+
+    it.todo('abandons boot when pc-app is detached before its graphics device resolves');
+
+    it('leaves hierarchyReady set after teardown, while the application is gone', async () => {
+        // KNOWN BUG (#312), pinned at its root cause rather than its symptom.
+        //
+        // disconnectedCallback nulls _app but never resets _hierarchyReady, and AsyncElement's
+        // ready promise is a one-shot latch that stays resolved. That combination is what breaks
+        // re-insertion: a descendant's connectedCallback sees hierarchyReady === true and an
+        // already-resolved ready promise, then dereferences a null app.
+        //
+        // The symptom itself is not pinned executably, because re-inserting a populated <pc-app>
+        // produces three unhandled rejections and Vitest fails a file on any unhandled rejection
+        // whether or not a test claims it. Asserting the inconsistent state is crash-free and
+        // identifies the same defect.
+        const { appElement, unmount } = await bootApp('<pc-entity name="e"></pc-entity>');
+
+        expect(appElement.hierarchyReady).toBe(true);
+
+        unmount();
+        await settleTask();
+
+        expect(appElement.app, 'the application is destroyed').toBeNull();
+        expect(
+            appElement.hierarchyReady,
+            'but hierarchyReady still claims the hierarchy is live - this is the bug'
+        ).toBe(true);
+
+        // The ready promise is likewise still resolved, so a descendant awaiting it would resume
+        // immediately against the null app above.
+        await expect(appElement.ready()).resolves.toBe(appElement);
+    });
+
+    it.todo('resets hierarchyReady and re-arms readiness so a removed pc-app can be re-added');
+});

--- a/test/integration/misplacement.test.ts
+++ b/test/integration/misplacement.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AppElement } from '../../src/app';
+import type { AsyncElement } from '../../src/async-element';
+import type { ComponentElement } from '../../src/components/component';
+import { mount } from '../helpers/dom';
+import { useGuard } from '../helpers/guard';
+import { expectNeverReady, readyWithin } from '../helpers/ready';
+
+
+/**
+ * Misplaced elements are this library's entire negative-path surface, and none of them throws or
+ * rejects: each logs a console.warn naming the parent it requires and then does nothing, leaving a
+ * ready promise that never settles.
+ *
+ * These tests deliberately do NOT use bootApp(), which settles every AsyncElement in the tree - a
+ * misplaced element never settles, so it would time out. They mount directly and await only the
+ * <pc-app>.
+ */
+describe('misplaced elements', () => {
+    const { warnings } = useGuard();
+
+    /**
+     * Mounts markup and waits for the `<pc-app>` alone to become ready.
+     *
+     * @param html - The markup to place inside the `<pc-app>`.
+     * @returns The mount handle, plus the app element.
+     */
+    const bootUnsettled = async (html: string) => {
+        const handle = mount(`<pc-app backend="null">${html}</pc-app>`);
+        const appElement = handle.get<AppElement>('pc-app');
+        await readyWithin(appElement);
+        return { ...handle, appElement };
+    };
+
+    it('warns and skips the component when a component element is outside pc-entity', async () => {
+        const { get } = await bootUnsettled('<pc-camera></pc-camera>');
+        const camera = get<ComponentElement>('pc-camera');
+
+        // The documented exception to the never-settles rule: a component element outside a
+        // pc-entity still becomes ready, but with a null component.
+        await readyWithin(camera);
+        expect(camera.component).toBeNull();
+        warnings.expect('pc-camera must be a descendant of pc-entity - component not added');
+    });
+
+    it('includes the element id in the warning when one is set', async () => {
+        const { get } = await bootUnsettled('<pc-camera id="main"></pc-camera>');
+        await readyWithin(get<ComponentElement>('pc-camera'));
+        warnings.expect('pc-camera \'main\' must be a descendant of pc-entity - component not added');
+    });
+
+    it('warns and never becomes ready when pc-asset is not a direct child of pc-app', async () => {
+        const { get } = await bootUnsettled('<div><pc-asset id="tex" src="/x.png"></pc-asset></div>');
+
+        warnings.expect('pc-asset \'tex\' must be a direct child of pc-app - asset not created');
+        await expectNeverReady(get<AsyncElement>('pc-asset'));
+    });
+
+    it('warns when pc-material is not a direct child of pc-app', async () => {
+        await bootUnsettled('<div><pc-material id="red" diffuse="red"></pc-material></div>');
+
+        // pc-material extends HTMLElement rather than AsyncElement, so there is no readiness to
+        // assert - only the warning.
+        warnings.expect('pc-material \'red\' must be a direct child of pc-app - material not created');
+    });
+
+    it('warns and never becomes ready when pc-script is not a direct child of pc-scripts', async () => {
+        const { get } = await bootUnsettled(`
+            <pc-entity name="e">
+                <pc-scripts>
+                    <div><pc-script name="rotate"></pc-script></div>
+                </pc-scripts>
+            </pc-entity>
+        `);
+
+        warnings.expect('pc-script \'rotate\' must be a direct child of pc-scripts - script not created');
+        await expectNeverReady(get<AsyncElement>('pc-script'));
+    });
+
+    it('warns and never becomes ready when pc-sound is not a direct child of pc-sounds', async () => {
+        const { get } = await bootUnsettled(`
+            <pc-entity name="e">
+                <pc-sounds>
+                    <div><pc-sound name="blip"></pc-sound></div>
+                </pc-sounds>
+            </pc-entity>
+        `);
+
+        warnings.expect('pc-sound must be a direct child of a pc-sounds element');
+        await expectNeverReady(get<AsyncElement>('pc-sound'));
+    });
+
+    it('never becomes ready and logs NOTHING for a pc-entity with no pc-app ancestor', async () => {
+        // KNOWN BUG (#314): every other misplacement names the parent it requires. This one is
+        // silent, so `await whenReady(...)` hangs with a completely clean console and the
+        // documented debugging route - "check the warning" - is a dead end.
+        const handle = mount('<pc-entity name="stray"></pc-entity>');
+        const entity = handle.get<AsyncElement>('pc-entity');
+
+        await expectNeverReady(entity);
+        expect(warnings.seen, 'no warning is emitted - this is the bug').toEqual([]);
+    });
+
+    it.todo('warns that a pc-entity must be a descendant of pc-app');
+
+    // KNOWN BUG (#313): a misplaced <pc-scene> throws instead of warning, because
+    // updateSceneSettings reads this.parentElement while connectedCallback in the same file uses
+    // closestApp - so a wrapper element makes it dereference `undefined.app`.
+    //
+    // This is deliberately NOT pinned with an executable test. The throw happens inside an async
+    // connectedCallback, so it becomes an unhandled rejection, and Vitest fails the whole file on
+    // any unhandled rejection regardless of whether a test claims it. There is no way to mount a
+    // misplaced <pc-scene> and still have the file pass, and the bug cannot be reached
+    // synchronously either: updateSceneSettings only gets past its `if (this.scene)` guard once
+    // connectedCallback has run, and re-parenting an already-connected element just triggers the
+    // async path again.
+    //
+    // Once #313 is fixed the todo below becomes a normal warning assertion, matching the other
+    // cases in this file.
+    it.todo('warns and does nothing when pc-scene is not a direct child of pc-app');
+});

--- a/test/integration/teardown.test.ts
+++ b/test/integration/teardown.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AppElement } from '../../src/app';
+import type { EntityElement } from '../../src/entity';
+import { bootApp } from '../helpers/app';
+import { useGuard } from '../helpers/guard';
+
+
+/**
+ * Teardown is where this library is most fragile, because a <pc-app> disconnects BEFORE its
+ * children - so a child's disconnectedCallback runs against an application that is already
+ * destroyed, and any connectedCallback still suspended on an await resumes into the same state.
+ * Three source files carry explicit guards for this: src/components/component.ts,
+ * src/components/sound-slot.ts and src/sky.ts.
+ *
+ * These tests rely on the console guard, which asserts from a cleanup returned by beforeEach and
+ * therefore runs AFTER the DOM has been torn down. An unclaimed warning or unhandled rejection
+ * produced during teardown fails the test.
+ */
+describe('teardown', () => {
+    const { warnings, uncaught } = useGuard();
+
+    // A macrotask turn, so suspended callbacks resume and rejections are delivered.
+    const settleTask = () => new Promise((resolve) => {
+        setTimeout(resolve, 0);
+    });
+
+    it('destroys the application and removes the canvas when pc-app is removed', async () => {
+        const { appElement, app, unmount } = await bootApp('<pc-entity name="e"></pc-entity>');
+        const destroy = vi.spyOn(app, 'destroy');
+
+        expect(appElement.querySelector('canvas')).toBeTruthy();
+
+        unmount();
+        await settleTask();
+
+        expect(destroy).toHaveBeenCalledTimes(1);
+        expect(appElement.app).toBeNull();
+        expect(appElement.querySelector('canvas')).toBeNull();
+    });
+
+    it('tears down a full tree of component elements without throwing', async () => {
+        // Every element type that carries a teardown guard, in one tree.
+        const { unmount } = await bootApp(`
+            <pc-scene></pc-scene>
+            <pc-entity name="camera"><pc-camera></pc-camera></pc-entity>
+            <pc-entity name="light"><pc-light type="directional"></pc-light></pc-entity>
+            <pc-entity name="box">
+                <pc-render type="box"></pc-render>
+                <pc-sounds><pc-sound name="blip"></pc-sound></pc-sounds>
+            </pc-entity>
+        `);
+
+        unmount();
+        await settleTask();
+
+        expect(uncaught.seen).toEqual([]);
+        expect(warnings.seen).toEqual([]);
+    });
+
+    it('survives repeated mount and teardown cycles', async () => {
+        // Repetition is what surfaces state that outlives a teardown. Each cycle asserts nothing
+        // escaped, so a leak is attributed to the cycle that caused it rather than to the suite.
+        const cycle = async () => {
+            const { unmount } = await bootApp(`
+                <pc-entity name="e">
+                    <pc-camera></pc-camera>
+                    <pc-sounds><pc-sound name="blip"></pc-sound></pc-sounds>
+                </pc-entity>
+            `);
+            unmount();
+            await settleTask();
+            expect(uncaught.seen).toEqual([]);
+        };
+
+        await cycle();
+        await cycle();
+        await cycle();
+    });
+
+    it('does not throw when a pc-sound is added and removed within the same task', async () => {
+        // Regression test for #310. SoundSlotElement.connectedCallback awaits its parent's ready
+        // promise and then used to dereference `soundElement!.component!` with no re-check, so a
+        // slot removed while that await was pending resumed against a null component and threw
+        // "Cannot read properties of null (reading 'addSlot')" as an unhandled rejection.
+        const { get } = await bootApp('<pc-entity name="e"><pc-sounds></pc-sounds></pc-entity>');
+        const sounds = get('pc-sounds');
+
+        const slot = document.createElement('pc-sound');
+        slot.setAttribute('name', 'blip');
+        sounds.appendChild(slot);
+        slot.remove();
+
+        await settleTask();
+
+        expect(uncaught.seen).toEqual([]);
+    });
+
+    it('does not throw when the whole app is removed while a pc-sound is connecting', async () => {
+        // The wider version of #310: the slot itself stays put, but the <pc-app> above it is torn
+        // down while the slot's connectedCallback is still suspended.
+        const { get, unmount } = await bootApp('<pc-entity name="e"><pc-sounds></pc-sounds></pc-entity>');
+        const sounds = get('pc-sounds');
+
+        const slot = document.createElement('pc-sound');
+        slot.setAttribute('name', 'blip');
+        sounds.appendChild(slot);
+        unmount();
+
+        await settleTask();
+
+        expect(uncaught.seen).toEqual([]);
+    });
+
+    it('removes the slot from the component when a pc-sound is removed', async () => {
+        // The bug this covers was found by the test above: disconnectedCallback used to rediscover
+        // its parent through the warning getter, but parentElement is already null by then - so
+        // removeSlot was never called (the slot leaked on a still-live component) and an ordinary
+        // removal emitted a misleading "must be a direct child of a pc-sounds element" warning.
+        const { get } = await bootApp(
+            '<pc-entity name="e"><pc-sounds><pc-sound name="blip"></pc-sound></pc-sounds></pc-entity>'
+        );
+        const soundsElement = get('pc-sounds');
+        const slot = get('pc-sound');
+        const component = (soundsElement as { component?: { slots: Record<string, unknown> } }).component!;
+
+        expect(Object.keys(component.slots)).toContain('blip');
+
+        slot.remove();
+        await settleTask();
+
+        expect(Object.keys(component.slots)).not.toContain('blip');
+        expect(warnings.seen).toEqual([]);
+    });
+
+    it('recreates the hierarchy when a pc-entity subtree is removed and re-added', async () => {
+        const { app, all } = await bootApp('<pc-entity name="parent"><pc-entity name="child"></pc-entity></pc-entity>');
+        // Two pc-entity elements in this tree, so get() - which asserts a single match - is not
+        // the right accessor here.
+        const parentElement = all('pc-entity')[0];
+        const container = parentElement.parentElement as AppElement;
+
+        expect(app.root.findByName('child')).toBeTruthy();
+
+        parentElement.remove();
+        await settleTask();
+        expect(app.root.findByName('parent')).toBeNull();
+        expect(app.root.findByName('child')).toBeNull();
+
+        container.appendChild(parentElement);
+        await settleTask();
+
+        // The parent comes back, because its own disconnectedCallback reset both _entity and
+        // _built.
+        expect(app.root.findByName('parent')).toBeTruthy();
+        expect(uncaught.seen).toEqual([]);
+
+        // KNOWN BUG (#315): the child does not. src/entity.ts:151-153 nulls _entity on every
+        // descendant, but line 158 resets _built only for `this` - and because the parent has
+        // already nulled the child's _entity, the child's own disconnectedCallback skips its reset
+        // behind the `if (this.entity)` guard. So on re-insertion createEntity() makes a fresh
+        // entity while buildHierarchy() bails on the stale _built, leaving it orphaned: created,
+        // never parented, and never ready again.
+        const childElement = all<EntityElement>('pc-entity')[1];
+        expect(childElement.entity, 'the child entity is recreated').toBeTruthy();
+        expect(app.root.findByName('child'), 'but never attached to the hierarchy').toBeNull();
+        expect(childElement.entity.parent, 'and has no parent').toBeNull();
+    });
+
+    it.todo('re-attaches a nested pc-entity when its subtree is removed and re-added');
+});

--- a/test/setup/dom.ts
+++ b/test/setup/dom.ts
@@ -1,6 +1,17 @@
 import { afterEach } from 'vitest';
 
 /**
+ * Loads the library for its side effects, which is what registers all 27 custom elements.
+ *
+ * This belongs in the setup file rather than in each test, for the same reason the examples load
+ * pwc.mjs once per page: document.createElement only upgrades a tag that has already been defined,
+ * so a test file that forgets the import gets inert elements whose properties are all undefined -
+ * a confusing failure a long way from its cause. Setup files run per test file, in that file's own
+ * realm, so this registers exactly once per file.
+ */
+import '../../src/index';
+
+/**
  * jsdom has no layout engine, so every element reports a clientWidth/clientHeight of 0 and an
  * all-zero bounding rect. Those are constant getters in jsdom's own Element-impl - `clientWidth`
  * and `clientHeight` are literally `return 0` - so no dependency choice can fix them. In


### PR DESCRIPTION
Adds the integration tier and fixes the defects it surfaced. **214 tests pass, 5 todo**, still with no build and no browser.

Follows #307. Closes #309, closes #310.

## Source fixes

**#309 — removing `tags` from `<pc-entity>` threw a `TypeError`.** `attributeChangedCallback` receives `null` on removal, and this case called `newValue.split(',')` unguarded — unlike every other case in the switch, which routes through a null-tolerant `parse*` helper. Removal now restores the `[]` default; the setter already clears before adding, so the entity's tags are cleared correctly.

**#310 — `<pc-sound>` threw if removed while its `connectedCallback` was still awaiting.** It dereferenced `soundElement!.component!` after the await with no re-check, so a slot removed in that window resumed against a null component. Now captures the parent *before* awaiting and bails if the element or its component has gone — the pattern `AssetElement` and `MaterialElement` already use.

**A third bug, found by the tests written for #310.** `disconnectedCallback` rediscovered its parent through the `soundElement` getter, but `parentElement` is already `null` by then. So removing a `<pc-sound>`:

- emitted a misleading `pc-sound must be a direct child of a pc-sounds element` warning for what is an ordinary removal, and
- never called `removeSlot`, **leaking the slot** on a still-live component.

The resolved parent is now cached at connect time and used for teardown. Not filed separately since it's in the method #310 already touches.

## Harness fixes

**The `uncaught` channel never worked.** The guard listened for unhandled rejections on `window`, but jsdom doesn't dispatch them there — measured: a rejected promise reaches `process.on('unhandledRejection')` and nothing else. So it had recorded nothing since it was written, which made every `expect(uncaught.seen).toEqual([])` a **vacuous assertion**. It now listens on `process` for rejections and keeps the `window` listener for synchronous throws in element reactions, which *are* reported there.

I verified the teardown tests are real regression tests rather than decorative, by reverting the #310 fix: exactly the three sound-slot tests fail and nothing else.

**The library is now imported once by the jsdom setup file** instead of per test file. `document.createElement` only upgrades a *defined* tag, so a file that forgot the import got inert elements whose properties were all `undefined` — a confusing failure a long way from its cause. That bit me twice while writing this, so it's better handled centrally, mirroring how a page loads `pwc.mjs` once.

## Tests

- **`teardown.test.ts`** — app destroyed and canvas removed on disconnect; a tree containing every element type that carries a teardown guard (`component.ts`, `sound-slot.ts`, `sky.ts`) torn down cleanly; repeated mount/teardown cycles; and the three sound-slot regressions.
- **`misplacement.test.ts`** — the exact warning text for each misplaced element, including the documented exception where a component element outside `<pc-entity>` still becomes ready with `component === null`. These deliberately don't use `bootApp()`, which settles every element — a misplaced one never settles by design.
- **`lifecycle.test.ts`** and the entity tests — pin four known bugs as current behaviour with an `it.todo` beside each.

## One new bug: #315

Found by these tests. `EntityElement.disconnectedCallback` nulls `_entity` on every descendant but resets `_built` only for itself — and because the parent nulls the children's `_entity` first, each child's own `disconnectedCallback` skips its reset behind the `if (this.entity)` guard. So removing and re-adding a subtree recreates a nested entity while `buildHierarchy` bails on the stale `_built`, leaving it **orphaned**: created, never parented, never ready again. The top-level entity is fine, which is what makes it easy to miss.

## Reviewer notes on what is *not* pinned executably

Two defects only ever manifest as unhandled rejections, and Vitest fails a file on any unhandled rejection whether or not a test claims it. So:

- **#312** (`<pc-app>` cannot be re-added) is pinned at its **root cause** instead of its symptom — `hierarchyReady` surviving teardown while `app` is `null`, plus the ready promise remaining resolved. That's crash-free and identifies the same defect.
- **#313** (`<pc-scene>` throws when misplaced) is documented in a comment with an `it.todo`, not pinned. It can't be reached synchronously either: `updateSceneSettings` only gets past its `if (this.scene)` guard once `connectedCallback` has run, and re-parenting an already-connected element just triggers the async path again.

Both flip to normal assertions once fixed. This is the one real limitation of the known-bug convention and worth knowing about before someone tries to "fix" those todos by writing a test that can't pass.

## Verification

- `npm test` — 214 passed, 5 todo, 9 files
- `npm run lint` — clean
- `npm run type-check` — clean, both programs
- `npm run build` — passes; CEM gate validates 27 elements
- Fix-guards-test check — reverting the #310 fix fails exactly the 3 sound-slot tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
