### PR TITLE
Scale the physics cluster's SSAO radius to the size of its scene

### DIFF
--- a/examples/physics-cluster.html
+++ b/examples/physics-cluster.html
@@ -38,7 +38,7 @@
                                 "type": "combine",
                                 "blurEnabled": true,
                                 "intensity": 0.5,
-                                "radius": 30,
+                                "radius": 2,
                                 "samples": 12,
                                 "power": 6,
                                 "minAngle": 20,


### PR DESCRIPTION
The spheres in `physics-cluster` render almost entirely black, with green surviving only on the silhouettes.

SSAO `radius` is in world units and the example asks for **30** — roughly three times the extent of the whole scene — so occlusion saturates across every surface that isn't an edge. Because `scene.ambientLight` is black, the studio HDR's image-based lighting is effectively the only light present, and an ambient term multiplied by a saturated AO term goes to *true* black rather than merely dark.

## Where it was introduced

**playcanvas 2.12.0.** Bisected by rendering this example against each engine build from 2.5.0 to 2.21.3 with the original `radius: 30`, pinning both the engine and its matching `scripts/esm/camera-frame.mjs` per run. Green channel across sphere pixels, settled simulation, identical canvas size:

| engine | SSAO off | `combine` r30 |
|---|---|---|
| 2.5.0 | — | 161 / 0% crushed |
| 2.9.0 | — | 158 / 0% |
| 2.11.0 | 188 / 0% | **151 / 0%** |
| 2.12.0 | 187 / 0% | **19 / 79%** |
| 2.13.0 | — | 21 / 78% |
| 2.21.3 | 186 / 0% | 16 / 84% |

The SSAO-off column is the control, and it's flat across the boundary — the scene's lighting isn't what moved, only the strength of the AO applied to it.

**The mechanism inside 2.12.0 is not identified.** Comparing the 2.11.0 and 2.12.0 builds directly rules out every obvious candidate; all are identical across the boundary:

- the SSAO pass math (`radius`, `peak = 0.1 * radius`, the intensity coupling, `projectionScale`)
- the lit-shader AO application (`litArgs_ao *= texture2DLod(ssaoTexture, …)`)
- `getLinearScreenDepth`
- the `SSAOTYPE_COMBINE` → `composePass.ssaoTexture` wiring
- compose-pass ordering of SSAO relative to tonemapping

Whatever changed is upstream of the AO output while leaving its declared inputs alone. That's the useful part for an upstream issue.

## What it isn't

- **Not `pc-material`**, despite the metalness default change that just landed. Reverting the material to the pre-metalness-workflow state renders equally black (mean green 32 vs 34), and `aoIntensity = 0` / `occludeSpecular` off both change nothing. Turning SSAO off is what restores the green.
- **Not the markup fix.** This example used to close `<pc-scripts>` with `</pc-entity>`. Restoring that malformed tag still attaches the script and still renders black, so that earlier fix was cosmetic.
- **Not `LIT_SSAO`.** An earlier revision of this PR claimed the trigger was 2.6.0 moving AO into the lit shader. That's wrong — 2.6.0 renders 155 / 0% crushed. Retracted.

## Reviewer notes

- Radius 2 restores the original look and holds on both sides of the boundary: 145 with nothing crushed on 2.12.0, 141 on 2.21.3, against the 151–161 that 2.5.0 through 2.11.0 produced from radius 30.
- It also lines up with the geometry — the spheres are 1 unit across. Chosen for headroom rather than the strongest AO: start positions are randomized per load, so 3–4 give slightly stronger contact shadows but begin crushing pixels on some arrangements.
- My first sweep pointed at radius 8 and was wrong, because I measured before the simulation had settled while the spheres were still spread through depth. All figures here are post-settle (900 fixed steps).
- **Worth raising upstream separately:** 30 is the `camera-frame` script's own default, so any small-scale scene enabling SSAO with default settings hits this. World units make that default scene-dependent in a way a single number can't express.
- Verified in a real renderer by reading the canvas back, not on the null device. No source or test changes — one number in one example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
