### PR TITLE
Reset _built on descendants so a re-added subtree re-attaches

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -147,10 +147,15 @@ class EntityElement extends AsyncElement {
 
     disconnectedCallback() {
         if (this.entity) {
-            // Notify all children that their entities are about to become invalid
-            const children = this.querySelectorAll('pc-entity');
+            // Notify all children that their entities are about to become invalid. Both fields have
+            // to be reset here, not just _entity: a descendant's own disconnectedCallback runs after
+            // this one and skips its reset behind the `if (this.entity)` guard, because we have
+            // already nulled the entity it tests. Leaving _built set would make buildHierarchy bail
+            // on re-insertion, so the descendant would get a fresh entity that is never parented.
+            const children = this.querySelectorAll<EntityElement>('pc-entity');
             children.forEach((child) => {
-                (child as EntityElement)._entity = null;
+                child._entity = null;
+                child._built = false;
             });
 
             // Destroy the entity

--- a/test/integration/teardown.test.ts
+++ b/test/integration/teardown.test.ts
@@ -153,10 +153,10 @@ describe('teardown', () => {
         expect(app.root.findByName('parent')).toBeTruthy();
         expect(uncaught.seen).toEqual([]);
 
-        // The nested entity comes back too, and is re-parented rather than merely recreated. This
-        // is what #315 fixed: disconnectedCallback resets _built alongside _entity on every
-        // descendant, so buildHierarchy no longer bails on a stale _built and leaves the child
-        // orphaned - created, never parented, never ready again.
+        // The nested entity comes back too, and is re-parented rather than merely recreated.
+        // disconnectedCallback resets _built alongside _entity on every descendant, so
+        // buildHierarchy no longer bails on a stale _built and leaves the child orphaned -
+        // created, never parented, and never ready again.
         const parentEntity = app.root.findByName('parent');
         const childEntity = app.root.findByName('child');
         const childElement = all<EntityElement>('pc-entity')[1];

--- a/test/integration/teardown.test.ts
+++ b/test/integration/teardown.test.ts
@@ -150,22 +150,51 @@ describe('teardown', () => {
         container.appendChild(parentElement);
         await settleTask();
 
-        // The parent comes back, because its own disconnectedCallback reset both _entity and
-        // _built.
         expect(app.root.findByName('parent')).toBeTruthy();
         expect(uncaught.seen).toEqual([]);
 
-        // KNOWN BUG (#315): the child does not. src/entity.ts:151-153 nulls _entity on every
-        // descendant, but line 158 resets _built only for `this` - and because the parent has
-        // already nulled the child's _entity, the child's own disconnectedCallback skips its reset
-        // behind the `if (this.entity)` guard. So on re-insertion createEntity() makes a fresh
-        // entity while buildHierarchy() bails on the stale _built, leaving it orphaned: created,
-        // never parented, and never ready again.
+        // The nested entity comes back too, and is re-parented rather than merely recreated. This
+        // is what #315 fixed: disconnectedCallback resets _built alongside _entity on every
+        // descendant, so buildHierarchy no longer bails on a stale _built and leaves the child
+        // orphaned - created, never parented, never ready again.
+        const parentEntity = app.root.findByName('parent');
+        const childEntity = app.root.findByName('child');
         const childElement = all<EntityElement>('pc-entity')[1];
-        expect(childElement.entity, 'the child entity is recreated').toBeTruthy();
-        expect(app.root.findByName('child'), 'but never attached to the hierarchy').toBeNull();
-        expect(childElement.entity?.parent, 'and has no parent').toBeNull();
+
+        expect(childEntity, 'the child is attached to the hierarchy').toBeTruthy();
+        expect(childElement.entity, 'and is the element\'s own entity').toBe(childEntity);
+        expect(childEntity?.parent, 'parented under the parent entity, not the root').toBe(parentEntity);
     });
 
-    it.todo('re-attaches a nested pc-entity when its subtree is removed and re-added');
+    it('restores every level when a three-deep pc-entity subtree is removed and re-added', async () => {
+        // The two-level case above cannot distinguish "descendants are reset" from "the first
+        // descendant is reset". This also pins buildHierarchy's dependence on document order:
+        // connectedCallback builds the querySelectorAll result in sequence, so each level has to be
+        // parented before the level below it looks up closestEntity.
+        const { app, all } = await bootApp(`
+            <pc-entity name="a">
+                <pc-entity name="b">
+                    <pc-entity name="c"></pc-entity>
+                </pc-entity>
+            </pc-entity>
+        `);
+        const root = all<EntityElement>('pc-entity')[0];
+        const container = root.parentElement as AppElement;
+
+        root.remove();
+        await settleTask();
+        expect(app.root.findByName('c')).toBeNull();
+
+        container.appendChild(root);
+        await settleTask();
+
+        const a = app.root.findByName('a');
+        const b = app.root.findByName('b');
+        const c = app.root.findByName('c');
+
+        expect([a, b, c].every(Boolean), 'all three levels are back').toBe(true);
+        expect(b?.parent, 'b under a').toBe(a);
+        expect(c?.parent, 'c under b').toBe(b);
+        expect(uncaught.seen).toEqual([]);
+    });
 });


### PR DESCRIPTION
Fixes #315.

## The defect

`EntityElement.disconnectedCallback` nulls `_entity` on every descendant but reset `_built` only for itself. The descendants *do* each get their own `disconnectedCallback` when a subtree is removed — but the parent has already nulled their `_entity`, so their reset is skipped behind the `if (this.entity)` guard. The parent's eager cleanup is what prevented each child from cleaning up after itself.

On re-insertion `createEntity` therefore succeeded (`_entity` was null) while `buildHierarchy` bailed on the stale `_built`, leaving every nested entity with a live `Entity` attached to nothing. Nothing threw, so the symptom was a subtree that silently stopped rendering.

The top-level entity was unaffected, which is what made this easy to miss — a single-level subtree round-trips correctly.

## Approach

Resets both fields on descendants — **option 1** in the issue.

Option 2 (drop the eager reset, let each child handle itself) is cleaner in principle but was not taken: the parent destroys its entity in the same callback, and the engine's own hierarchy teardown takes the children's entities with it, so each child would then call `destroy()` on an already-destroyed entity. The eager reset exists to prevent exactly that.

## This needs no change to the readiness contract

The issue asks whether re-attachment should re-arm readiness. It does not need to here: a re-attached element **is** genuinely ready again, and its ready promise is already resolved, so callers get the correct answer.

That is why this ships ahead of #311/#312 rather than waiting on them. The separate problem — readiness resolving while `entity` is `null` in the window *between* removal and re-insertion — is #312's latch, untouched here and still pinned by its own test.

## Tests

The `it.todo` left for this issue becomes a positive assertion, extended to check the child is the element's own entity and is parented under the parent rather than the root. Verified to fail against the unfixed file (`the child is attached to the hierarchy: expected null to be truthy`).

A three-deep case is added, for two reasons: the two-level test cannot distinguish "descendants are reset" from "the first descendant is reset", and it pins `buildHierarchy`'s dependence on document order — each level has to be parented before the level below it resolves `closestEntity`.

`type-check`, `lint` clean; 466 tests pass, 3 todo remaining (was 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)