### PR TITLE
Default pc-app to WebGPU with WebGL2 fallback

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -87,7 +87,7 @@ class AppElement extends AsyncElement {
 
     private _alpha = true;
 
-    private _backend: 'webgpu' | 'webgl2' | 'null' = 'webgl2';
+    private _backend: 'webgpu' | 'webgl2' | 'null' = 'webgpu';
 
     private _antialias = true;
 
@@ -528,7 +528,8 @@ class AppElement extends AsyncElement {
     }
 
     /**
-     * Sets the graphics backend.
+     * Sets the graphics backend. Defaults to 'webgpu', which falls back to 'webgl2' if WebGPU
+     * is not supported by the browser.
      * @param value - The graphics backend ('webgpu', 'webgl2', or 'null').
      */
     set backend(value: 'webgpu' | 'webgl2' | 'null') {
@@ -617,7 +618,7 @@ class AppElement extends AsyncElement {
                 this.antialias = parseBool(newValue, true);
                 break;
             case 'backend':
-                this.backend = parseEnum(newValue, ['webgpu', 'webgl2', 'null'], 'webgl2', name);
+                this.backend = parseEnum(newValue, ['webgpu', 'webgl2', 'null'], 'webgpu', name);
                 break;
             case 'depth':
                 this.depth = parseBool(newValue, true);


### PR DESCRIPTION
## What changed

`<pc-app>` now defaults its `backend` attribute to `webgpu` instead of `webgl2`. The existing device-type mapping already handles the fallback (`webgpu: ['webgpu', 'webgl2']`), so browsers without WebGPU support automatically fall back to WebGL2 — no other logic changes were needed.

- `_backend` field initializer: `'webgl2'` → `'webgpu'`
- `parseEnum` fallback in `attributeChangedCallback`: `'webgl2'` → `'webgpu'`
- Setter JSDoc now documents the default and fallback behavior

## Why

WebGPU support in the PlayCanvas Engine is now mature, so it should be the preferred backend by default.

## Notes for reviewers

- This is a behavior change worth mentioning in release notes. Apps that need to force WebGL2 can set `backend="webgl2"` explicitly.
- The generated Custom Elements Manifest picks up the new default (`"default": "webgpu"` for the `backend` attribute); CEM validation passes (27 elements).
- All 247 tests pass — tests are unaffected since they use `backend="null"` explicitly.
- Verified live in-browser on `examples/basic-shapes.html`: `graphicsDevice.deviceType === 'webgpu'`, renders correctly with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)