### PR TITLE
Show a built-in loading bar on pc-app by default

### DIFF
--- a/custom-elements-manifest.config.mjs
+++ b/custom-elements-manifest.config.mjs
@@ -7,10 +7,10 @@ import { manifestCleanupPlugin } from './utils/cem/cleanup-plugin.mjs';
 export default {
     globs: ['src/**/*.ts'],
 
-    // Neither file declares an element, so excluding them keeps the manifest to the public
+    // None of these files declares an element, so excluding them keeps the manifest to the public
     // element surface. The base classes in async-element.ts and components/component.ts are
     // deliberately included - the elements that extend them inherit their attributes and events.
-    exclude: ['src/colors.ts', 'src/parse.ts'],
+    exclude: ['src/colors.ts', 'src/loading-bar.ts', 'src/parse.ts'],
 
     // dist is wiped by `prebuild` and shipped via the `files` and `exports` fields, so the
     // generated files can never go stale and never need committing

--- a/src/app.ts
+++ b/src/app.ts
@@ -69,6 +69,7 @@ import {
 import { AssetElement } from './asset';
 import { AsyncElement } from './async-element';
 import { EntityElement } from './entity';
+import { LoadingBar } from './loading-bar';
 import { MaterialElement } from './material';
 import { ModuleElement } from './module';
 import { parseBool, parseEnum } from './parse';
@@ -101,6 +102,10 @@ class AppElement extends AsyncElement {
     private _stencil = true;
 
     private _highResolution = true;
+
+    private _loadingBar = true;
+
+    private _bar: LoadingBar | null = null;
 
     private _hierarchyReady = false;
 
@@ -160,6 +165,12 @@ class AppElement extends AsyncElement {
     }
 
     async connectedCallback() {
+        // Created before the first await, so the bar is visible while modules and the graphics
+        // device are created, and exists before any disconnect could need to clean it up
+        if (this._loadingBar && !this._bar) {
+            this._bar = new LoadingBar(this);
+        }
+
         // Get all pc-module elements that are direct children of the pc-app element
         const moduleElements = this.querySelectorAll<ModuleElement>(':scope > pc-module');
 
@@ -299,11 +310,13 @@ class AppElement extends AsyncElement {
         const onPreloadProgress = () => {
             loaded += 1;
             this._loadProgress = loaded / total;
+            this._bar?.progress(loaded, total);
             this.dispatchEvent(new ProgressEvent('progress', { lengthComputable: true, loaded, total }));
         };
         app.on('preload:progress', onPreloadProgress);
 
         this._loadProgress = total === 0 ? 1 : 0;
+        this._bar?.progress(0, total);
         this.dispatchEvent(new ProgressEvent('progress', { lengthComputable: true, loaded: 0, total }));
 
         // Load assets before starting the application
@@ -315,6 +328,10 @@ class AppElement extends AsyncElement {
 
             // Start the application
             app.start();
+
+            // Dismiss the bar only once a frame has actually rendered; ready fires before the
+            // first rAF tick
+            app.once('frameend', () => this._bar?.complete());
 
             // Handle window resize to keep the canvas responsive
             window.addEventListener('resize', this._onWindowResize);
@@ -332,6 +349,8 @@ class AppElement extends AsyncElement {
             this._app = null;
         }
         this._loadProgress = 0;
+        this._bar?.destroy();
+        this._bar = null;
 
         // Remove event listeners
         window.removeEventListener('resize', this._onWindowResize);
@@ -631,6 +650,31 @@ class AppElement extends AsyncElement {
     }
 
     /**
+     * Sets whether the application shows its built-in loading bar while it boots and preloads its
+     * assets. Enabled by default; setting `false` removes the bar immediately, while setting
+     * `true` has no effect until the element is next connected. The bar can be themed with the
+     * CSS custom properties `--pc-loading-bar-color`, `--pc-loading-bar-background` and
+     * `--pc-loading-bar-height`.
+     * @param value - The loading bar flag.
+     */
+    set loadingBar(value: boolean) {
+        this._loadingBar = value;
+        if (!value && this._bar) {
+            this._bar.destroy();
+            this._bar = null;
+        }
+    }
+
+    /**
+     * Gets whether the application shows its built-in loading bar while it boots and preloads
+     * its assets.
+     * @returns The loading bar flag.
+     */
+    get loadingBar() {
+        return this._loadingBar;
+    }
+
+    /**
      * Sets the stencil flag.
      * @param value - The stencil flag.
      */
@@ -647,7 +691,7 @@ class AppElement extends AsyncElement {
     }
 
     static get observedAttributes() {
-        return ['alpha', 'antialias', 'backend', 'depth', 'stencil', 'high-resolution'];
+        return ['alpha', 'antialias', 'backend', 'depth', 'stencil', 'high-resolution', 'loading-bar'];
     }
 
     attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
@@ -666,6 +710,9 @@ class AppElement extends AsyncElement {
                 break;
             case 'high-resolution':
                 this.highResolution = parseBool(newValue, true);
+                break;
+            case 'loading-bar':
+                this.loadingBar = parseBool(newValue, true);
                 break;
             case 'stencil':
                 this.stencil = parseBool(newValue, true);

--- a/src/loading-bar.ts
+++ b/src/loading-bar.ts
@@ -1,0 +1,122 @@
+/** Covers the 0.2s opacity transition; jsdom never fires transitionend, so removal is timed. */
+const REMOVAL_DELAY_MS = 250;
+
+/**
+ * The slim progress bar `<pc-app>` shows while it boots and preloads. An implementation detail of
+ * AppElement rather than a custom element, so its shape can change without a breaking change.
+ *
+ * All styling is inline, so the library injects no stylesheet. The colors and height resolve CSS
+ * custom properties — `--pc-loading-bar-color`, `--pc-loading-bar-background` and
+ * `--pc-loading-bar-height` — so a page can theme the bar from `pc-app` or `:root`.
+ */
+class LoadingBar {
+    private _track: HTMLDivElement;
+
+    private _fill: HTMLDivElement;
+
+    private _sweep: Animation | null = null;
+
+    private _removal: ReturnType<typeof setTimeout> | null = null;
+
+    /**
+     * Creates the bar and appends it to `parent`, starting in the indeterminate state.
+     * @param parent - The element to append the bar to.
+     */
+    constructor(parent: HTMLElement) {
+        this._track = document.createElement('div');
+        this._track.setAttribute('role', 'progressbar');
+        this._track.setAttribute('aria-label', 'Loading');
+        this._track.setAttribute('aria-valuemin', '0');
+        this._track.setAttribute('aria-valuemax', '100');
+        // Fixed positioning matches the canvas, which always fills the window (FILLMODE_FILL_WINDOW)
+        this._track.style.cssText = [
+            'position: fixed',
+            'top: 0',
+            'left: 0',
+            'width: 100%',
+            'height: var(--pc-loading-bar-height, 3px)',
+            'background: var(--pc-loading-bar-background, rgba(0, 0, 0, 0.1))',
+            'z-index: 10000',
+            'pointer-events: none',
+            'opacity: 1',
+            'transition: opacity 0.2s ease'
+        ].join('; ');
+
+        this._fill = document.createElement('div');
+        this._fill.style.cssText = [
+            'width: 100%',
+            'height: 100%',
+            'transform-origin: left center',
+            'transform: scaleX(0)',
+            'background: var(--pc-loading-bar-color, #f60)',
+            'transition: transform 0.2s ease'
+        ].join('; ');
+
+        this._track.appendChild(this._fill);
+        parent.appendChild(this._track);
+
+        // Indeterminate sweep until the first progress() call reports a real total. No
+        // aria-valuenow is set, which is what marks a progressbar indeterminate. jsdom has no Web
+        // Animations API, so the guard degrades to a static bar there rather than crashing boot.
+        if (typeof this._fill.animate === 'function') {
+            this._sweep = this._fill.animate([
+                { transform: 'scaleX(0.25) translateX(-100%)' },
+                { transform: 'scaleX(0.25) translateX(500%)' }
+            ], {
+                duration: 1000,
+                iterations: Infinity,
+                easing: 'ease-in-out'
+            });
+        }
+    }
+
+    /**
+     * Reflects preload progress, switching the bar from indeterminate to determinate on the first
+     * call.
+     * @param loaded - The number of assets that have finished loading.
+     * @param total - The number of assets being preloaded.
+     */
+    progress(loaded: number, total: number) {
+        if (this._sweep) {
+            this._sweep.cancel();
+            this._sweep = null;
+        }
+        const fraction = total === 0 ? 1 : loaded / total;
+        this._track.setAttribute('aria-valuenow', String(Math.round(fraction * 100)));
+        this._fill.style.transform = `scaleX(${fraction})`;
+    }
+
+    /**
+     * Fills the bar, fades it out and removes it. Idempotent.
+     */
+    complete() {
+        if (this._removal !== null) {
+            return;
+        }
+        if (this._sweep) {
+            this._sweep.cancel();
+            this._sweep = null;
+        }
+        this._track.setAttribute('aria-valuenow', '100');
+        this._fill.style.transform = 'scaleX(1)';
+        this._track.style.opacity = '0';
+        this._removal = setTimeout(() => this._track.remove(), REMOVAL_DELAY_MS);
+    }
+
+    /**
+     * Removes the bar immediately, cancelling any pending fade. Idempotent.
+     */
+    destroy() {
+        if (this._sweep) {
+            this._sweep.cancel();
+            this._sweep = null;
+        }
+        if (this._removal !== null) {
+            clearTimeout(this._removal);
+            this._removal = null;
+        }
+        this._track.remove();
+    }
+}
+
+export { LoadingBar };

--- a/test/elements/loading-bar.test.ts
+++ b/test/elements/loading-bar.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { useGuard } from '../helpers/guard';
+
+
+/**
+ * The loading-bar boolean attribute on an unconnected <pc-app>. No engine boots in this tier, so
+ * only attributeChangedCallback and the accessor are exercised - the bar itself is covered in the
+ * integration tier.
+ */
+describe('<pc-app> loading-bar attribute', () => {
+    useGuard();
+
+    it('parses like every boolean attribute and restores true on removal', () => {
+        const element = document.createElement('pc-app');
+
+        expect(element.loadingBar, 'the bar is enabled by default').toBe(true);
+
+        element.setAttribute('loading-bar', 'false');
+        expect(element.loadingBar).toBe(false);
+
+        element.setAttribute('loading-bar', '');
+        expect(element.loadingBar, 'a bare boolean attribute means true').toBe(true);
+
+        element.setAttribute('loading-bar', 'false');
+        element.removeAttribute('loading-bar');
+        expect(element.loadingBar).toBe(true);
+    });
+});

--- a/test/integration/loading-bar.test.ts
+++ b/test/integration/loading-bar.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AppElement } from '../../src/app';
+import { bootApp, settle } from '../helpers/app';
+import { mount } from '../helpers/dom';
+import { useGuard } from '../helpers/guard';
+import { readyWithin } from '../helpers/ready';
+
+
+/**
+ * The built-in loading bar <pc-app> shows by default. It is a plain <div role="progressbar">
+ * child of the element - deliberately not a custom element - created synchronously on connect
+ * (before the module and device awaits), driven by the preload ticks, and dismissed after the
+ * first rendered frame.
+ */
+describe('<pc-app> loading bar', () => {
+    const { uncaught } = useGuard();
+
+    const settleTask = () => new Promise((resolve) => {
+        setTimeout(resolve, 0);
+    });
+
+    const barOf = (appElement: AppElement) => appElement.querySelector<HTMLDivElement>('[role="progressbar"]');
+
+    it('appears synchronously on connect, indeterminate until totals are known', async () => {
+        const handle = mount('<pc-app backend="null"></pc-app>');
+        const appElement = handle.get<AppElement>('pc-app');
+
+        const bar = barOf(appElement);
+        if (!bar) {
+            throw new Error('the bar should exist before connectedCallback first awaits');
+        }
+        expect(bar.getAttribute('aria-valuenow'), 'no valuenow marks a progressbar indeterminate')
+        .toBeNull();
+        expect(bar.getAttribute('aria-label')).toBe('Loading');
+
+        await readyWithin(appElement);
+    });
+
+    it('reports determinate progress once preloading begins', async () => {
+        const handle = mount(`<pc-app backend="null">
+            <pc-asset id="a" type="text" src="data:text/plain,alpha"></pc-asset>
+            <pc-asset id="b" type="text" src="data:text/plain,beta"></pc-asset>
+        </pc-app>`);
+        const appElement = handle.get<AppElement>('pc-app');
+
+        await readyWithin(appElement);
+        await settle(handle.container);
+
+        const bar = barOf(appElement);
+        if (!bar) {
+            throw new Error('the bar should still be visible at ready; dismissal waits for a frame');
+        }
+        expect(bar.getAttribute('aria-valuenow')).toBe('100');
+        expect(bar.firstElementChild instanceof HTMLElement &&
+            bar.firstElementChild.style.transform).toBe('scaleX(1)');
+    });
+
+    it('is dismissed after the first rendered frame', async () => {
+        const { appElement } = await bootApp();
+
+        await vi.waitFor(() => {
+            expect(barOf(appElement)).toBeNull();
+        }, { timeout: 2000 });
+    });
+
+    it('never appears when opted out with loading-bar="false"', async () => {
+        const handle = mount('<pc-app backend="null" loading-bar="false"></pc-app>');
+        const appElement = handle.get<AppElement>('pc-app');
+
+        expect(barOf(appElement)).toBeNull();
+
+        await readyWithin(appElement);
+
+        expect(barOf(appElement)).toBeNull();
+    });
+
+    it('is removed immediately when the property is set to false mid-boot', async () => {
+        const handle = mount('<pc-app backend="null"></pc-app>');
+        const appElement = handle.get<AppElement>('pc-app');
+
+        expect(barOf(appElement)).not.toBeNull();
+
+        appElement.loadingBar = false;
+
+        expect(barOf(appElement)).toBeNull();
+
+        await readyWithin(appElement);
+
+        expect(barOf(appElement), 'boot must not resurrect a disabled bar').toBeNull();
+    });
+
+    it('is destroyed by a detach mid-boot and not recreated by the leaked boot', async () => {
+        // Pairs with the pinned #311 behaviour: a synchronously detached pc-app still completes
+        // boot. The bar is created before the first await, so disconnectedCallback has something
+        // to destroy, and every later touch is null-guarded.
+        const handle = mount('<pc-app backend="null"></pc-app>');
+        const appElement = handle.get<AppElement>('pc-app');
+
+        expect(barOf(appElement)).not.toBeNull();
+
+        appElement.remove();
+
+        expect(barOf(appElement), 'disconnect destroys the bar immediately').toBeNull();
+
+        await readyWithin(appElement);
+
+        expect(barOf(appElement), 'the detached boot must not recreate it').toBeNull();
+        expect(uncaught.seen).toEqual([]);
+
+        // Clean up after the pinned bug, so the leak does not follow us into the next test.
+        appElement.app?.destroy();
+    });
+
+    it('stays clean across repeated mount and teardown cycles', async () => {
+        const cycle = async () => {
+            const { unmount } = await bootApp();
+            unmount();
+            await settleTask();
+            expect(uncaught.seen).toEqual([]);
+        };
+
+        await cycle();
+        await cycle();
+        await cycle();
+    });
+});

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -158,6 +158,13 @@ if (manifest) {
     expectEnum('pc-light', 'shadow-type', 9, 'pcf3-32f');
     expectEnum('pc-scrollview', 'horizontal-scrollbar-visibility', 2, 'when-required');
 
+    // The description comes from the getter's "Gets whether ..." JSDoc, so it exercises
+    // toAttributeDescription's rewrite as well as the boolean default. Pinned because the terse
+    // "The x flag." accessor style would make a useless tooltip for a behaviour switch.
+    expectAttribute('pc-app', 'loading-bar', { type: 'boolean', default: 'true', fieldName: 'loadingBar' });
+    check(/^Whether .* built-in loading bar/.test(attribute('pc-app', 'loading-bar')?.description ?? ''),
+        `pc-app[loading-bar] lost its descriptive tooltip: ${JSON.stringify(attribute('pc-app', 'loading-bar')?.description)}`);
+
     // Attributes read with getAttribute, so declared with @attribute
     for (const name of ['name', 'glue', 'wasm', 'fallback']) {
         expectAttribute('pc-module', name, { type: 'string' });


### PR DESCRIPTION
Stacked on #331 (progress events) — merge that first; GitHub will retarget this to `main`.

## Why

Most pages using the library are purely declarative — no author JavaScript at all — so even a perfect event API leaves them showing a white tab while megabytes of assets preload. The default experience should show loading feedback out of the box, the way `<model-viewer>` does.

## What

`<pc-app>` now shows a slim progress bar along the top edge while it boots:

- **Created synchronously on connect**, before the module/device awaits — so the bar covers the whole boot, not just asset preload, and exists before any disconnect could need to clean it up.
- **Indeterminate sweep** (Web Animations API, feature-detected) until the first `progress` tick reports a real total, then determinate `scaleX` tracking of the preload count, with `role="progressbar"` / `aria-valuenow` kept in sync.
- **Dismissed after the first rendered frame** (`app.once('frameend', ...)`) with a short fade — `ready` fires before the first rAF tick, so dismissing at `ready` would flash the old background for a frame.
- **Opt out**: `<pc-app loading-bar="false">`, following the same `parseBool` idiom as `antialias="false"`. Setting the `loadingBar` property to `false` removes the bar immediately at any point.
- **Themable** via CSS custom properties resolved by the inline styles (no stylesheet injection): `--pc-loading-bar-color` (default PlayCanvas orange `#f60`), `--pc-loading-bar-background`, `--pc-loading-bar-height` (default `3px`). Works from `pc-app` or `:root`.
- The bar is a plain `<div>` injected as a light-DOM child (like the canvas), deliberately **not** a custom element or an export — an implementation detail of `<pc-app>` whose shape can change without a breaking change. Fixed positioning matches the canvas, which always fills the window today.

Every touch is `?.`-guarded so the pinned detached-boot path (#311) destroys the bar on disconnect and never resurrects it; the leaked boot's `frameend` no-ops.

## Tests

- `test/integration/loading-bar.test.ts` — present synchronously and indeterminate before totals; `aria-valuenow` 100 at ready; dismissed after the first frame; `loading-bar="false"` never creates it; property-set removal mid-boot; detach mid-boot destroys it with no uncaught errors; repeated mount/teardown cycles stay clean.
- `test/elements/loading-bar.test.ts` — boolean parse semantics on an unconnected element (absent/bare/false/removal).
- CEM validation pins the attribute metadata (`boolean`, default `'true'`, fieldName `loadingBar`) and the descriptive tooltip.

`npm test` (487 passing), `npm run type-check`, `npm run lint`, `npm run build` (CEM validated), `npm run docs` all clean. jsdom constraints honored: `Element.animate` is feature-detected and removal is timed (jsdom never fires `transitionend`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)