### PR TITLE
Pick asynchronously so pointer events work on WebGPU

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -121,6 +121,9 @@ class AppElement extends AsyncElement {
 
     private _hoveredEntity: EntityElement | null = null;
 
+    // Identifies the newest in-flight hover pick, so out-of-order results can be discarded
+    private _pickToken = 0;
+
     private _pointerHandlers: { [key: string]: EventListener | null } = {
         pointermove: null,
         pointerdown: null,
@@ -372,10 +375,18 @@ class AppElement extends AsyncElement {
         const { width, height } = this.app!.graphicsDevice;
         this._picker = new Picker(this.app!, width, height);
 
-        // Create bound handlers but don't attach them yet
-        this._pointerHandlers.pointermove = this._onPointerMove.bind(this) as EventListener;
-        this._pointerHandlers.pointerdown = this._onPointerDown.bind(this) as EventListener;
-        this._pointerHandlers.pointerup = this._onPointerUp.bind(this) as EventListener;
+        // Create bound handlers but don't attach them yet. The handlers pick asynchronously, so
+        // each is wrapped to discard the promise - a listener must not return one, and nothing
+        // awaits the result.
+        const listener = (handler: (event: PointerEvent) => Promise<void>): EventListener => {
+            return (event: Event) => {
+                handler.call(this, event as PointerEvent);
+            };
+        };
+
+        this._pointerHandlers.pointermove = listener(this._onPointerMove);
+        this._pointerHandlers.pointerdown = listener(this._onPointerDown);
+        this._pointerHandlers.pointerup = listener(this._onPointerUp);
 
         // Listen for pointer listeners being added/removed
         ['pointermove', 'pointerdown', 'pointerup', 'pointerenter', 'pointerleave'].forEach((type) => {
@@ -429,31 +440,51 @@ class AppElement extends AsyncElement {
         return { x, y };
     }
 
-    _onPointerMove(event: PointerEvent) {
-        if (!this._picker || !this.app) return;
-
+    /**
+     * Picks the scene under the pointer and returns the graph node that was hit, or `null`.
+     *
+     * The read back is asynchronous because the synchronous {@link Picker.getSelection} is not
+     * supported on WebGPU, where it returns an empty selection rather than failing - which
+     * silently disabled every `onpointer*` handler once WebGPU became the resolved backend. The
+     * async variant works on both backends and does not block the main thread on a GPU read.
+     *
+     * @param event - The pointer event to pick under.
+     * @returns The graph node under the pointer, or `null` if nothing was hit.
+     */
+    private async _pickNode(event: PointerEvent): Promise<GraphNode | null> {
         const camera = this.app!.root.findComponent('camera') as CameraComponent;
-        if (!camera) return;
+        if (!camera) return null;
 
-        // Use the helper to convert event coordinates into canvas/picker coordinates.
         const { x, y } = this._getPickerCoordinates(event);
 
-        this._picker.prepare(camera, this.app!.scene);
-        const selection = this._picker.getSelection(x, y);
+        this._picker!.prepare(camera, this.app!.scene);
+        const selection = await this._picker!.getSelectionAsync(x, y);
+        if (selection.length === 0) return null;
+
+        const item = selection[0];
+        return item instanceof MeshInstance ? item.node : (item as GSplatComponent).entity;
+    }
+
+    async _onPointerMove(event: PointerEvent) {
+        if (!this._picker || !this.app) return;
+
+        // Moves arrive faster than a pick resolves, so results can land out of order. Only the
+        // newest pick may update the hover state - an older one describes a pointer position the
+        // user has already left.
+        const token = ++this._pickToken;
+        const node = await this._pickNode(event);
+        if (token !== this._pickToken || !this._picker) return;
 
         // Get the currently hovered entity by walking up the hierarchy
         let newHoverEntity: EntityElement | null = null;
-        if (selection.length > 0) {
-            const item = selection[0];
-            let currentNode: GraphNode | null = item instanceof MeshInstance ? item.node : (item as GSplatComponent).entity;
-            while (currentNode !== null) {
-                const entityElement = this.querySelector(`pc-entity[name="${currentNode.name}"]`) as EntityElement;
-                if (entityElement) {
-                    newHoverEntity = entityElement;
-                    break;
-                }
-                currentNode = currentNode.parent;
+        let currentNode = node;
+        while (currentNode !== null) {
+            const entityElement = this.querySelector(`pc-entity[name="${currentNode.name}"]`) as EntityElement;
+            if (entityElement) {
+                newHoverEntity = entityElement;
+                break;
             }
+            currentNode = currentNode.parent;
         }
 
         // Handle enter/leave events
@@ -475,51 +506,31 @@ class AppElement extends AsyncElement {
         }
     }
 
-    _onPointerDown(event: PointerEvent) {
+    async _onPointerDown(event: PointerEvent) {
         if (!this._picker || !this.app) return;
 
-        const camera = this.app!.root.findComponent('camera') as CameraComponent;
-        if (!camera) return;
+        let currentNode = await this._pickNode(event);
+        if (!this._picker) return; // the element disconnected while the pick was in flight
 
-        // Convert the event's pointer coordinates
-        const { x, y } = this._getPickerCoordinates(event);
-
-        this._picker.prepare(camera, this.app!.scene);
-        const selection = this._picker.getSelection(x, y);
-
-        if (selection.length > 0) {
-            const item = selection[0];
-            let currentNode: GraphNode | null = item instanceof MeshInstance ? item.node : (item as GSplatComponent).entity;
-            while (currentNode !== null) {
-                const entityElement = this.querySelector(`pc-entity[name="${currentNode.name}"]`) as EntityElement;
-                if (entityElement && entityElement.hasListeners('pointerdown')) {
-                    entityElement.dispatchEvent(new PointerEvent('pointerdown', event));
-                    break;
-                }
-                currentNode = currentNode.parent;
+        while (currentNode !== null) {
+            const entityElement = this.querySelector(`pc-entity[name="${currentNode.name}"]`) as EntityElement;
+            if (entityElement && entityElement.hasListeners('pointerdown')) {
+                entityElement.dispatchEvent(new PointerEvent('pointerdown', event));
+                break;
             }
+            currentNode = currentNode.parent;
         }
     }
 
-    _onPointerUp(event: PointerEvent) {
+    async _onPointerUp(event: PointerEvent) {
         if (!this._picker || !this.app) return;
 
-        const camera = this.app!.root.findComponent('camera') as CameraComponent;
-        if (!camera) return;
+        const node = await this._pickNode(event);
+        if (!node || !this._picker) return;
 
-        // Convert CSS coordinates to picker coordinates
-        const { x, y } = this._getPickerCoordinates(event);
-
-        this._picker.prepare(camera, this.app!.scene);
-        const selection = this._picker.getSelection(x, y);
-
-        if (selection.length > 0) {
-            const item = selection[0];
-            const node = item instanceof MeshInstance ? item.node : (item as GSplatComponent).entity;
-            const entityElement = this.querySelector(`pc-entity[name="${node.name}"]`) as EntityElement;
-            if (entityElement && entityElement.hasListeners('pointerup')) {
-                entityElement.dispatchEvent(new PointerEvent('pointerup', event));
-            }
+        const entityElement = this.querySelector(`pc-entity[name="${node.name}"]`) as EntityElement;
+        if (entityElement && entityElement.hasListeners('pointerup')) {
+            entityElement.dispatchEvent(new PointerEvent('pointerup', event));
         }
     }
 

--- a/test/integration/pointer.test.ts
+++ b/test/integration/pointer.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AppElement } from '../../src/app';
+import type { EntityElement } from '../../src/entity';
+import { bootApp } from '../helpers/app';
+import { useGuard } from '../helpers/guard';
+
+
+/** A graph node stand-in. The pick only reads `name` and walks `parent`. */
+type Node = { name: string, parent: Node | null };
+
+const node = (name: string, parent: Node | null = null): Node => ({ name, parent });
+
+/**
+ * Builds a selection entry. `_pickNode` branches on `instanceof MeshInstance`, so a plain object
+ * always takes the gsplat branch and is read through `entity` - which is all this needs.
+ *
+ * @param target - The node the pick should report.
+ * @returns The selection entry.
+ */
+const hit = (target: Node) => ({ entity: target });
+
+/**
+ * Creates a promise plus its resolver, for driving two picks to completion out of order.
+ *
+ * @returns The promise and its resolve function.
+ */
+const deferred = <T>() => {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((r) => {
+        resolve = r;
+    });
+    return { promise, resolve };
+};
+
+/**
+ * Swaps in a picker whose read back this test controls, and records which of the two read-back
+ * APIs the element reached for.
+ *
+ * The null device renders nothing, so a real Picker can only ever return an empty selection. The
+ * substitution keeps the assertions on the element's own logic - the hierarchy walk, the
+ * enter/leave bookkeeping and the ordering guard - rather than on the GPU.
+ *
+ * @param appElement - The booted pc-app.
+ * @param queue - Selections to hand out, one per call. A deferred entry is resolved by the test.
+ * @returns The per-API call counts.
+ */
+const stubPicker = (appElement: AppElement, queue: (ReturnType<typeof hit>[] | Promise<ReturnType<typeof hit>[]>)[]) => {
+    const calls = { sync: 0, async: 0 };
+
+    (appElement as unknown as { _picker: unknown })._picker = {
+        prepare: () => {},
+        getSelection: () => {
+            calls.sync++;
+            return [];
+        },
+        getSelectionAsync: () => {
+            calls.async++;
+            return Promise.resolve(queue.shift() ?? []);
+        }
+    };
+
+    return calls;
+};
+
+/**
+ * Yields to the task queue so an awaited pick can run to completion.
+ *
+ * @returns A promise that settles once queued work has run.
+ */
+const flush = () => new Promise((resolve) => {
+    setTimeout(resolve, 0);
+});
+
+describe('pc-app pointer picking', () => {
+    useGuard();
+
+    /**
+     * Boots one pc-entity with pointer listeners attached, which is also what makes pc-app attach
+     * its canvas handlers - they are wired lazily, on the first listener of each type.
+     *
+     * The camera is not decoration: the pick resolves one from the scene and gives up before
+     * reading anything back if there is none.
+     *
+     * @param name - The entity name, matched against the picked node's name.
+     * @returns The booted handle plus the canvas and a spy per pointer type.
+     */
+    const bootTarget = async (name = 'target') => {
+        const handle = await bootApp(`
+            <pc-entity name="camera"><pc-camera></pc-camera></pc-entity>
+            <pc-entity name="${name}"></pc-entity>
+        `);
+        const element = handle.get<EntityElement>(`pc-entity[name="${name}"]`);
+
+        const spies = {
+            pointerenter: vi.fn(),
+            pointerleave: vi.fn(),
+            pointerdown: vi.fn(),
+            pointerup: vi.fn()
+        };
+        Object.entries(spies).forEach(([type, spy]) => element.addEventListener(type, spy));
+
+        const canvas = handle.appElement.querySelector('canvas');
+        if (!canvas) throw new Error('bootTarget: pc-app created no canvas');
+
+        return { ...handle, element, spies, canvas };
+    };
+
+    const move = (x: number, y: number) => new PointerEvent('pointermove', { clientX: x, clientY: y });
+
+    it('dispatches pointerenter when a pick lands on the entity', async () => {
+        const { appElement, canvas, spies } = await bootTarget();
+        stubPicker(appElement, [[hit(node('target'))]]);
+
+        canvas.dispatchEvent(move(400, 300));
+        await flush();
+
+        expect(spies.pointerenter).toHaveBeenCalledTimes(1);
+        expect(spies.pointerleave).not.toHaveBeenCalled();
+    });
+
+    it('reads back asynchronously, because getSelection is unsupported on WebGPU', async () => {
+        // The synchronous Picker.getSelection returns an empty selection on WebGPU rather than
+        // failing, which silently disabled every onpointer* handler once WebGPU became the
+        // resolved backend. Reaching for it again would reintroduce that, invisibly on WebGL2.
+        const { appElement, canvas } = await bootTarget();
+        const calls = stubPicker(appElement, [[hit(node('target'))]]);
+
+        canvas.dispatchEvent(move(400, 300));
+        await flush();
+
+        expect(calls.async, 'the pick must use getSelectionAsync').toBe(1);
+        expect(calls.sync, 'getSelection returns nothing on WebGPU').toBe(0);
+    });
+
+    it('walks up to the nearest ancestor that has a pc-entity', async () => {
+        // A picked GLB gives back its own internal nodes - Object_8 and friends - never the name
+        // on the pc-entity, so the walk is what makes a model pickable at all.
+        const { appElement, canvas, spies } = await bootTarget();
+        const inner = node('Object_8', node('GLTF_SceneRootNode', node('target')));
+        stubPicker(appElement, [[hit(inner)]]);
+
+        canvas.dispatchEvent(move(400, 300));
+        await flush();
+
+        expect(spies.pointerenter).toHaveBeenCalledTimes(1);
+    });
+
+    it('dispatches pointerleave once the pointer moves off the entity', async () => {
+        const { appElement, canvas, spies } = await bootTarget();
+        stubPicker(appElement, [[hit(node('target'))], []]);
+
+        canvas.dispatchEvent(move(400, 300));
+        await flush();
+        canvas.dispatchEvent(move(10, 10));
+        await flush();
+
+        expect(spies.pointerenter).toHaveBeenCalledTimes(1);
+        expect(spies.pointerleave).toHaveBeenCalledTimes(1);
+    });
+
+    it('discards a hover pick that resolves after a newer one', async () => {
+        // Moves arrive faster than a pick resolves, so results can land out of order. Applying a
+        // stale one would flap the hover state against a pointer position already left behind.
+        const { appElement, canvas, spies } = await bootTarget();
+        const stale = deferred<ReturnType<typeof hit>[]>();
+        const fresh = deferred<ReturnType<typeof hit>[]>();
+        stubPicker(appElement, [stale.promise, fresh.promise]);
+
+        canvas.dispatchEvent(move(10, 10));   // pick 1, resolved last
+        canvas.dispatchEvent(move(400, 300)); // pick 2, resolved first
+
+        fresh.resolve([hit(node('target'))]);
+        await flush();
+        expect(spies.pointerenter, 'the newest pick applies').toHaveBeenCalledTimes(1);
+
+        stale.resolve([]);
+        await flush();
+
+        expect(spies.pointerleave, 'the stale empty pick must not clear the hover').not.toHaveBeenCalled();
+        expect(spies.pointerenter).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores a pick that resolves after the element has disconnected', async () => {
+        const { appElement, canvas, spies, unmount } = await bootTarget();
+        const pending = deferred<ReturnType<typeof hit>[]>();
+        stubPicker(appElement, [pending.promise]);
+
+        canvas.dispatchEvent(move(400, 300));
+        unmount();
+        pending.resolve([hit(node('target'))]);
+        await flush();
+
+        expect(spies.pointerenter).not.toHaveBeenCalled();
+    });
+
+    it('dispatches pointerdown and pointerup on the picked entity', async () => {
+        const { appElement, canvas, spies } = await bootTarget();
+        stubPicker(appElement, [[hit(node('target'))], [hit(node('target'))]]);
+
+        canvas.dispatchEvent(new PointerEvent('pointerdown', { clientX: 400, clientY: 300 }));
+        await flush();
+        canvas.dispatchEvent(new PointerEvent('pointerup', { clientX: 400, clientY: 300 }));
+        await flush();
+
+        expect(spies.pointerdown).toHaveBeenCalledTimes(1);
+        expect(spies.pointerup).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
**Every `onpointer*` handler in the library was dead.** The three pointer handlers on `pc-app` read the pick back with `Picker.getSelection`, which the engine documents as unsupported on WebGPU — and it doesn't fail there, it returns an empty selection. So nothing was ever hovered, clicked or released, in any scene, silently.

Measured on one frame of `tween.html`, the only example that uses these handlers:

| backend | `getSelection` | `getSelectionAsync` |
|---|---|---|
| webgpu | **0** | 1 |
| webgl2 | 1 | 1 |

The reported symptom was "hover and click don't trigger the tweens in tween.html," but the tween code is fine — this is the whole picking feature.

## Why it looks like it broke on its own

Neither half is new. `pc-app` has defaulted to `backend="webgpu"` (falling back to `webgl2`) since #172, and `getSelectionAsync` has existed since engine 2.5.0 — so the synchronous call has *never* worked on WebGPU. What changed is the environment: the browser now offers WebGPU, so the webgpu-first default stops falling back to webgl2, and the picking stops with it. Nothing in this repo or the engine changed to cause it.

## What was ruled out first

- The star renders correctly throughout — center pixel `238,173,110` against a clear color of `128,153,230` — and a full-frame grid scan returned no pick hits at all, so this is the picker rather than the geometry or the camera.
- The event wiring is intact: `hasListeners` true for all three types, inline handlers compiled by the browser, canvas listeners attached, picker constructed.

## The fix

The three handlers share a `_pickNode` helper built on `getSelectionAsync`, which works on both backends and doesn't block the main thread on a GPU read. Each handler keeps its own hierarchy walk, so no dispatch semantics change. Going async needs two guards:

- **Ordering.** Moves arrive faster than a pick resolves, so results can land out of order. A `_pickToken` counter discards a stale result rather than letting it flap the hover state against a pointer position the user has already left.
- **Teardown.** `_picker` is nulled on disconnect, so a pick still in flight when the element unmounts is dropped instead of dereferencing a torn-down app.

## Tests

7 new, 494 pass overall. This path had **no coverage whatsoever**, which is precisely how a backend-dependent failure this total went unnoticed. The null device can't pick, so the picker is substituted and the assertions stay on the element's own logic: enter/leave, the ancestor walk (what makes a GLB pickable at all, given it reports `Object_8` rather than the `pc-entity` name), out-of-order discard, the teardown guard, and down/up.

One test asserts `getSelection` is never reached, so a refactor back to it fails here instead of silently breaking WebGPU while still passing on WebGL2. Verified by mutation: restoring the synchronous call fails 6 of the 7.

## Reviewer notes

- Verified in a real renderer on **both** backends, not the null device: hover scales 1 → 1.1875, leave returns to 1.0000, click spins Y 0 → 45. Identical on `webgpu` and `backend="webgl2"`.
- Async dispatch means a synthesized `pointerdown` no longer lands inside the user-activation window. Nothing in `examples/` relies on that — `tween.html` is the only user of these attributes — but it would matter to anyone starting fullscreen, XR or audio from an `onpointerdown`.
- **Not fixed here, pre-existing:** `_onPointerUp` doesn't walk the hierarchy the way `_onPointerDown` does — it only tests the picked node's own name. For a GLB that name is an internal node, so `pointerup` never reaches a loaded model. Its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
