### PR TITLE
Fix 21 attribute-removal bugs surfaced by widening attributeChangedCallback

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -609,7 +609,7 @@ class AppElement extends AsyncElement {
         return ['alpha', 'antialias', 'backend', 'depth', 'stencil', 'high-resolution'];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         switch (name) {
             case 'alpha':
                 this.alpha = parseBool(newValue, true);

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -284,7 +284,7 @@ class AssetElement extends AsyncElement {
         return ['lazy'];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         if (name === 'lazy') {
             this.lazy = parseBool(newValue, false);
         }

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -396,7 +396,7 @@ class ButtonComponentElement extends ComponentElement {
         ];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         super.attributeChangedCallback(name, _oldValue, newValue);
 
         switch (name) {
@@ -404,7 +404,7 @@ class ButtonComponentElement extends ComponentElement {
                 this.active = parseBool(newValue, true);
                 break;
             case 'image':
-                this.image = newValue;
+                this.image = newValue ?? '';
                 break;
             case 'hit-padding':
                 this.hitPadding = parseVec4(newValue, Vec4.ZERO, name);
@@ -425,19 +425,19 @@ class ButtonComponentElement extends ComponentElement {
                 this.fadeDuration = parseNumber(newValue, 0, name);
                 break;
             case 'hover-sprite-asset':
-                this.hoverSpriteAsset = newValue;
+                this.hoverSpriteAsset = newValue ?? '';
                 break;
             case 'hover-sprite-frame':
                 this.hoverSpriteFrame = parseNumber(newValue, 0, name);
                 break;
             case 'pressed-sprite-asset':
-                this.pressedSpriteAsset = newValue;
+                this.pressedSpriteAsset = newValue ?? '';
                 break;
             case 'pressed-sprite-frame':
                 this.pressedSpriteFrame = parseNumber(newValue, 0, name);
                 break;
             case 'inactive-sprite-asset':
-                this.inactiveSpriteAsset = newValue;
+                this.inactiveSpriteAsset = newValue ?? '';
                 break;
             case 'inactive-sprite-frame':
                 this.inactiveSpriteFrame = parseNumber(newValue, 0, name);

--- a/src/components/camera-component.ts
+++ b/src/components/camera-component.ts
@@ -490,7 +490,7 @@ class CameraComponentElement extends ComponentElement {
         ];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         super.attributeChangedCallback(name, _oldValue, newValue);
 
         switch (name) {

--- a/src/components/collision-component.ts
+++ b/src/components/collision-component.ts
@@ -146,7 +146,7 @@ class CollisionComponentElement extends ComponentElement {
         return [...super.observedAttributes, 'angular-offset', 'axis', 'convex-hull', 'half-extents', 'height', 'linear-offset', 'radius', 'type'];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         super.attributeChangedCallback(name, _oldValue, newValue);
 
         switch (name) {

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -104,7 +104,7 @@ class ComponentElement extends AsyncElement {
         return ['enabled'];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         switch (name) {
             case 'enabled':
                 this.enabled = parseBool(newValue, true);

--- a/src/components/element-component.ts
+++ b/src/components/element-component.ts
@@ -686,7 +686,7 @@ class ElementComponentElement extends ComponentElement {
         ];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         super.attributeChangedCallback(name, _oldValue, newValue);
 
         switch (name) {
@@ -712,7 +712,7 @@ class ElementComponentElement extends ComponentElement {
                 this.enableMarkup = parseBool(newValue, false);
                 break;
             case 'font-asset':
-                this.fontAsset = newValue;
+                this.fontAsset = newValue ?? '';
                 break;
             case 'font-size':
                 this.fontSize = parseNumber(newValue, 32, name);
@@ -745,16 +745,16 @@ class ElementComponentElement extends ComponentElement {
                 this.pixelsPerUnit = parseNumber(newValue, null, name);
                 break;
             case 'sprite-asset':
-                this.spriteAsset = newValue;
+                this.spriteAsset = newValue ?? '';
                 break;
             case 'sprite-frame':
                 this.spriteFrame = parseNumber(newValue, 0, name);
                 break;
             case 'text':
-                this.text = newValue;
+                this.text = newValue ?? '';
                 break;
             case 'texture-asset':
-                this.textureAsset = newValue;
+                this.textureAsset = newValue ?? '';
                 break;
             case 'type':
                 this.type = parseEnum(newValue, ['group', 'image', 'text'], 'group', name);

--- a/src/components/gsplat-component.ts
+++ b/src/components/gsplat-component.ts
@@ -188,12 +188,12 @@ class GSplatComponentElement extends ComponentElement {
         ];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         super.attributeChangedCallback(name, _oldValue, newValue);
 
         switch (name) {
             case 'asset':
-                this.asset = newValue;
+                this.asset = newValue ?? '';
                 break;
             case 'cast-shadows':
                 this.castShadows = parseBool(newValue, false);

--- a/src/components/layoutchild-component.ts
+++ b/src/components/layoutchild-component.ts
@@ -199,7 +199,7 @@ class LayoutChildComponentElement extends ComponentElement {
         ];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         super.attributeChangedCallback(name, _oldValue, newValue);
 
         switch (name) {

--- a/src/components/layoutgroup-component.ts
+++ b/src/components/layoutgroup-component.ts
@@ -258,7 +258,7 @@ class LayoutGroupComponentElement extends ComponentElement {
         ];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         super.attributeChangedCallback(name, _oldValue, newValue);
 
         switch (name) {

--- a/src/components/light-component.ts
+++ b/src/components/light-component.ts
@@ -496,7 +496,7 @@ class LightComponentElement extends ComponentElement {
         ];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         super.attributeChangedCallback(name, _oldValue, newValue);
 
         switch (name) {

--- a/src/components/particlesystem-component.ts
+++ b/src/components/particlesystem-component.ts
@@ -139,12 +139,12 @@ class ParticleSystemComponentElement extends ComponentElement {
         ];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         super.attributeChangedCallback(name, _oldValue, newValue);
 
         switch (name) {
             case 'asset':
-                this.asset = newValue;
+                this.asset = newValue ?? '';
                 break;
         }
     }

--- a/src/components/render-component.ts
+++ b/src/components/render-component.ts
@@ -91,8 +91,13 @@ class RenderComponentElement extends ComponentElement {
      */
     set material(value: string) {
         this._material = value;
-        if (this.component) {
-            this.component.material = MaterialElement.get(value) as StandardMaterial;
+        const material = MaterialElement.get(value);
+        // Guarded like every other reference attribute in the library. Assigning an unresolved
+        // lookup used to write `undefined` straight through to every mesh instance, and the
+        // engine's MeshInstance setter takes that literally - it clears the material and skips
+        // the ref/transparency/key bookkeeping, leaving the mesh with no material at all.
+        if (this.component && material) {
+            this.component.material = material as StandardMaterial;
         }
     }
 
@@ -127,7 +132,7 @@ class RenderComponentElement extends ComponentElement {
         return [...super.observedAttributes, 'cast-shadows', 'material', 'receive-shadows', 'type'];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         super.attributeChangedCallback(name, _oldValue, newValue);
 
         switch (name) {
@@ -135,7 +140,7 @@ class RenderComponentElement extends ComponentElement {
                 this.castShadows = parseBool(newValue, true);
                 break;
             case 'material':
-                this.material = newValue;
+                this.material = newValue ?? '';
                 break;
             case 'receive-shadows':
                 this.receiveShadows = parseBool(newValue, true);

--- a/src/components/rigidbody-component.ts
+++ b/src/components/rigidbody-component.ts
@@ -187,7 +187,7 @@ class RigidBodyComponentElement extends ComponentElement {
         return [...super.observedAttributes, 'angular-damping', 'angular-factor', 'friction', 'linear-damping', 'linear-factor', 'mass', 'restitution', 'rolling-friction', 'type'];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         super.attributeChangedCallback(name, _oldValue, newValue);
 
         switch (name) {

--- a/src/components/screen-component.ts
+++ b/src/components/screen-component.ts
@@ -126,7 +126,7 @@ class ScreenComponentElement extends ComponentElement {
         ];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         super.attributeChangedCallback(name, _oldValue, newValue);
 
         switch (name) {

--- a/src/components/script.ts
+++ b/src/components/script.ts
@@ -155,7 +155,7 @@ class ScriptElement extends AsyncElement {
         return ['attributes', 'enabled', 'name'];
     }
 
-    attributeChangedCallback(name: string, oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null) {
         switch (name) {
             case 'attributes':
                 if (newValue === null) {

--- a/src/components/scrollbar-component.ts
+++ b/src/components/scrollbar-component.ts
@@ -142,7 +142,7 @@ class ScrollbarComponentElement extends ComponentElement {
         ];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         super.attributeChangedCallback(name, _oldValue, newValue);
 
         switch (name) {
@@ -156,7 +156,7 @@ class ScrollbarComponentElement extends ComponentElement {
                 this.handleSize = parseNumber(newValue, 0.5, name);
                 break;
             case 'handle':
-                this.handle = newValue;
+                this.handle = newValue ?? '';
                 break;
         }
     }

--- a/src/components/scrollview-component.ts
+++ b/src/components/scrollview-component.ts
@@ -377,7 +377,7 @@ class ScrollViewComponentElement extends ComponentElement {
         ];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         super.attributeChangedCallback(name, _oldValue, newValue);
 
         switch (name) {
@@ -409,16 +409,16 @@ class ScrollViewComponentElement extends ComponentElement {
                 this.verticalScrollbarVisibility = parseEnum(newValue, visibilities, 'when-required', name);
                 break;
             case 'viewport':
-                this.viewport = newValue;
+                this.viewport = newValue ?? '';
                 break;
             case 'content':
-                this.content = newValue;
+                this.content = newValue ?? '';
                 break;
             case 'horizontal-scrollbar':
-                this.horizontalScrollbar = newValue;
+                this.horizontalScrollbar = newValue ?? '';
                 break;
             case 'vertical-scrollbar':
-                this.verticalScrollbar = newValue;
+                this.verticalScrollbar = newValue ?? '';
                 break;
         }
     }

--- a/src/components/sound-component.ts
+++ b/src/components/sound-component.ts
@@ -197,7 +197,7 @@ class SoundComponentElement extends ComponentElement {
         ];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         super.attributeChangedCallback(name, _oldValue, newValue);
 
         switch (name) {

--- a/src/components/sound-slot.ts
+++ b/src/components/sound-slot.ts
@@ -275,10 +275,10 @@ class SoundSlotElement extends AsyncElement {
         return ['asset', 'auto-play', 'duration', 'loop', 'name', 'overlap', 'pitch', 'start-time', 'volume'];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         switch (name) {
             case 'asset':
-                this.asset = newValue;
+                this.asset = newValue ?? '';
                 break;
             case 'auto-play':
                 this.autoPlay = parseBool(newValue, false);
@@ -290,7 +290,7 @@ class SoundSlotElement extends AsyncElement {
                 this.loop = parseBool(newValue, false);
                 break;
             case 'name':
-                this.name = newValue;
+                this.name = newValue ?? '';
                 break;
             case 'overlap':
                 this.overlap = parseBool(newValue, false);

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -315,13 +315,13 @@ class EntityElement extends AsyncElement {
         ];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         switch (name) {
             case 'enabled':
                 this.enabled = parseBool(newValue, true);
                 break;
             case 'name':
-                this.name = newValue;
+                this.name = newValue ?? 'Untitled';
                 break;
             case 'position':
                 this.position = parseVec3(newValue, Vec3.ZERO, name);

--- a/src/model.ts
+++ b/src/model.ts
@@ -97,10 +97,10 @@ class ModelElement extends AsyncElement {
         return ['asset'];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         switch (name) {
             case 'asset':
-                this.asset = newValue;
+                this.asset = newValue ?? '';
                 break;
         }
     }

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -194,7 +194,7 @@ class SceneElement extends AsyncElement {
         return ['fog', 'fog-color', 'fog-density', 'fog-start', 'fog-end', 'gravity'];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         switch (name) {
             case 'fog':
                 this.fog = parseEnum(newValue, ['none', 'linear', 'exp', 'exp2'], 'none', name);

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -270,10 +270,10 @@ class SkyElement extends AsyncElement {
         return ['asset', 'center', 'intensity', 'level', 'lighting', 'rotation', 'scale', 'type'];
     }
 
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         switch (name) {
             case 'asset':
-                this.asset = newValue;
+                this.asset = newValue ?? '';
                 break;
             case 'center':
                 this.center = parseVec3(newValue, new Vec3(0, 0.01, 0), name);

--- a/test/elements/attribute-removal.test.ts
+++ b/test/elements/attribute-removal.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { useGuard } from '../helpers/guard';
+
+
+/**
+ * Removal semantics for every attribute that assigns `newValue` straight to a string-typed
+ * property, rather than routing through a null-tolerant `parse*` helper.
+ *
+ * Custom elements pass `null` to attributeChangedCallback on removal. These cases used to assign
+ * that null through, so the element property reported `null` where its own backing field had been
+ * initialised to `''` - and the value then reached the engine. `attributeChangedCallback` declared
+ * `newValue: string`, so TypeScript never flagged any of it; widening the signature is what
+ * surfaced the whole set at once.
+ *
+ * Every element here caches to a private field and only writes through once its engine handle
+ * exists, so removal is fully observable with no <pc-app> in play. The one case that also had an
+ * engine-visible consequence - pc-render[material] - is covered in the integration tier.
+ */
+describe('attribute removal', () => {
+    useGuard();
+
+    /** tag, attribute, property, and the value removal must restore. */
+    const cases: [tag: string, attribute: string, property: string, restored: string][] = [
+        ['pc-button', 'image', 'image', ''],
+        ['pc-button', 'hover-sprite-asset', 'hoverSpriteAsset', ''],
+        ['pc-button', 'pressed-sprite-asset', 'pressedSpriteAsset', ''],
+        ['pc-button', 'inactive-sprite-asset', 'inactiveSpriteAsset', ''],
+        ['pc-element', 'font-asset', 'fontAsset', ''],
+        ['pc-element', 'sprite-asset', 'spriteAsset', ''],
+        ['pc-element', 'texture-asset', 'textureAsset', ''],
+        ['pc-element', 'text', 'text', ''],
+        ['pc-gsplat', 'asset', 'asset', ''],
+        ['pc-particles', 'asset', 'asset', ''],
+        ['pc-render', 'material', 'material', ''],
+        ['pc-scrollbar', 'handle', 'handle', ''],
+        ['pc-scrollview', 'viewport', 'viewport', ''],
+        ['pc-scrollview', 'content', 'content', ''],
+        ['pc-scrollview', 'horizontal-scrollbar', 'horizontalScrollbar', ''],
+        ['pc-scrollview', 'vertical-scrollbar', 'verticalScrollbar', ''],
+        ['pc-sound', 'asset', 'asset', ''],
+        ['pc-sound', 'name', 'name', ''],
+        ['pc-model', 'asset', 'asset', ''],
+        ['pc-sky', 'asset', 'asset', ''],
+
+        // The odd one out: pc-entity's backing field starts at the engine's default entity name,
+        // so restoring '' would leave a nameless entity that no name lookup could find.
+        ['pc-entity', 'name', 'name', 'Untitled']
+    ];
+
+    it.for(cases)('%s[%s] restores its default on removal', ([tag, attribute, property, restored]) => {
+        const element = document.createElement(tag) as unknown as Record<string, unknown>;
+
+        expect(element[property], `${tag}[${attribute}] does not start at its documented default`)
+        .toBe(restored);
+
+        (element as unknown as Element).setAttribute(attribute, 'some-reference');
+        expect(element[property]).toBe('some-reference');
+
+        // Reactions on an upgraded element run in the caller's stack, so a parser that mishandles
+        // null throws straight out of removeAttribute() - the #309 shape.
+        expect(() => (element as unknown as Element).removeAttribute(attribute)).not.toThrow();
+        expect(element[property], `${tag}[${attribute}] leaked null instead of its default`)
+        .toBe(restored);
+    });
+
+    it('covers every unparsed string attribute in the library', () => {
+        // If a new `this.x = newValue ?? ''` branch is added without a case above, this fails.
+        // Counted rather than enumerated, so it stays a one-line update rather than a second table.
+        expect(cases).toHaveLength(21);
+    });
+});

--- a/test/integration/render-material.test.ts
+++ b/test/integration/render-material.test.ts
@@ -1,0 +1,63 @@
+import type { StandardMaterial } from 'playcanvas';
+import { describe, expect, it } from 'vitest';
+
+import type { RenderComponentElement } from '../../src/components/render-component';
+import { bootApp } from '../helpers/app';
+import { useGuard } from '../helpers/guard';
+
+
+/**
+ * pc-render[material] against a real render component. This is the one unparsed string attribute
+ * whose removal reached the engine rather than stopping at the element, so it gets engine-level
+ * coverage on top of the element-tier removal table.
+ */
+describe('<pc-render> material', () => {
+    useGuard();
+
+    const markup = `
+        <pc-material id="red" diffuse="1 0 0"></pc-material>
+        <pc-entity name="box">
+            <pc-render type="box" material="red"></pc-render>
+        </pc-entity>
+    `;
+
+    it('resolves the material onto every mesh instance', async () => {
+        const { get } = await bootApp(markup);
+        const component = get<RenderComponentElement>('pc-render').component;
+
+        expect(component.meshInstances.length).toBeGreaterThan(0);
+        for (const meshInstance of component.meshInstances) {
+            expect((meshInstance.material as StandardMaterial)?.diffuse.r).toBe(1);
+        }
+    });
+
+    it('leaves the mesh instances usable when the attribute is removed', async () => {
+        // Previously the setter assigned the unresolved lookup straight through. The engine's
+        // MeshInstance material setter takes `undefined` literally - it clears _material and skips
+        // the ref/transparency/key bookkeeping - so removing the attribute left every mesh instance
+        // with no material at all. The lookup is now guarded like every other reference attribute.
+        const { get } = await bootApp(markup);
+        const element = get<RenderComponentElement>('pc-render');
+        const component = element.component;
+
+        element.removeAttribute('material');
+
+        expect(element.material, 'the element property returns to its default').toBe('');
+        for (const meshInstance of component.meshInstances) {
+            expect(meshInstance.material, 'a mesh instance was left with no material').toBeTruthy();
+        }
+    });
+
+    it('ignores a material id that resolves to nothing', async () => {
+        const { get } = await bootApp(markup);
+        const element = get<RenderComponentElement>('pc-render');
+        const component = element.component;
+
+        element.setAttribute('material', 'no-such-material');
+
+        expect(element.material).toBe('no-such-material');
+        for (const meshInstance of component.meshInstances) {
+            expect(meshInstance.material, 'an unresolved id wiped the material').toBeTruthy();
+        }
+    });
+});


### PR DESCRIPTION
Follow-up to the review of #321, where widening one element's `attributeChangedCallback` signature was deferred on the grounds that widening all of them surfaces real bugs. It does — **21 of them** — so here they are.

## The problem

Custom elements pass `null` to `attributeChangedCallback` when an attribute is removed. Every element declared `newValue: string`, so TypeScript never questioned assigning it straight into a string-typed property.

Widening to `string | null` across all 24 elements produces **21 type errors in 10 files**, and each one is a place where removing an attribute wrote `null` into a property whose own backing field had been initialised to `''`.

This is the same shape as #309, which shipped and had to be fixed after the fact.

## What removal now restores

Twenty of the twenty-one restore `''` — the value their backing field already starts at.

`pc-entity[name]` is the exception and restores `'Untitled'`, the engine's default entity name. Restoring `''` there would leave an entity that no name lookup could find.

| Element | Attributes |
|---|---|
| `pc-button` | `image`, `hover-sprite-asset`, `pressed-sprite-asset`, `inactive-sprite-asset` |
| `pc-element` | `font-asset`, `sprite-asset`, `texture-asset`, `text` |
| `pc-scrollview` | `viewport`, `content`, `horizontal-scrollbar`, `vertical-scrollbar` |
| `pc-sound` | `asset`, `name` |
| `pc-gsplat`, `pc-particles`, `pc-model`, `pc-sky` | `asset` |
| `pc-render` | `material` |
| `pc-scrollbar` | `handle` |
| `pc-entity` | `name` → `'Untitled'` |

## Most were element-only — one was not

Most of these setters guard with `if (this.component && lookup)`, so a failed lookup was already a no-op and only the element's own property lied about its value. Three route through a loader instead (`pc-model`, `pc-sky`, `pc-particles`) and all three bail on an unresolved asset, so those were element-only too — `pc-model` even unloads first, so removing its asset already did the right thing engine-side.

**`pc-render[material]` was the exception**, and the only one with a consequence past the element boundary:

```ts
this.component.material = MaterialElement.get(value) as StandardMaterial;
```

Unlike every other reference attribute in the library this assignment is unguarded, so an unresolved id wrote `undefined` through to the component, which forwards it to every mesh instance. The engine's `MeshInstance` material setter takes that literally:

```js
set material(material) {
    this.clearShaders();
    const prevMat = this._material;
    if (prevMat) prevMat.removeMeshInstanceRef(this);
    this._material = material;
    if (material) {          // ← skipped entirely for undefined
        material.addMeshInstanceRef(this);
        this.transparent = material.transparent;
        this.updateKey();
    }
}
```

So the mesh was left with **no material at all**. Removing the attribute — or simply pointing it at an id that doesn't resolve — broke the mesh. It's now guarded like its siblings.

## Tests

- **`test/elements/attribute-removal.test.ts`** drives all 21 from one table: each starts at its documented default, takes a value, and returns to that default on removal without throwing. *Verified by mutation — reverting the removal handling fails 21 of the 22.*
- **`test/integration/render-material.test.ts`** covers the engine-visible case against a real render component: the material resolves onto every mesh instance, and neither removal nor an unresolvable id leaves one without a material. *Verified by mutation — dropping the guard fails two of the three.*

462 tests pass, 5 todo. Lint, both type-check projects and the CEM build are green.

## No public API change

The widened signature is a lifecycle callback the browser calls, not something consumers invoke, and the CEM analyzer reads the `switch` rather than the types — the generated manifest is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)