### PR TITLE
Expose loading progress on pc-app and load/error events on pc-asset

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -78,6 +78,11 @@ import { parseBool, parseEnum } from './parse';
  * {@link https://developer.playcanvas.com/user-manual/web-components/tags/pc-app/ | `<pc-app>`} elements.
  * The AppElement interface also inherits the properties and methods of the
  * {@link HTMLElement} interface.
+ *
+ * @fires {ProgressEvent} progress - Fired while the application preloads its assets. `loaded` and
+ * `total` are asset counts, not bytes, and an asset that fails to load still counts as loaded.
+ * Fired at least once per boot, and the final event always has `loaded` equal to `total`. Does
+ * not bubble.
  */
 class AppElement extends AsyncElement {
     /**
@@ -119,6 +124,8 @@ class AppElement extends AsyncElement {
 
     private _app: AppBase | null = null;
 
+    private _loadProgress = 0;
+
     /**
      * The PlayCanvas application instance. `null` until the element is ready, and again once it
      * has been removed from the document — await {@link whenReady} or the element's `ready()`
@@ -127,6 +134,17 @@ class AppElement extends AsyncElement {
      */
     get app(): AppBase | null {
         return this._app;
+    }
+
+    /**
+     * The asset preload progress of the application, as a fraction from 0 to 1. It is 0 until
+     * preloading begins (and again once the element has been removed from the document), and 1
+     * once preloading has finished — including when there was nothing to preload. Read this to
+     * initialize a loading UI; subsequent updates arrive via the `progress` event.
+     * @returns The preload progress.
+     */
+    get loadProgress(): number {
+        return this._loadProgress;
     }
 
     /**
@@ -273,8 +291,28 @@ class AppElement extends AsyncElement {
 
         this._hierarchyReady = true;
 
+        // Forward the engine's preload lifecycle as DOM ProgressEvents on this element. The
+        // listener must be attached before preload() is called: an asset that is already loaded
+        // ticks synchronously inside it.
+        const total = app.assets.list({ preload: true }).length;
+        let loaded = 0;
+        const onPreloadProgress = () => {
+            loaded += 1;
+            this._loadProgress = loaded / total;
+            this.dispatchEvent(new ProgressEvent('progress', { lengthComputable: true, loaded, total }));
+        };
+        app.on('preload:progress', onPreloadProgress);
+
+        this._loadProgress = total === 0 ? 1 : 0;
+        this.dispatchEvent(new ProgressEvent('progress', { lengthComputable: true, loaded: 0, total }));
+
         // Load assets before starting the application
         app.preload(() => {
+            // Scope the counter to this preload pass, so a later app.preload() call by user code
+            // cannot push `loaded` past `total`
+            app.off('preload:progress', onPreloadProgress);
+            this._loadProgress = 1;
+
             // Start the application
             app.start();
 
@@ -293,6 +331,7 @@ class AppElement extends AsyncElement {
             this._app.destroy();
             this._app = null;
         }
+        this._loadProgress = 0;
 
         // Remove event listeners
         window.removeEventListener('resize', this._onWindowResize);

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -99,6 +99,13 @@ const processBufferView = (
  * @attribute {number} pixels-per-unit - For a `sprite` asset, the number of pixels per world unit.
  * @attribute {'simple' | 'sliced' | 'tiled'} render-mode - For a `sprite` asset, how the sprite is
  * rendered when resized.
+ *
+ * @fires {Event} load - Fired each time the asset finishes loading, including a `lazy` asset
+ * loaded later and any subsequent reloads. Does not bubble — listen on this element, or use a
+ * capture-phase listener on an ancestor to observe every asset.
+ * @fires {ErrorEvent} error - Fired when the asset fails to load, with the engine's error in
+ * `message`. Does not bubble. The element still becomes ready — readiness means the load settled,
+ * not that it succeeded.
  */
 class AssetElement extends AsyncElement {
     private _lazy: boolean = false;
@@ -149,6 +156,16 @@ class AssetElement extends AsyncElement {
         this.destroyAsset();
     }
 
+    private _onAssetLoad() {
+        this.dispatchEvent(new Event('load'));
+    }
+
+    private _onAssetError(err: string | Error) {
+        this.dispatchEvent(new ErrorEvent('error', {
+            message: err instanceof Error ? err.message : String(err)
+        }));
+    }
+
     createAsset() {
         const id = this.getAttribute('id') || '';
         const src = this.getAttribute('src') || '';
@@ -186,6 +203,11 @@ class AssetElement extends AsyncElement {
         }
 
         this.asset.preload = !this._lazy;
+
+        // Forward the engine asset's load outcome as DOM events on this element, like <img>.
+        // Attached before the asset joins the registry, which is what starts a preloaded load.
+        this.asset.on('load', this._onAssetLoad, this);
+        this.asset.on('error', this._onAssetError, this);
     }
 
     /**
@@ -249,6 +271,9 @@ class AssetElement extends AsyncElement {
 
     destroyAsset() {
         if (this.asset) {
+            // A caller that keeps the Asset alive must not dispatch on a removed element
+            this.asset.off('load', this._onAssetLoad, this);
+            this.asset.off('error', this._onAssetError, this);
             // Deregister first so unload() can still notify the registry
             this.asset.registry?.remove(this.asset);
             this.asset.unload();

--- a/test/integration/asset-events.test.ts
+++ b/test/integration/asset-events.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AppElement } from '../../src/app';
+import type { AssetElement } from '../../src/asset';
+import { settle } from '../helpers/app';
+import { mount } from '../helpers/dom';
+import { useGuard } from '../helpers/guard';
+import { readyWithin } from '../helpers/ready';
+
+
+/**
+ * The `load` and `error` DOM events on <pc-asset>. Both mirror <img> resource semantics: they are
+ * dispatched on the element and do not bubble, so a window-level bubble-phase 'error' listener
+ * (the shape every error-reporting SDK installs) never sees them - aggregation is done with a
+ * capture-phase listener on an ancestor instead.
+ */
+describe('<pc-asset> load and error events', () => {
+    const { errors, uncaught } = useGuard();
+
+    const settleTask = () => new Promise((resolve) => {
+        setTimeout(resolve, 0);
+    });
+
+    const boot = (assetHtml: string) => {
+        const handle = mount(`<pc-app backend="null">${assetHtml}</pc-app>`);
+        const appElement = handle.get<AppElement>('pc-app');
+        const assetElement = handle.get<AssetElement>('pc-asset');
+        return { handle, appElement, assetElement };
+    };
+
+    it('fires load on the element, visible to ancestors only in the capture phase', async () => {
+        const { handle, appElement, assetElement } =
+            boot('<pc-asset id="note" type="text" src="data:text/plain,hello"></pc-asset>');
+        const events: Event[] = [];
+        let bubbled = 0;
+        let captured = 0;
+        assetElement.addEventListener('load', event => events.push(event));
+        appElement.addEventListener('load', () => {
+            bubbled += 1;
+        });
+        appElement.addEventListener('load', () => {
+            captured += 1;
+        }, true);
+
+        await readyWithin(appElement);
+        await settle(handle.container);
+
+        expect(events).toHaveLength(1);
+        expect(events[0].bubbles).toBe(false);
+        expect(captured).toBe(1);
+        expect(bubbled).toBe(0);
+    });
+
+    it('fires error with the engine message, without reaching the window error channel', async () => {
+        const { handle, appElement, assetElement } =
+            boot('<pc-asset id="bad" type="container" src="data:model/gltf-binary,notaglb"></pc-asset>');
+        const events: ErrorEvent[] = [];
+        assetElement.addEventListener('error', event => events.push(event));
+
+        await readyWithin(appElement);
+        await settle(handle.container);
+
+        expect(events).toHaveLength(1);
+        expect(events[0]).toBeInstanceOf(ErrorEvent);
+        expect(events[0].message).not.toBe('');
+        expect(events[0].bubbles).toBe(false);
+
+        // The guard's window listener is bubble-phase, exactly like an error-reporting SDK's - a
+        // non-bubbling asset failure must stay off that channel
+        expect(uncaught.seen).toEqual([]);
+        errors.expect(/glb/i);
+    });
+
+    it('fires load for a lazy asset only once something loads it', async () => {
+        const { handle, appElement, assetElement } =
+            boot('<pc-asset id="later" type="text" src="data:text/plain,later" lazy></pc-asset>');
+        let loads = 0;
+        assetElement.addEventListener('load', () => {
+            loads += 1;
+        });
+
+        await readyWithin(appElement);
+        await settle(handle.container);
+
+        expect(loads, 'a lazy asset does not load during boot').toBe(0);
+
+        const { asset } = assetElement;
+        const app = appElement.app;
+        if (!asset || !app) {
+            throw new Error('a lazy asset should be registered by the time the app is ready');
+        }
+
+        const loaded = new Promise<void>((resolve) => {
+            assetElement.addEventListener('load', () => resolve(), { once: true });
+        });
+        app.assets.load(asset);
+        await loaded;
+
+        expect(loads).toBe(1);
+    });
+
+    it('stops dispatching once the element is removed', async () => {
+        const { handle, appElement, assetElement } =
+            boot('<pc-asset id="gone" type="text" src="data:text/plain,gone"></pc-asset>');
+        let loads = 0;
+        let errorCount = 0;
+        assetElement.addEventListener('load', () => {
+            loads += 1;
+        });
+        assetElement.addEventListener('error', () => {
+            errorCount += 1;
+        });
+
+        await readyWithin(appElement);
+        await settle(handle.container);
+
+        const { asset } = assetElement;
+        if (!asset) {
+            throw new Error('the asset should exist once the element is ready');
+        }
+        expect(loads).toBe(1);
+
+        assetElement.remove();
+        await settleTask();
+
+        // A caller that kept the Asset can still fire it; the removed element must stay silent
+        asset.fire('load', asset);
+        asset.fire('error', 'late failure', asset);
+
+        expect(loads).toBe(1);
+        expect(errorCount).toBe(0);
+    });
+});

--- a/test/integration/loading-progress.test.ts
+++ b/test/integration/loading-progress.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AppElement } from '../../src/app';
+import { bootApp, settle } from '../helpers/app';
+import { mount } from '../helpers/dom';
+import { useGuard } from '../helpers/guard';
+import { readyWithin } from '../helpers/ready';
+
+
+interface Tick {
+    loaded: number;
+    total: number;
+    lengthComputable: boolean;
+    /** `loadProgress` observed at dispatch time, proving the property never lags the event. */
+    fraction: number;
+}
+
+/**
+ * The `progress` ProgressEvents and `loadProgress` property on <pc-app>. Listeners are attached
+ * synchronously after mount(): boot is still suspended on its module and device awaits at that
+ * point, so no tick can be missed - the ordering guarantee a loading UI relies on.
+ */
+describe('<pc-app> loading progress', () => {
+    const { errors, uncaught } = useGuard();
+
+    const settleTask = () => new Promise((resolve) => {
+        setTimeout(resolve, 0);
+    });
+
+    const observe = (appElement: AppElement) => {
+        const ticks: Tick[] = [];
+        const order: string[] = [];
+        appElement.addEventListener('progress', (event) => {
+            ticks.push({
+                loaded: event.loaded,
+                total: event.total,
+                lengthComputable: event.lengthComputable,
+                fraction: appElement.loadProgress
+            });
+            order.push('progress');
+        });
+        appElement.addEventListener('ready', (event) => {
+            // ready bubbles from every descendant; only the app's own marks the boot complete
+            if (event.target === appElement) {
+                order.push('ready');
+            }
+        });
+        return { ticks, order };
+    };
+
+    it('dispatches a single 0-of-0 tick before ready when there is nothing to preload', async () => {
+        const handle = mount('<pc-app backend="null"></pc-app>');
+        const appElement = handle.get<AppElement>('pc-app');
+        const { ticks, order } = observe(appElement);
+
+        expect(appElement.loadProgress, 'progress is 0 until preloading begins').toBe(0);
+
+        await readyWithin(appElement);
+
+        expect(ticks).toEqual([{ loaded: 0, total: 0, lengthComputable: true, fraction: 1 }]);
+        expect(order).toEqual(['progress', 'ready']);
+        expect(appElement.loadProgress).toBe(1);
+        expect(uncaught.seen).toEqual([]);
+    });
+
+    it('ticks once per asset, ending with loaded equal to total, all before ready', async () => {
+        const handle = mount(`<pc-app backend="null">
+            <pc-asset id="a" type="text" src="data:text/plain,alpha"></pc-asset>
+            <pc-asset id="b" type="text" src="data:text/plain,beta"></pc-asset>
+        </pc-app>`);
+        const appElement = handle.get<AppElement>('pc-app');
+        const { ticks, order } = observe(appElement);
+
+        await readyWithin(appElement);
+        await settle(handle.container);
+
+        expect(ticks).toEqual([
+            { loaded: 0, total: 2, lengthComputable: true, fraction: 0 },
+            { loaded: 1, total: 2, lengthComputable: true, fraction: 0.5 },
+            { loaded: 2, total: 2, lengthComputable: true, fraction: 1 }
+        ]);
+        expect(order).toEqual(['progress', 'progress', 'progress', 'ready']);
+    });
+
+    it('counts a failing asset as loaded and still becomes ready', async () => {
+        const handle = mount(`<pc-app backend="null">
+            <pc-asset id="good" type="text" src="data:text/plain,good"></pc-asset>
+            <pc-asset id="bad" type="container" src="data:model/gltf-binary,notaglb"></pc-asset>
+        </pc-app>`);
+        const appElement = handle.get<AppElement>('pc-app');
+        const { ticks } = observe(appElement);
+
+        await readyWithin(appElement);
+        await settle(handle.container);
+
+        expect(ticks.at(-1)).toEqual({ loaded: 2, total: 2, lengthComputable: true, fraction: 1 });
+        errors.expect(/glb/i);
+    });
+
+    it('does not bubble', async () => {
+        const handle = mount('<pc-app backend="null"></pc-app>');
+        let bubbled = 0;
+        let captured = 0;
+        handle.container.addEventListener('progress', () => {
+            bubbled += 1;
+        });
+        handle.container.addEventListener('progress', () => {
+            captured += 1;
+        }, true);
+
+        await readyWithin(handle.get<AppElement>('pc-app'));
+
+        expect(captured).toBeGreaterThan(0);
+        expect(bubbled).toBe(0);
+    });
+
+    it('resets loadProgress once the element is removed', async () => {
+        const { appElement, unmount } = await bootApp();
+
+        expect(appElement.loadProgress).toBe(1);
+
+        unmount();
+        await settleTask();
+
+        expect(appElement.loadProgress).toBe(0);
+    });
+});

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -200,6 +200,18 @@ if (manifest) {
     check(strayPointerEvents.length === 0,
         `pc-app should not declare pointer events: ${strayPointerEvents.join(', ')}`);
 
+    // Loading events are leaf-declared (ProgressEvent/ErrorEvent dispatches, not CustomEvent), so
+    // they exercise the analyzer's non-CustomEvent detection - and must not leak onto other tags
+    // through the inheritance step
+    check(events('pc-app').includes('progress'), "pc-app is missing the 'progress' event");
+    for (const name of ['load', 'error']) {
+        check(events('pc-asset').includes(name), `pc-asset is missing the '${name}' event`);
+    }
+    check(!events('pc-entity').includes('progress'), 'pc-entity should not have a progress event');
+    const strayAssetEvents = ['load', 'error'].filter(name => events('pc-app').includes(name));
+    check(strayAssetEvents.length === 0,
+        `pc-app should not declare asset events: ${strayAssetEvents.join(', ')}`);
+
     // Global invariants
     for (const [tag, declaration] of elements) {
         for (const item of declaration.attributes ?? []) {


### PR DESCRIPTION
## Why

Opening a page today gives no loading signal at all: the only lifecycle event is `ready`, which fires after *every* preload asset has finished. The engine's `preload:start` is unobservable from outside (`appElement.app` is assigned and `app.preload()` called in the same synchronous run), so the one example with a loading bar (solar-system) has to poll for `.app` with `requestAnimationFrame` and subscribe to the raw engine event. Asset failures are entirely silent — a failed asset still resolves `ready` by design.

## What

- **`<pc-app>` fires `progress`** — native `ProgressEvent`s with `loaded`/`total` as **asset counts** (an asset that fails still counts as loaded, matching the engine). One initial tick when preloading begins, one per asset, and the final tick always has `loaded === total` — including a single `(0, 0)` tick when there is nothing to preload, so listeners need no special casing. Non-bubbling, like every native resource-progress event; `ready` remains the completion signal.
- **`AppElement.loadProgress`** — read-only fraction from 0 to 1, so a UI attaching after boot has begun can initialize without racing events. Reset to 0 on removal, mirroring `app`.
- **`<pc-asset>` fires `load` and `error`** — mirroring `<img>` resource semantics: dispatched on the element, non-bubbling (so window-level bubble-phase `error` reporters like Sentry never see them), aggregatable via a capture-phase listener on an ancestor. `error` is an `ErrorEvent` carrying the engine's message — the error channel that previously didn't exist. Fires for lazy assets when they eventually load, and again on reloads. Listeners detach in `destroyAsset()` so a caller holding the `Asset` cannot dispatch on a removed element.

Native event types mean zero `HTMLElementEventMap` additions — `progress`/`load`/`error` are already typed via `GlobalEventHandlersEventMap`.

## Tests

- `test/integration/loading-progress.test.ts` — zero-asset boot (single `(0,0)` tick before `ready`), per-asset tick sequence with `loadProgress` observed at each dispatch, failing asset still completing the count, non-bubbling propagation, reset on removal.
- `test/integration/asset-events.test.ts` — `load` visible to ancestors only in the capture phase, `error` message content while the guard's window bubble-phase channel stays empty, lazy assets firing only when loaded, and silence after element removal.
- CEM validation now pins the three new events (and that they don't leak onto other tags through manifest inheritance).

`npm test` (479 passing), `npm run type-check`, `npm run lint`, `npm run build` (CEM validated), `npm run docs` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)