### PR TITLE
Declare the six element accessors nullable

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -120,12 +120,13 @@ class AppElement extends AsyncElement {
     private _app: AppBase | null = null;
 
     /**
-     * The PlayCanvas application instance. Available once the element is ready — await
-     * {@link whenReady} or the element's `ready()` promise before accessing it.
-     * @returns The application instance.
+     * The PlayCanvas application instance. `null` until the element is ready, and again once it
+     * has been removed from the document — await {@link whenReady} or the element's `ready()`
+     * promise before accessing it.
+     * @returns The application instance, or `null`.
      */
-    get app(): AppBase {
-        return this._app!;
+    get app(): AppBase | null {
+        return this._app;
     }
 
     /**
@@ -234,11 +235,12 @@ class AppElement extends AsyncElement {
         createOptions.batchManager = BatchManager;
         createOptions.xr = XrManager;
 
-        this._app = new AppBase(this._canvas);
-        this.app.init(createOptions);
+        const app = new AppBase(this._canvas);
+        this._app = app;
+        app.init(createOptions);
 
-        this.app.setCanvasFillMode(FILLMODE_FILL_WINDOW);
-        this.app.setCanvasResolution(RESOLUTION_AUTO);
+        app.setCanvasFillMode(FILLMODE_FILL_WINDOW);
+        app.setCanvasResolution(RESOLUTION_AUTO);
 
         this._pickerCreate();
 
@@ -248,7 +250,7 @@ class AppElement extends AsyncElement {
             assetElement.createAsset();
             const asset = assetElement.asset;
             if (asset) {
-                this.app!.assets.add(asset);
+                app.assets.add(asset);
             }
         });
 
@@ -261,20 +263,20 @@ class AppElement extends AsyncElement {
         // Create all entities
         const entityElements = this.querySelectorAll<EntityElement>('pc-entity');
         Array.from(entityElements).forEach((entityElement) => {
-            entityElement.createEntity(this.app!);
+            entityElement.createEntity(app);
         });
 
         // Build hierarchy
         entityElements.forEach((entityElement) => {
-            entityElement.buildHierarchy(this.app!);
+            entityElement.buildHierarchy(app);
         });
 
         this._hierarchyReady = true;
 
         // Load assets before starting the application
-        this.app.preload(() => {
+        app.preload(() => {
             // Start the application
-            this.app!.start();
+            app.start();
 
             // Handle window resize to keep the canvas responsive
             window.addEventListener('resize', this._onWindowResize);
@@ -287,8 +289,8 @@ class AppElement extends AsyncElement {
         this._pickerDestroy();
 
         // Clean up the application
-        if (this.app) {
-            this.app.destroy();
+        if (this._app) {
+            this._app.destroy();
             this._app = null;
         }
 

--- a/src/async-element.ts
+++ b/src/async-element.ts
@@ -20,12 +20,22 @@ class AsyncElement extends HTMLElement {
         });
     }
 
-    get closestApp(): AppElement {
-        return this.parentElement?.closest('pc-app') as AppElement;
+    /**
+     * The nearest ancestor `<pc-app>` element, or `null` if this element has no `<pc-app>`
+     * ancestor. The search starts at the parent, so an element never resolves to itself.
+     * @returns The closest app element, or `null`.
+     */
+    get closestApp(): AppElement | null {
+        return this.parentElement?.closest('pc-app') as AppElement | null ?? null;
     }
 
-    get closestEntity(): EntityElement {
-        return this.parentElement?.closest('pc-entity') as EntityElement;
+    /**
+     * The nearest ancestor `<pc-entity>` element, or `null` if this element has no `<pc-entity>`
+     * ancestor. The search starts at the parent, so an element never resolves to itself.
+     * @returns The closest entity element, or `null`.
+     */
+    get closestEntity(): EntityElement | null {
+        return this.parentElement?.closest('pc-entity') as EntityElement | null ?? null;
     }
 
     /**

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -73,12 +73,13 @@ class ComponentElement extends AsyncElement {
     }
 
     /**
-     * The PlayCanvas component instance. Available once the element is ready — await
-     * {@link whenReady} or the element's `ready()` promise before accessing it.
-     * @returns The component instance.
+     * The PlayCanvas component instance. `null` until the element is ready, and also for an
+     * element that is not a descendant of a `<pc-entity>` — await {@link whenReady} or the
+     * element's `ready()` promise before accessing it.
+     * @returns The component instance, or `null`.
      */
-    get component(): Component {
-        return this._component!;
+    get component(): Component | null {
+        return this._component;
     }
 
     /**

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -76,12 +76,13 @@ class EntityElement extends AsyncElement {
     private _entity: Entity | null = null;
 
     /**
-     * The PlayCanvas entity instance. Available once the element is ready — await
-     * {@link whenReady} or the element's `ready()` promise before accessing it.
-     * @returns The entity instance.
+     * The PlayCanvas entity instance. `null` until the element is ready, and again once it has
+     * been removed from the document — await {@link whenReady} or the element's `ready()`
+     * promise before accessing it.
+     * @returns The entity instance, or `null`.
      */
-    get entity(): Entity {
-        return this._entity!;
+    get entity(): Entity | null {
+        return this._entity;
     }
 
     createEntity(app: AppBase) {

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -44,12 +44,12 @@ class SceneElement extends AsyncElement {
     private _scene: Scene | null = null;
 
     /**
-     * The PlayCanvas scene instance. Available once the element is ready — await
+     * The PlayCanvas scene instance. `null` until the element is ready — await
      * {@link whenReady} or the element's `ready()` promise before accessing it.
-     * @returns The scene instance.
+     * @returns The scene instance, or `null`.
      */
-    get scene(): Scene {
-        return this._scene!;
+    get scene(): Scene | null {
+        return this._scene;
     }
 
     async connectedCallback() {

--- a/test/helpers/app.ts
+++ b/test/helpers/app.ts
@@ -76,8 +76,12 @@ export const bootApp = async (html = '', options: BootOptions = {}): Promise<Boo
     await readyWithin(appElement, options.timeout);
     await settle(handle.container, options.timeout);
 
+    // Thrown rather than asserted with `expect`, which does not narrow away the `null` that
+    // `AppElement.app` legitimately returns before boot and after teardown.
     const app = appElement.app;
-    expect(app, 'pc-app became ready without an application').toBeTruthy();
+    if (!app) {
+        throw new Error('bootApp: pc-app became ready without an application');
+    }
     expect(app.graphicsDevice.isNull, 'expected the null graphics device').toBe(true);
 
     // app.start() has already requested a frame. Frames are stepped explicitly from here so that

--- a/test/integration/lifecycle.test.ts
+++ b/test/integration/lifecycle.test.ts
@@ -36,7 +36,7 @@ describe('<pc-app> lifecycle', () => {
         expect(uncaught.seen).toEqual([]);
 
         // Clean up after the bug, so the leak does not follow us into the next test.
-        appElement.app.destroy();
+        appElement.app?.destroy();
     });
 
     it.todo('abandons boot when pc-app is detached before its graphics device resolves');

--- a/test/integration/teardown.test.ts
+++ b/test/integration/teardown.test.ts
@@ -164,7 +164,7 @@ describe('teardown', () => {
         const childElement = all<EntityElement>('pc-entity')[1];
         expect(childElement.entity, 'the child entity is recreated').toBeTruthy();
         expect(app.root.findByName('child'), 'but never attached to the hierarchy').toBeNull();
-        expect(childElement.entity.parent, 'and has no parent').toBeNull();
+        expect(childElement.entity?.parent, 'and has no parent').toBeNull();
     });
 
     it.todo('re-attaches a nested pc-entity when its subtree is removed and re-added');


### PR DESCRIPTION
## Summary

`AppElement.app`, `EntityElement.entity`, `SceneElement.scene` and `ComponentElement.component` each declared a non-nullable engine type while returning `this._x!`. All four are `null` before the element is ready, and `app`/`entity` are `null` again after teardown. `AsyncElement.closestApp` and `closestEntity` cast to `as AppElement`/`as EntityElement` while returning `undefined` for an element with no such ancestor.

This is the type lie behind the crashes in #313 and #314 — a call site that trusts the declared type has no reason to guard. `parse.ts`'s `getEntity()` already returns `Entity | null`, so the codebase contradicted itself.

Widening these after 1.0.0 would break every TypeScript consumer, so it is done now.

## Behaviour

Unchanged, with one exception: `closestApp`/`closestEntity` now return `null` consistently. Previously they returned `undefined` when the element had no parent and `null` when the parent had no matching ancestor. Every internal caller tests truthiness, so none are affected.

The four engine-object getters are erased entirely — verified by diffing `dist/pwc.mjs` before and after, where the only runtime changes are the two `?? null` normalizations and the boot-block rebinding below.

## Also in this PR

- Bind the application to a local `const app` through `connectedCallback`'s boot block rather than re-reading the getter. Removes five non-null assertions. `disconnectedCallback` reads `this._app` directly.
- Document *when* each accessor is `null`, rather than only when it is available.
- Document `closestApp`/`closestEntity`, which had no doc comments.

## Tests

`bootApp()` asserted the application was present with `expect().toBeTruthy()`, which does not narrow, so it now throws instead. Two tests pinning known bugs (#312, #315) reach through these accessors and use optional chaining.

`type-check`, `lint` and `publint` clean; 462 tests pass; the manifest still validates 27 elements.

## Not in this PR

Hiding the internals that ship as public API — 8 underscore-prefixed methods on `AppElement`, `ScriptElement._script`/`_onScriptCreated`, and 60 non-underscore cross-module methods such as `createEntity` and `buildHierarchy`. That needs a decision on how elements address each other privately, and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)