### PR TITLE
Add parseTags and route both entity tags call sites through it

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -1,7 +1,7 @@
 import { AppBase, Entity, Vec3 } from 'playcanvas';
 
 import { AsyncElement } from './async-element';
-import { parseBool, parseVec3 } from './utils';
+import { parseBool, parseTags, parseVec3 } from './utils';
 
 /**
  * The EntityElement interface provides properties and methods for manipulating
@@ -101,9 +101,9 @@ class EntityElement extends AsyncElement {
         entity.setLocalEulerAngles(parseVec3(this.getAttribute('rotation'), Vec3.ZERO, 'rotation'));
         entity.setLocalScale(parseVec3(this.getAttribute('scale'), Vec3.ONE, 'scale'));
 
-        const tags = this.getAttribute('tags');
-        if (tags) {
-            entity.tags.add(tags.split(',').map(tag => tag.trim()));
+        const tags = parseTags(this.getAttribute('tags'));
+        if (tags.length > 0) {
+            entity.tags.add(tags);
         }
     }
 
@@ -333,10 +333,7 @@ class EntityElement extends AsyncElement {
                 this.scale = parseVec3(newValue, Vec3.ONE, name);
                 break;
             case 'tags':
-                // newValue is null when the attribute is removed, which must restore the default
-                // rather than throw. Every other case here routes through a null-tolerant parse*
-                // helper; this one has to do it itself.
-                this.tags = newValue === null ? [] : newValue.split(',').map(tag => tag.trim());
+                this.tags = parseTags(newValue);
                 break;
             case 'onpointerenter':
             case 'onpointerleave':

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,6 +19,27 @@ export const parseBool = (value: string | null, defaultValue: boolean): boolean 
 };
 
 /**
+ * Parse a tags attribute value. The expected format is a comma-separated list of tag names
+ * (e.g. 'enemy, flying'). Surrounding whitespace is trimmed from each name and empty names are
+ * discarded, so a trailing comma or a doubled separator does not produce a blank tag. Returns a
+ * copy of `defaultValue` when the attribute is absent or removed (`null`).
+ *
+ * Every value is valid, so this never warns.
+ *
+ * @param value - The attribute value to parse (`null` when the attribute is absent).
+ * @param defaultValue - The value to use when the attribute is absent or removed.
+ * @returns The parsed tag names.
+ */
+export const parseTags = (value: string | null, defaultValue: string[] = []): string[] => {
+    if (value === null) {
+        // Copied for the same reason cloneDefault exists: a parsed result must never alias the
+        // caller's default, or a later mutation would write back through it.
+        return [...defaultValue];
+    }
+    return value.split(',').map(tag => tag.trim()).filter(tag => tag !== '');
+};
+
+/**
  * Splits an attribute value into exactly `count` numeric components. Returns `null` when the
  * value does not consist of exactly `count` whitespace-separated finite numbers.
  *

--- a/test/elements/entity.test.ts
+++ b/test/elements/entity.test.ts
@@ -36,12 +36,14 @@ describe('<pc-entity>', () => {
             expect(element.tags).toEqual([]);
         });
 
-        it('treats an empty attribute as a single empty tag', () => {
-            // ''.split(',') is [''], so this is the documented consequence rather than a special
-            // case. Pinned so a future change to the parsing is deliberate.
+        it.for(['', '   ', ',', 'enemy,', ',enemy', 'enemy,,flying'])('discards empty names in %o', (value) => {
+            // Both tags call sites now route through parseTags, which drops empty names. Before
+            // that, `tags=""` set the element property to [''] - a single blank tag - while
+            // createEntity's `if (tags)` truthiness check skipped it entirely, so the element and
+            // its backing entity disagreed. See the integration test for the agreement assertion.
             const element = create();
-            element.setAttribute('tags', '');
-            expect(element.tags).toEqual(['']);
+            element.setAttribute('tags', value);
+            expect(element.tags).not.toContain('');
         });
 
         it('does not warn for any tags value, valid or not', () => {

--- a/test/integration/entity-tags.test.ts
+++ b/test/integration/entity-tags.test.ts
@@ -1,0 +1,95 @@
+import type { Entity } from 'playcanvas';
+import { describe, expect, it } from 'vitest';
+
+import type { EntityElement } from '../../src/entity';
+import { bootApp } from '../helpers/app';
+import { useGuard } from '../helpers/guard';
+import { readyWithin } from '../helpers/ready';
+
+/**
+ * `tags` is set from two independent places - createEntity, which runs when the app builds the
+ * hierarchy, and attributeChangedCallback, which runs on upgrade and on every later change. Both now
+ * route through parseTags, so these tests assert the thing that actually matters: that the element's
+ * `tags` property and the backing entity's tags agree, whichever path produced them.
+ *
+ * Before parseTags they disagreed for any value containing an empty name. `tags=""` set the element
+ * property to [''] - one blank tag - while createEntity's `if (tags)` truthiness check skipped the
+ * value entirely, leaving the entity with none.
+ */
+describe('<pc-entity> tags', () => {
+    useGuard();
+
+    const tagsOf = (element: EntityElement) => (element.entity as Entity).tags.list().sort();
+
+    describe('at boot time', () => {
+        it.for([
+            ['enemy', ['enemy']],
+            ['enemy,flying', ['enemy', 'flying']],
+            ['enemy, flying ,boss', ['boss', 'enemy', 'flying']],
+            // The cases that used to diverge
+            ['', []],
+            ['   ', []],
+            ['enemy,', ['enemy']],
+            ['enemy,,flying', ['enemy', 'flying']]
+        ] as [string, string[]][])('applies %o to the entity as %o', async ([value, expected]) => {
+            const { all } = await bootApp(`<pc-entity name="e" tags="${value}"></pc-entity>`);
+            const element = all<EntityElement>('pc-entity')[0];
+
+            expect(tagsOf(element)).toEqual(expected);
+            // The element property and the engine object must agree.
+            expect([...element.tags].sort()).toEqual(expected);
+        });
+    });
+
+    describe('inserted at runtime', () => {
+        it('applies tags through the same path as boot', async () => {
+            const { appElement, app } = await bootApp();
+
+            const element = document.createElement('pc-entity') as EntityElement;
+            element.setAttribute('name', 'runtime');
+            element.setAttribute('tags', 'enemy, flying,');
+            appElement.appendChild(element);
+
+            await readyWithin(element);
+
+            expect(tagsOf(element)).toEqual(['enemy', 'flying']);
+            expect(app.root.findByTag('enemy')).toHaveLength(1);
+        });
+    });
+
+    describe('changed after boot', () => {
+        it('replaces the entity tags when the attribute changes', async () => {
+            const { all } = await bootApp('<pc-entity name="e" tags="enemy"></pc-entity>');
+            const element = all<EntityElement>('pc-entity')[0];
+
+            element.setAttribute('tags', 'boss,flying');
+
+            // The setter clears before adding, so this is a replacement rather than a merge.
+            expect(tagsOf(element)).toEqual(['boss', 'flying']);
+        });
+
+        it('clears the entity tags when the attribute is removed', async () => {
+            const { all } = await bootApp('<pc-entity name="e" tags="enemy,flying"></pc-entity>');
+            const element = all<EntityElement>('pc-entity')[0];
+
+            element.removeAttribute('tags');
+
+            expect(element.tags).toEqual([]);
+            expect(tagsOf(element)).toEqual([]);
+        });
+
+        it('is findable through the engine registry', async () => {
+            const { app, all } = await bootApp(`
+                <pc-entity name="a" tags="enemy"></pc-entity>
+                <pc-entity name="b" tags="enemy,boss"></pc-entity>
+                <pc-entity name="c" tags="friendly"></pc-entity>
+            `);
+
+            expect(app.root.findByTag('enemy')).toHaveLength(2);
+            expect(app.root.findByTag('boss')).toHaveLength(1);
+
+            all<EntityElement>('pc-entity')[2].setAttribute('tags', 'enemy');
+            expect(app.root.findByTag('enemy')).toHaveLength(3);
+        });
+    });
+});

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -8,6 +8,7 @@ import {
     parseEnum,
     parseNumber,
     parseQuat,
+    parseTags,
     parseVec2,
     parseVec3,
     parseVec4
@@ -47,6 +48,55 @@ describe('utils', () => {
 
         it('never warns, because every value is valid', () => {
             parseBool('nonsense', false);
+            expect(warnings.seen).toEqual([]);
+        });
+    });
+
+    describe('parseTags', () => {
+        it.for([
+            ['enemy', ['enemy']],
+            ['enemy,flying', ['enemy', 'flying']],
+            // Whitespace around each name is trimmed
+            ['enemy, flying ,boss', ['enemy', 'flying', 'boss']],
+            ['  enemy  ', ['enemy']],
+            // Empty names are discarded, so a trailing comma or a doubled separator does not
+            // produce a blank tag. This is what makes the two call sites in entity.ts agree.
+            ['enemy,', ['enemy']],
+            [',enemy', ['enemy']],
+            ['enemy,,flying', ['enemy', 'flying']],
+            ['', []],
+            ['   ', []],
+            [',', []],
+            [',,,', []],
+            // Duplicates are passed through - the engine's Tags.add dedupes
+            ['enemy,enemy', ['enemy', 'enemy']],
+            // Internal whitespace is preserved: only the ends are trimmed
+            ['big enemy', ['big enemy']]
+        ] as [string, string[]][])('parses %o as %o', ([value, expected]) => {
+            expect(parseTags(value)).toEqual(expected);
+        });
+
+        it('returns an empty array by default when the attribute is absent', () => {
+            expect(parseTags(null)).toEqual([]);
+        });
+
+        it('returns the supplied default when the attribute is absent', () => {
+            expect(parseTags(null, ['fallback'])).toEqual(['fallback']);
+        });
+
+        it('never returns the caller default instance, so the result cannot alias it', () => {
+            const defaultValue = ['fallback'];
+            const result = parseTags(null, defaultValue);
+
+            expect(result).not.toBe(defaultValue);
+            result.push('mutated');
+            expect(defaultValue).toEqual(['fallback']);
+        });
+
+        it('never warns, because every value is valid', () => {
+            parseTags('');
+            parseTags(',,,');
+            parseTags('anything at all');
             expect(warnings.seen).toEqual([]);
         });
     });


### PR DESCRIPTION
Adds `parseTags` to `src/utils.ts` and routes both `tags` call sites through it. **247 tests pass, 5 todo.**

## Why

`tags` was parsed in two independent places in `entity.ts`, and the two implementations disagreed:

```ts
// createEntity
if (tags) { entity.tags.add(tags.split(',').map(tag => tag.trim())); }

// attributeChangedCallback
this.tags = newValue === null ? [] : newValue.split(',').map(tag => tag.trim());
```

For any value containing an empty name the results differed. `tags=""` set the element property to `['']` — a single blank tag — while `createEntity`'s `if (tags)` truthiness check skipped the value entirely, so **the element and its backing entity reported different tags**. `tags="enemy,"` and `tags="a,,b"` likewise added a blank tag to the entity.

Worth noting this came out of a question about sharing a helper between assets and entities. `pc-asset` has no `tags` attribute today, so there was no cross-element duplication to collapse — the duplication was inside `entity.ts` all along.

## The helper

```ts
export const parseTags = (value: string | null, defaultValue: string[] = []): string[] => {
    if (value === null) {
        return [...defaultValue];
    }
    return value.split(',').map(tag => tag.trim()).filter(tag => tag !== '');
};
```

Follows the existing conventions: null-tolerant, and no `attribute` parameter because every value is valid so it never warns — the same shape as `parseBool`. It copies the default rather than returning it by reference, for the reason `cloneDefault` exists.

## Behaviour change worth a reviewer's eye

**Empty names are now discarded.** `''` and `'   '` yield `[]`, and a trailing comma or doubled separator no longer produces a blank tag. Previously those added an empty-string tag to the entity, which is not something an author can have intended — and discarding them is what makes the two call sites agree.

This is the only shipped behaviour change here, which is why it is its own PR rather than folded into the attribute-suite work where it would be buried.

## Tests

- **18 tier-1 cases** for `parseTags` — trimming, empty-name handling, internal whitespace preserved, duplicates passed through for the engine to dedupe, the default-copy invariant, and that it never warns.
- **`test/integration/entity-tags.test.ts`** asserts the element property and the engine entity **agree** across both creation paths — boot-time and runtime insertion — plus replacement on change, clearing on removal, and lookup via `findByTag`.
- The element-tier test that pinned `tags=""` as `['']` is updated. That was the divergent behaviour, not intended behaviour — I pinned it in #316 without noticing it contradicted the boot path.

Verified these target the real defect rather than merely passing: reverting `entity.ts` to the previous logic fails **exactly** the five divergent cases and passes the six that were already consistent.

## Related

`parseTags` is also what a future `pc-asset[tags]` would use — the engine already has `Asset.tags` and `AssetRegistry.findByTag` — rather than a third implementation.

Separately filed while looking at this: #317, where `createEntity` reads attributes instead of the cached private fields, so a property set before boot is discarded. That affects `enabled`, `position`, `rotation`, `scale` and `tags`, and is deliberately not addressed here.

## Verification

- `npm test` — 247 passed, 5 todo, 10 files
- `npm run lint` — clean
- `npm run type-check` — clean, both programs
- `npm run build` — passes; CEM gate validates 27 elements
- Revert check — old logic fails exactly the 5 divergent cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
