### PR TITLE
Rename utils.ts to parse.ts and order it sensibly

### DIFF
--- a/custom-elements-manifest.config.mjs
+++ b/custom-elements-manifest.config.mjs
@@ -10,7 +10,7 @@ export default {
     // Neither file declares an element, so excluding them keeps the manifest to the public
     // element surface. The base classes in async-element.ts and components/component.ts are
     // deliberately included - the elements that extend them inherit their attributes and events.
-    exclude: ['src/colors.ts', 'src/utils.ts'],
+    exclude: ['src/colors.ts', 'src/parse.ts'],
 
     // dist is wiped by `prebuild` and shipped via the `files` and `exports` fields, so the
     // generated files can never go stale and never need committing

--- a/src/app.ts
+++ b/src/app.ts
@@ -71,7 +71,7 @@ import { AsyncElement } from './async-element';
 import { EntityElement } from './entity';
 import { MaterialElement } from './material';
 import { ModuleElement } from './module';
-import { parseBool, parseEnum } from './utils';
+import { parseBool, parseEnum } from './parse';
 
 /**
  * The AppElement interface provides properties and methods for manipulating

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -1,7 +1,7 @@
 import { Asset, SPRITE_RENDERMODE_SIMPLE, SPRITE_RENDERMODE_SLICED, SPRITE_RENDERMODE_TILED } from 'playcanvas';
 
 import { AsyncElement } from './async-element';
-import { parseBool, parseEnum, parseNumber } from './utils';
+import { parseBool, parseEnum, parseNumber } from './parse';
 import { MeshoptDecoder } from '../lib/meshopt_decoder.module.js';
 
 const renderModes = new Map<'simple' | 'sliced' | 'tiled', number>([

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -2,7 +2,7 @@ import { BUTTON_TRANSITION_MODE_SPRITE_CHANGE, BUTTON_TRANSITION_MODE_TINT, Butt
 
 import { AssetElement } from '../asset';
 import { ComponentElement } from './component';
-import { getEntity, parseBool, parseColor, parseEnum, parseNumber, parseVec4 } from '../utils';
+import { getEntity, parseBool, parseColor, parseEnum, parseNumber, parseVec4 } from '../parse';
 
 const transitionModes = new Map<'tint' | 'sprite', number>([
     ['tint', BUTTON_TRANSITION_MODE_TINT],

--- a/src/components/camera-component.ts
+++ b/src/components/camera-component.ts
@@ -1,7 +1,7 @@
 import { CameraComponent, Color, Vec4, GAMMA_NONE, GAMMA_SRGB, PROJECTION_ORTHOGRAPHIC, PROJECTION_PERSPECTIVE, TONEMAP_LINEAR, TONEMAP_FILMIC, TONEMAP_NEUTRAL, TONEMAP_ACES2, TONEMAP_ACES, TONEMAP_HEJL, TONEMAP_NONE, XRTYPE_VR } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseBool, parseColor, parseEnum, parseNumber, parseVec4 } from '../utils';
+import { parseBool, parseColor, parseEnum, parseNumber, parseVec4 } from '../parse';
 
 const tonemaps = new Map<'none' | 'linear' | 'filmic' | 'hejl' | 'aces' | 'aces2' | 'neutral', number>([
     ['none', TONEMAP_NONE],

--- a/src/components/collision-component.ts
+++ b/src/components/collision-component.ts
@@ -1,7 +1,7 @@
 import { CollisionComponent, Quat, Vec3 } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseBool, parseEnum, parseNumber, parseQuat, parseVec3 } from '../utils';
+import { parseBool, parseEnum, parseNumber, parseQuat, parseVec3 } from '../parse';
 
 /**
  * The CollisionComponentElement interface provides properties and methods for manipulating

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -2,7 +2,7 @@ import { Component } from 'playcanvas';
 
 import { AppElement } from '../app';
 import { AsyncElement } from '../async-element';
-import { parseBool } from '../utils';
+import { parseBool } from '../parse';
 
 /**
  * Represents a component in the PlayCanvas engine.

--- a/src/components/element-component.ts
+++ b/src/components/element-component.ts
@@ -2,7 +2,7 @@ import { Color, ElementComponent, Vec2, Vec4 } from 'playcanvas';
 
 import { AssetElement } from '../asset';
 import { ComponentElement } from './component';
-import { parseBool, parseColor, parseEnum, parseNumber, parseVec2, parseVec4 } from '../utils';
+import { parseBool, parseColor, parseEnum, parseNumber, parseVec2, parseVec4 } from '../parse';
 
 /**
  * The ElementComponentElement interface provides properties and methods for manipulating

--- a/src/components/gsplat-component.ts
+++ b/src/components/gsplat-component.ts
@@ -2,7 +2,7 @@ import { GSplatComponent } from 'playcanvas';
 
 import { ComponentElement } from './component';
 import { AssetElement } from '../asset';
-import { parseBool, parseNumber } from '../utils';
+import { parseBool, parseNumber } from '../parse';
 
 /**
  * The GSplatComponentElement interface provides properties and methods for manipulating

--- a/src/components/layoutchild-component.ts
+++ b/src/components/layoutchild-component.ts
@@ -1,7 +1,7 @@
 import { LayoutChildComponent } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseBool, parseNumber } from '../utils';
+import { parseBool, parseNumber } from '../parse';
 
 /**
  * The LayoutChildComponentElement interface provides properties and methods for manipulating

--- a/src/components/layoutgroup-component.ts
+++ b/src/components/layoutgroup-component.ts
@@ -1,7 +1,7 @@
 import { FITTING_NONE, FITTING_STRETCH, FITTING_SHRINK, FITTING_BOTH, LayoutGroupComponent, ORIENTATION_HORIZONTAL, ORIENTATION_VERTICAL, Vec2, Vec4 } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseBool, parseEnum, parseVec2, parseVec4 } from '../utils';
+import { parseBool, parseEnum, parseVec2, parseVec4 } from '../parse';
 
 const orientations = new Map<'horizontal' | 'vertical', number>([
     ['horizontal', ORIENTATION_HORIZONTAL],

--- a/src/components/light-component.ts
+++ b/src/components/light-component.ts
@@ -1,7 +1,7 @@
 import { Color, LightComponent, SHADOW_PCF1_16F, SHADOW_PCF1_32F, SHADOW_PCF3_16F, SHADOW_PCF3_32F, SHADOW_PCF5_16F, SHADOW_PCF5_32F, SHADOW_PCSS_32F, SHADOW_VSM_16F, SHADOW_VSM_32F } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseBool, parseColor, parseEnum, parseNumber } from '../utils';
+import { parseBool, parseColor, parseEnum, parseNumber } from '../parse';
 
 const shadowTypes = new Map<'pcf1-16f' | 'pcf1-32f' | 'pcf3-16f' | 'pcf3-32f' | 'pcf5-16f' | 'pcf5-32f' | 'vsm-16f' | 'vsm-32f' | 'pcss-32f', number>([
     ['pcf1-16f', SHADOW_PCF1_16F],

--- a/src/components/render-component.ts
+++ b/src/components/render-component.ts
@@ -2,7 +2,7 @@ import { RenderComponent, StandardMaterial } from 'playcanvas';
 
 import { ComponentElement } from './component';
 import { MaterialElement } from '../material';
-import { parseBool, parseEnum } from '../utils';
+import { parseBool, parseEnum } from '../parse';
 
 /**
  * The RenderComponentElement interface provides properties and methods for manipulating

--- a/src/components/rigidbody-component.ts
+++ b/src/components/rigidbody-component.ts
@@ -1,7 +1,7 @@
 import { RigidBodyComponent, Vec3 } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseEnum, parseNumber, parseVec3 } from '../utils';
+import { parseEnum, parseNumber, parseVec3 } from '../parse';
 
 /**
  * The RigidBodyComponentElement interface provides properties and methods for manipulating

--- a/src/components/screen-component.ts
+++ b/src/components/screen-component.ts
@@ -1,7 +1,7 @@
 import { SCALEMODE_BLEND, SCALEMODE_NONE, ScreenComponent, Vec2 } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseBool, parseNumber, parseVec2 } from '../utils';
+import { parseBool, parseNumber, parseVec2 } from '../parse';
 
 /**
  * The ScreenComponentElement interface provides properties and methods for manipulating

--- a/src/components/script-component.ts
+++ b/src/components/script-component.ts
@@ -3,7 +3,7 @@ import { Color, Quat, ScriptComponent, Script, Vec2, Vec3, Vec4 } from 'playcanv
 import { AssetElement } from '../asset';
 import { ComponentElement } from './component';
 import { ScriptElement } from './script';
-import { getEntity, parseBool, parseColor, parseComponents, parseNumber, parseQuat, parseVec2, parseVec3, parseVec4 } from '../utils';
+import { getEntity, parseBool, parseColor, parseComponents, parseNumber, parseQuat, parseVec2, parseVec3, parseVec4 } from '../parse';
 
 /**
  * Attributes on `pc-script` that never map to script attributes: the element's own API (derived

--- a/src/components/script.ts
+++ b/src/components/script.ts
@@ -1,7 +1,7 @@
 import { Script } from 'playcanvas';
 
 import { AsyncElement } from '../async-element';
-import { parseBool } from '../utils';
+import { parseBool } from '../parse';
 
 /**
  * The ScriptElement interface provides properties and methods for manipulating

--- a/src/components/scrollbar-component.ts
+++ b/src/components/scrollbar-component.ts
@@ -1,7 +1,7 @@
 import { ORIENTATION_HORIZONTAL, ORIENTATION_VERTICAL, ScrollbarComponent } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { getEntity, parseEnum, parseNumber } from '../utils';
+import { getEntity, parseEnum, parseNumber } from '../parse';
 
 const orientations = new Map<'horizontal' | 'vertical', number>([
     ['horizontal', ORIENTATION_HORIZONTAL],

--- a/src/components/scrollview-component.ts
+++ b/src/components/scrollview-component.ts
@@ -1,7 +1,7 @@
 import { SCROLL_MODE_BOUNCE, SCROLL_MODE_CLAMP, SCROLL_MODE_INFINITE, SCROLLBAR_VISIBILITY_SHOW_ALWAYS, SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED, ScrollViewComponent, Vec2 } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { getEntity, parseBool, parseEnum, parseNumber, parseVec2 } from '../utils';
+import { getEntity, parseBool, parseEnum, parseNumber, parseVec2 } from '../parse';
 
 const scrollModes = new Map<'clamp' | 'bounce' | 'infinite', number>([
     ['clamp', SCROLL_MODE_CLAMP],

--- a/src/components/sound-component.ts
+++ b/src/components/sound-component.ts
@@ -1,7 +1,7 @@
 import { SoundComponent } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseBool, parseEnum, parseNumber } from '../utils';
+import { parseBool, parseEnum, parseNumber } from '../parse';
 
 /**
  * The SoundComponentElement interface provides properties and methods for manipulating

--- a/src/components/sound-slot.ts
+++ b/src/components/sound-slot.ts
@@ -3,7 +3,7 @@ import { SoundSlot } from 'playcanvas';
 import { AssetElement } from '../asset';
 import { AsyncElement } from '../async-element';
 import { SoundComponentElement } from './sound-component';
-import { parseBool, parseNumber } from '../utils';
+import { parseBool, parseNumber } from '../parse';
 
 /**
  * The SoundSlotElement interface provides properties and methods for manipulating

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -1,7 +1,7 @@
 import { AppBase, Entity, Vec3 } from 'playcanvas';
 
 import { AsyncElement } from './async-element';
-import { parseBool, parseTags, parseVec3 } from './utils';
+import { parseBool, parseTags, parseVec3 } from './parse';
 
 /**
  * The EntityElement interface provides properties and methods for manipulating

--- a/src/material.ts
+++ b/src/material.ts
@@ -2,7 +2,7 @@ import { Color, StandardMaterial, Texture } from 'playcanvas';
 
 import { AppElement } from './app';
 import { AssetElement } from './asset';
-import { parseColor } from './utils';
+import { parseColor } from './parse';
 
 /**
  * The MaterialElement interface provides properties and methods for manipulating

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,43 +1,24 @@
+/**
+ * Converts HTML attribute values into the values the engine expects. Every element's
+ * `attributeChangedCallback` funnels through this module.
+ *
+ * The parsers share one contract:
+ *
+ * - A `null` value means the attribute is absent or was removed, and yields the supplied default.
+ * - A malformed value yields the same default and logs exactly one `console.warn` naming the
+ *   attribute, so misuse is reported rather than thrown — nothing here throws or rejects.
+ * - A math-type default is cloned on the way out, which is what makes it safe to pass the engine's
+ *   shared frozen constants (`Vec3.ZERO`, `Color.WHITE`) as defaults.
+ * - `parseBool` and `parseTags` take no attribute name, because every value is valid for them and
+ *   so they never warn.
+ *
+ * `getEntity` is the exception: it resolves a reference to a live entity rather than parsing a
+ * literal, and returns `null` instead of falling back to a default.
+ */
+
 import { Color, Entity, Quat, Vec2, Vec3, Vec4 } from 'playcanvas';
 
 import { CSS_COLORS } from './colors';
-
-/**
- * Parse a boolean attribute value. The same rules apply to every boolean attribute:
- *
- * - Attribute absent (or removed): the supplied default is used.
- * - Attribute set to the string 'false': `false`.
- * - Attribute present with any other value, including the empty string of a bare boolean
- *   attribute (e.g. `<pc-light cast-shadows>`): `true`.
- *
- * @param value - The attribute value to parse (`null` when the attribute is absent).
- * @param defaultValue - The value to use when the attribute is absent or removed.
- * @returns The parsed boolean.
- */
-export const parseBool = (value: string | null, defaultValue: boolean): boolean => {
-    return value === null ? defaultValue : value !== 'false';
-};
-
-/**
- * Parse a tags attribute value. The expected format is a comma-separated list of tag names
- * (e.g. 'enemy, flying'). Surrounding whitespace is trimmed from each name and empty names are
- * discarded, so a trailing comma or a doubled separator does not produce a blank tag. Returns a
- * copy of `defaultValue` when the attribute is absent or removed (`null`).
- *
- * Every value is valid, so this never warns.
- *
- * @param value - The attribute value to parse (`null` when the attribute is absent).
- * @param defaultValue - The value to use when the attribute is absent or removed.
- * @returns The parsed tag names.
- */
-export const parseTags = (value: string | null, defaultValue: string[] = []): string[] => {
-    if (value === null) {
-        // Copied for the same reason cloneDefault exists: a parsed result must never alias the
-        // caller's default, or a later mutation would write back through it.
-        return [...defaultValue];
-    }
-    return value.split(',').map(tag => tag.trim()).filter(tag => tag !== '');
-};
 
 /**
  * Splits an attribute value into exactly `count` numeric components. Returns `null` when the
@@ -66,6 +47,22 @@ export const parseComponents = (value: string, count: number): number[] | null =
  */
 const cloneDefault = <T extends Color | Quat | Vec2 | Vec3 | Vec4 | null>(value: T): T => {
     return (value === null ? null : value.clone()) as T;
+};
+
+/**
+ * Parse a boolean attribute value. The same rules apply to every boolean attribute:
+ *
+ * - Attribute absent (or removed): the supplied default is used.
+ * - Attribute set to the string 'false': `false`.
+ * - Attribute present with any other value, including the empty string of a bare boolean
+ *   attribute (e.g. `<pc-light cast-shadows>`): `true`.
+ *
+ * @param value - The attribute value to parse (`null` when the attribute is absent).
+ * @param defaultValue - The value to use when the attribute is absent or removed.
+ * @returns The parsed boolean.
+ */
+export const parseBool = (value: string | null, defaultValue: boolean): boolean => {
+    return value === null ? defaultValue : value !== 'false';
 };
 
 /**
@@ -111,6 +108,56 @@ export const parseColor = <T extends Color | null>(value: string | null, default
 };
 
 /**
+ * Resolves an enum attribute value against its set of valid names. Returns the value when it is
+ * one of the valid names. Returns `defaultValue` when the attribute is absent (`null`), or when
+ * the value is invalid — the latter also logs a warning listing the valid names.
+ *
+ * @param value - The attribute value to parse (`null` when the attribute is absent).
+ * @param valid - The valid names: an array, or a map whose keys are the valid names.
+ * @param defaultValue - The value to use when the attribute is absent or invalid.
+ * @param attribute - The attribute name, used in the warning message.
+ * @returns The resolved enum name.
+ */
+export const parseEnum = <T extends string>(
+    value: string | null,
+    valid: readonly T[] | ReadonlyMap<T, number>,
+    defaultValue: T,
+    attribute: string
+): T => {
+    if (value === null) {
+        return defaultValue;
+    }
+    const names = Array.isArray(valid) ? valid : [...(valid as ReadonlyMap<T, number>).keys()];
+    if (names.includes(value as T)) {
+        return value as T;
+    }
+    console.warn(`Invalid value '${value}' for attribute '${attribute}'. Valid values: ${names.join(', ')}. Using '${defaultValue}'.`);
+    return defaultValue;
+};
+
+/**
+ * Parses a number attribute value. Returns the parsed number when the value is a finite number.
+ * Returns `defaultValue` when the attribute is absent (`null`), or when the value is not a
+ * finite number — the latter also logs a warning.
+ *
+ * @param value - The attribute value to parse (`null` when the attribute is absent).
+ * @param defaultValue - The value to use when the attribute is absent or invalid.
+ * @param attribute - The attribute name, used in the warning message.
+ * @returns The parsed number.
+ */
+export const parseNumber = <T extends number | null>(value: string | null, defaultValue: T, attribute: string): number | T => {
+    if (value === null) {
+        return defaultValue;
+    }
+    const number = value.trim() === '' ? NaN : Number(value);
+    if (!Number.isFinite(number)) {
+        console.warn(`Invalid value '${value}' for attribute '${attribute}'. Expected a finite number. Using '${defaultValue}'.`);
+        return defaultValue;
+    }
+    return number;
+};
+
+/**
  * Parse an Euler-angles attribute value into a quaternion. The expected format is 3
  * space-separated angles in degrees (e.g. '0 90 0'). Returns `defaultValue` (cloned, when it is
  * a quaternion) when the attribute is absent (`null`), or when the value is malformed — the
@@ -131,6 +178,27 @@ export const parseQuat = <T extends Quat | null>(value: string | null, defaultVa
         return cloneDefault(defaultValue);
     }
     return new Quat().setFromEulerAngles(components[0], components[1], components[2]);
+};
+
+/**
+ * Parse a tags attribute value. The expected format is a comma-separated list of tag names
+ * (e.g. 'enemy, flying'). Surrounding whitespace is trimmed from each name and empty names are
+ * discarded, so a trailing comma or a doubled separator does not produce a blank tag. Returns a
+ * copy of `defaultValue` when the attribute is absent or removed (`null`).
+ *
+ * Every value is valid, so this never warns.
+ *
+ * @param value - The attribute value to parse (`null` when the attribute is absent).
+ * @param defaultValue - The value to use when the attribute is absent or removed.
+ * @returns The parsed tag names.
+ */
+export const parseTags = (value: string | null, defaultValue: string[] = []): string[] => {
+    if (value === null) {
+        // Copied for the same reason cloneDefault exists: a parsed result must never alias the
+        // caller's default, or a later mutation would write back through it.
+        return [...defaultValue];
+    }
+    return value.split(',').map(tag => tag.trim()).filter(tag => tag !== '');
 };
 
 /**
@@ -197,56 +265,6 @@ export const parseVec4 = <T extends Vec4 | null>(value: string | null, defaultVa
         return cloneDefault(defaultValue);
     }
     return new Vec4(components);
-};
-
-/**
- * Resolves an enum attribute value against its set of valid names. Returns the value when it is
- * one of the valid names. Returns `defaultValue` when the attribute is absent (`null`), or when
- * the value is invalid — the latter also logs a warning listing the valid names.
- *
- * @param value - The attribute value to parse (`null` when the attribute is absent).
- * @param valid - The valid names: an array, or a map whose keys are the valid names.
- * @param defaultValue - The value to use when the attribute is absent or invalid.
- * @param attribute - The attribute name, used in the warning message.
- * @returns The resolved enum name.
- */
-export const parseEnum = <T extends string>(
-    value: string | null,
-    valid: readonly T[] | ReadonlyMap<T, number>,
-    defaultValue: T,
-    attribute: string
-): T => {
-    if (value === null) {
-        return defaultValue;
-    }
-    const names = Array.isArray(valid) ? valid : [...(valid as ReadonlyMap<T, number>).keys()];
-    if (names.includes(value as T)) {
-        return value as T;
-    }
-    console.warn(`Invalid value '${value}' for attribute '${attribute}'. Valid values: ${names.join(', ')}. Using '${defaultValue}'.`);
-    return defaultValue;
-};
-
-/**
- * Parses a number attribute value. Returns the parsed number when the value is a finite number.
- * Returns `defaultValue` when the attribute is absent (`null`), or when the value is not a
- * finite number — the latter also logs a warning.
- *
- * @param value - The attribute value to parse (`null` when the attribute is absent).
- * @param defaultValue - The value to use when the attribute is absent or invalid.
- * @param attribute - The attribute name, used in the warning message.
- * @returns The parsed number.
- */
-export const parseNumber = <T extends number | null>(value: string | null, defaultValue: T, attribute: string): number | T => {
-    if (value === null) {
-        return defaultValue;
-    }
-    const number = value.trim() === '' ? NaN : Number(value);
-    if (!Number.isFinite(number)) {
-        console.warn(`Invalid value '${value}' for attribute '${attribute}'. Expected a finite number. Using '${defaultValue}'.`);
-        return defaultValue;
-    }
-    return number;
 };
 
 /**

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -2,7 +2,7 @@ import { Color, Scene, Vec3 } from 'playcanvas';
 
 import { AppElement } from './app';
 import { AsyncElement } from './async-element';
-import { parseColor, parseEnum, parseNumber, parseVec3 } from './utils';
+import { parseColor, parseEnum, parseNumber, parseVec3 } from './parse';
 
 /**
  * The SceneElement interface provides properties and methods for manipulating

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -3,7 +3,7 @@ import { Asset, EnvLighting, LAYERID_SKYBOX, Quat, Scene, Texture, Vec3 } from '
 import { AppElement } from './app';
 import { AssetElement } from './asset';
 import { AsyncElement } from './async-element';
-import { parseBool, parseEnum, parseNumber, parseVec3 } from './utils';
+import { parseBool, parseEnum, parseNumber, parseVec3 } from './parse';
 
 /**
  * The SkyElement interface provides properties and methods for manipulating

--- a/test/README.md
+++ b/test/README.md
@@ -4,7 +4,7 @@ Four tiers, three of which run in Node with jsdom and need neither a build nor a
 
 | Tier | Command | Environment | Covers |
 |---|---|---|---|
-| Unit | `npm run test:unit` | `node` | The pure parsers in `src/utils.ts` and the `CSS_COLORS` table |
+| Unit | `npm run test:unit` | `node` | The pure parsers in `src/parse.ts` and the `CSS_COLORS` table |
 | Elements | `npm run test:elements` | `jsdom` | Attribute and property surface, with no engine created |
 | Integration | `npm run test:integration` | `jsdom` | A real `AppBase` on `NullGraphicsDevice`, via `<pc-app backend="null">` |
 | Browser | *(not yet implemented)* | Chromium | The built `dist/` bundle and the example pages |

--- a/test/integration/get-entity.test.ts
+++ b/test/integration/get-entity.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { getEntity } from '../../src/utils';
+import { getEntity } from '../../src/parse';
 import { bootApp } from '../helpers/app';
 import { useGuard } from '../helpers/guard';
 
 /**
- * getEntity is the one export in src/utils.ts that touches the DOM, so it is covered here against a
+ * getEntity is the one export in src/parse.ts that touches the DOM, so it is covered here against a
  * real hierarchy rather than in the pure-unit tier.
  */
 describe('getEntity', () => {

--- a/test/unit/parse.test.ts
+++ b/test/unit/parse.test.ts
@@ -12,7 +12,7 @@ import {
     parseVec2,
     parseVec3,
     parseVec4
-} from '../../src/utils';
+} from '../../src/parse';
 import { useGuard } from '../helpers/guard';
 
 /**
@@ -21,9 +21,9 @@ import { useGuard } from '../helpers/guard';
  * Vec2 '[x, y]', Vec3 '[x, y, z]', Vec4 and Quat '[x, y, z, w]', Color '#rrggbb'.
  *
  * getEntity() is the one export that touches the DOM, so it is covered by
- * test/elements/get-entity.test.ts rather than here.
+ * test/integration/get-entity.test.ts rather than here.
  */
-describe('utils', () => {
+describe('parse', () => {
     const { warnings } = useGuard();
 
     describe('parseBool', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -55,7 +55,7 @@ export default defineConfig({
                 extends: true,
                 test: {
                     /**
-                     * Pure functions: the parsers in src/utils.ts and the CSS_COLORS table. No DOM
+                     * Pure functions: the parsers in src/parse.ts and the CSS_COLORS table. No DOM
                      * at all - getEntity() touches document, so its tests live in `elements`.
                      */
                     name: 'unit',


### PR DESCRIPTION
Renames `src/utils.ts` to `src/parse.ts`, orders it sensibly, and documents the contract its parsers share. **247 tests pass, 5 todo.** No public API change.

## Why rename

`utils` said nothing about what the module does — and it turns out it isn't a grab bag. All ten exports convert an HTML attribute value into a value the engine expects, which makes it the module every `attributeChangedCallback` in the library depends on. `parse.ts` says that.

`getEntity` looked like the exception that would block this, but it isn't: all **twelve** of its call sites — across `button`, `script`, `scrollbar` and `scrollview` components — resolve an attribute string to an entity, exactly as the parsers resolve one to a colour or a vector.

```ts
const handle = getEntity(this._handle);          // scrollbar-component.ts:40
const viewport = getEntity(this._viewport);      // scrollview-component.ts:70
```

Its **name** is kept, though. Its contract genuinely differs — no default, no attribute name, no warning, and `null` rather than a fallback — so the different prefix communicates something real. Renaming it to `parseEntity` would flatten that.

## Why reorder

The previous order was historical accretion — neither alphabetical, nor grouped, nor dependency-ordered:

```
parseBool, parseTags, parseComponents, [cloneDefault], parseColor,
parseQuat, parseVec2, parseVec3, parseVec4, parseEnum, parseNumber, getEntity
```

- `parseEnum` and `parseNumber` were stranded after the Vec family, despite `parseNumber` being the most-called helper in the library (92 call sites).
- The two shared internals sat in the middle, *after* two parsers that don't use them.
- `parseTags` was second because that's where I happened to add it in #318.

Now three buckets, alphabetical within each — a rule simple enough that nobody has to remember a taxonomy:

```
internals   parseComponents, cloneDefault
parsers     parseBool, parseColor, parseEnum, parseNumber, parseQuat,
            parseTags, parseVec2, parseVec3, parseVec4
resolver    getEntity
```

Reading top-down you now meet `parseComponents` and `cloneDefault` before their users.

## Module header

Added, stating what the parsers share: `null` yields the default; malformed yields the default plus exactly one `console.warn`; math defaults are cloned so the engine's frozen constants are safe to pass; and the two helpers that cannot fail take no attribute name. Previously that was only inferable by reading nine JSDoc blocks.

## The non-obvious part

`custom-elements-manifest.config.mjs` excluded `src/utils.ts` **by path**. Left alone, the analyzer would have started ingesting `parse.ts` and changed the shipped manifest — a silent break that `publint` wouldn't catch and that only `utils/cem/validate.mjs` might. Updated, and verified afterwards that the manifest still has 30 modules, still validates 27 elements, and contains no module for `parse`.

## Scope

Mechanical otherwise: every import site updated, and the test module renamed to `test/unit/parse.test.ts` to keep mirroring its source per the convention in `test/README.md`. Both moves are staged as renames (`git mv`), so `git log --follow` still works.

The module is internal and was never re-exported from `index.ts`, so nothing in `dist/index.d.ts` moves and no consumer is affected.

## Considered and rejected

`parseVec2`/`3`/`4` are three near-identical bodies differing only in arity and constructor, and a factory would cut ~40 lines to ~15. Not done: it would tangle the `<T extends Vec2 | null>` generics that give call sites their precise return types, for a cosmetic gain in a file nobody reads top-to-bottom. The duplication is shallow and honest.

## Verification

- `npm test` — 247 passed, 5 todo, 10 files
- `npm run lint` — clean
- `npm run type-check` — clean, both programs
- `npm run build` — passes; manifest unchanged at 30 modules / 27 elements, with no `parse` module
- `npm run publint` — unchanged (only the 3 pre-existing items)
- `dist/parse.d.ts` emitted as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
