### PR TITLE
Join picked nodes to elements by identity instead of name

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import {
     CameraComponent,
     createGraphicsDevice,
     ElementInput,
+    Entity,
     FILLMODE_FILL_WINDOW,
     GraphNode,
     Keyboard,
@@ -108,6 +109,13 @@ class AppElement extends AsyncElement {
     private _bar: LoadingBar | null = null;
 
     private _hierarchyReady = false;
+
+    /**
+     * The elements backing this application's entities, keyed by the entity itself. Registered
+     * by EntityElement at creation and removed when an entity is destroyed, this joins engine
+     * scene nodes back to their owning elements by identity - never by name.
+     */
+    private _entityElements = new Map<GraphNode, EntityElement>();
 
     private _picker: Picker | null = null;
 
@@ -346,11 +354,13 @@ class AppElement extends AsyncElement {
     disconnectedCallback() {
         this._pickerDestroy();
 
-        // Clean up the application
+        // Clean up the application. Destroying it destroys every entity, whose destroy hooks
+        // unregister them - clear() covers any entity the engine no longer reached.
         if (this._app) {
             this._app.destroy();
             this._app = null;
         }
+        this._entityElements.clear();
         this._loadProgress = 0;
         this._bar?.destroy();
         this._bar = null;
@@ -427,6 +437,79 @@ class AppElement extends AsyncElement {
         };
     }
 
+    /**
+     * Registers the element that created an entity. Called by EntityElement when it creates its
+     * entity.
+     *
+     * @param entity - The entity.
+     * @param element - The element that created it.
+     * @ignore
+     */
+    _registerEntityElement(entity: Entity, element: EntityElement) {
+        this._entityElements.set(entity, element);
+    }
+
+    /**
+     * Removes the registration for a destroyed entity. Called by EntityElement.
+     *
+     * @param entity - The entity.
+     * @ignore
+     */
+    _unregisterEntityElement(entity: Entity) {
+        this._entityElements.delete(entity);
+    }
+
+    /**
+     * Returns the `<pc-entity>` element whose backing entity is `entity`, or `null` if the
+     * entity was not created by an element of this application - for example, a node inside a
+     * model's instantiated hierarchy, or an entity created through the engine API.
+     *
+     * @param entity - The entity to look up.
+     * @returns The element backing the entity, or `null`.
+     */
+    elementFromEntity(entity: Entity): EntityElement | null {
+        return this._entityElements.get(entity) ?? null;
+    }
+
+    /**
+     * Resolves the element that owns a picked node: the nearest node up the parent chain -
+     * starting with the node itself - that was created by a `<pc-entity>` of this application.
+     * A hit inside a model's instantiated hierarchy therefore resolves to the element hosting
+     * the model.
+     *
+     * @param node - The picked node, or `null`.
+     * @returns The owning element, or `null`.
+     */
+    private _elementFromNode(node: GraphNode | null): EntityElement | null {
+        while (node !== null) {
+            const element = this._entityElements.get(node);
+            if (element) {
+                return element;
+            }
+            node = node.parent;
+        }
+        return null;
+    }
+
+    /**
+     * Like {@link _elementFromNode}, but skips elements without a listener for `type`, so a hit
+     * on an unlistened child still reaches a listening ancestor.
+     *
+     * @param node - The picked node, or `null`.
+     * @param type - The pointer event type a listener is required for.
+     * @returns The nearest listening element, or `null`.
+     */
+    private _elementWithListener(node: GraphNode | null, type: string): EntityElement | null {
+        while (node !== null) {
+            const element = this._entityElements.get(node);
+            if (element?.hasListeners(type)) {
+                return element;
+            }
+            node = node.parent;
+        }
+        return null;
+    }
+
     // New helper to convert CSS coordinates to canvas (picker) coordinates
     private _getPickerCoordinates(event: PointerEvent): { x: number, y: number } {
         // Get the canvas' bounding rectangle in CSS pixels.
@@ -475,17 +558,9 @@ class AppElement extends AsyncElement {
         const node = await this._pickNode(event);
         if (token !== this._pickToken || !this._picker) return;
 
-        // Get the currently hovered entity by walking up the hierarchy
-        let newHoverEntity: EntityElement | null = null;
-        let currentNode = node;
-        while (currentNode !== null) {
-            const entityElement = this.querySelector(`pc-entity[name="${currentNode.name}"]`) as EntityElement;
-            if (entityElement) {
-                newHoverEntity = entityElement;
-                break;
-            }
-            currentNode = currentNode.parent;
-        }
+        // The hovered element is the nearest one up the node's parent chain, listening or not -
+        // dispatch is gated per event type below
+        const newHoverEntity = this._elementFromNode(node);
 
         // Handle enter/leave events
         if (this._hoveredEntity !== newHoverEntity) {
@@ -509,16 +584,12 @@ class AppElement extends AsyncElement {
     async _onPointerDown(event: PointerEvent) {
         if (!this._picker || !this.app) return;
 
-        let currentNode = await this._pickNode(event);
+        const node = await this._pickNode(event);
         if (!this._picker) return; // the element disconnected while the pick was in flight
 
-        while (currentNode !== null) {
-            const entityElement = this.querySelector(`pc-entity[name="${currentNode.name}"]`) as EntityElement;
-            if (entityElement && entityElement.hasListeners('pointerdown')) {
-                entityElement.dispatchEvent(new PointerEvent('pointerdown', event));
-                break;
-            }
-            currentNode = currentNode.parent;
+        const entityElement = this._elementWithListener(node, 'pointerdown');
+        if (entityElement) {
+            entityElement.dispatchEvent(new PointerEvent('pointerdown', event));
         }
     }
 
@@ -526,10 +597,10 @@ class AppElement extends AsyncElement {
         if (!this._picker || !this.app) return;
 
         const node = await this._pickNode(event);
-        if (!node || !this._picker) return;
+        if (!this._picker) return; // the element disconnected while the pick was in flight
 
-        const entityElement = this.querySelector(`pc-entity[name="${node.name}"]`) as EntityElement;
-        if (entityElement && entityElement.hasListeners('pointerup')) {
+        const entityElement = this._elementWithListener(node, 'pointerup');
+        if (entityElement) {
             entityElement.dispatchEvent(new PointerEvent('pointerup', event));
         }
     }

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -1,5 +1,6 @@
 import { AppBase, Entity, Vec3 } from 'playcanvas';
 
+import { AppElement } from './app';
 import { AsyncElement } from './async-element';
 import { parseBool, parseTags, parseVec3 } from './parse';
 
@@ -76,6 +77,12 @@ class EntityElement extends AsyncElement {
     private _entity: Entity | null = null;
 
     /**
+     * The application element this entity is registered with, cached at creation time so the
+     * entity can be unregistered even once this element has left the DOM.
+     */
+    private _appElement: AppElement | null = null;
+
+    /**
      * The PlayCanvas entity instance. `null` until the element is ready, and again once it has
      * been removed from the document — await {@link whenReady} or the element's `ready()`
      * promise before accessing it.
@@ -108,6 +115,29 @@ class EntityElement extends AsyncElement {
         if (this._tags.length > 0) {
             entity.tags.add(this._tags);
         }
+
+        // Register with the owning application, which joins engine nodes back to elements by
+        // identity (never by name), and hook the entity's destruction. The engine fires 'destroy'
+        // for every entity in a destroyed subtree, so the element learns of its entity's death no
+        // matter who causes it: this element, an ancestor, the whole application, or a user
+        // script calling entity.destroy().
+        this._appElement = this.closestApp;
+        this._appElement?._registerEntityElement(entity, this);
+        entity.once('destroy', this._onEntityDestroy, this);
+    }
+
+    /**
+     * Handles the destruction of the backing entity. Resets the element so a later re-insertion
+     * starts clean: `_built` must be cleared alongside `_entity`, or buildHierarchy would bail
+     * and a re-created entity would never be parented.
+     *
+     * @param entity - The entity that was destroyed.
+     */
+    private _onEntityDestroy(entity: Entity) {
+        this._appElement?._unregisterEntityElement(entity);
+        this._appElement = null;
+        this._entity = null;
+        this._built = false;
     }
 
     buildHierarchy(app: AppBase) {
@@ -156,23 +186,11 @@ class EntityElement extends AsyncElement {
     }
 
     disconnectedCallback() {
-        if (this.entity) {
-            // Notify all children that their entities are about to become invalid. Both fields have
-            // to be reset here, not just _entity: a descendant's own disconnectedCallback runs after
-            // this one and skips its reset behind the `if (this.entity)` guard, because we have
-            // already nulled the entity it tests. Leaving _built set would make buildHierarchy bail
-            // on re-insertion, so the descendant would get a fresh entity that is never parented.
-            const children = this.querySelectorAll<EntityElement>('pc-entity');
-            children.forEach((child) => {
-                child._entity = null;
-                child._built = false;
-            });
-
-            // Destroy the entity
-            this.entity.destroy();
-            this._entity = null;
-            this._built = false;
-        }
+        // Destroying the entity destroys its whole subtree, and the engine fires 'destroy' for
+        // every entity in it - so _onEntityDestroy resets this element AND every descendant
+        // element before the descendants' own disconnectedCallbacks run. Their entities are null
+        // by then, making this call a no-op for them.
+        this._entity?.destroy();
     }
 
     /**

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -1,6 +1,6 @@
 import { AppBase, Entity, Vec3 } from 'playcanvas';
 
-import { AppElement } from './app';
+import type { AppElement } from './app';
 import { AsyncElement } from './async-element';
 import { parseBool, parseTags, parseVec3 } from './parse';
 

--- a/test/integration/entity-map.test.ts
+++ b/test/integration/entity-map.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import type { EntityElement } from '../../src/entity';
+import { bootApp } from '../helpers/app';
+import { useGuard } from '../helpers/guard';
+
+
+/**
+ * A macrotask turn, so disconnect callbacks and suspended awaits run to completion.
+ *
+ * @returns A promise that settles once queued work has run.
+ */
+const settleTask = () => new Promise((resolve) => {
+    setTimeout(resolve, 0);
+});
+
+/**
+ * The entity map is what joins engine scene nodes back to their owning elements by identity.
+ * Picking resolves hits through it, and pc-node (#297) will register bound entities into it, so
+ * its bookkeeping - registration at creation, removal on destruction, whoever triggers it - is
+ * behavior in its own right.
+ */
+describe('pc-app entity map', () => {
+    const { uncaught } = useGuard();
+
+    it('elementFromEntity returns the element that created each entity', async () => {
+        const { appElement, all } = await bootApp(
+            '<pc-entity name="parent"><pc-entity name="child"></pc-entity></pc-entity>'
+        );
+        const elements = Array.from(all<EntityElement>('pc-entity'));
+
+        expect(elements).toHaveLength(2);
+        for (const element of elements) {
+            expect(element.entity).not.toBeNull();
+            expect(appElement.elementFromEntity(element.entity!)).toBe(element);
+        }
+    });
+
+    it('returns null for an entity no element created', async () => {
+        const { appElement, app } = await bootApp('<pc-entity name="e"></pc-entity>');
+
+        // app.root is a real entity of this application, but no element owns it
+        expect(appElement.elementFromEntity(app.root)).toBeNull();
+    });
+
+    it('resets the element and its registration when a user script destroys the entity', async () => {
+        const { appElement, get } = await bootApp('<pc-entity name="e"></pc-entity>');
+        const element = get<EntityElement>('pc-entity');
+        const entity = element.entity!;
+
+        entity.destroy();
+
+        expect(appElement.elementFromEntity(entity)).toBeNull();
+        expect(element.entity, 'the element no longer references the destroyed entity').toBeNull();
+    });
+
+    it('is emptied when the application is torn down', async () => {
+        const { appElement, get, unmount } = await bootApp('<pc-entity name="e"></pc-entity>');
+        const entity = get<EntityElement>('pc-entity').entity!;
+
+        unmount();
+        await settleTask();
+
+        expect(appElement.elementFromEntity(entity)).toBeNull();
+        expect(uncaught.seen).toEqual([]);
+    });
+
+    it('registers the fresh entity when a subtree is removed and re-added', async () => {
+        const { appElement, all } = await bootApp(
+            '<pc-entity name="parent"><pc-entity name="child"></pc-entity></pc-entity>'
+        );
+        const parentElement = all<EntityElement>('pc-entity')[0];
+        const container = parentElement.parentElement!;
+        const oldEntity = parentElement.entity!;
+
+        parentElement.remove();
+        await settleTask();
+        expect(appElement.elementFromEntity(oldEntity), 'the destroyed entity is unregistered').toBeNull();
+
+        container.appendChild(parentElement);
+        await settleTask();
+
+        const fresh = parentElement.entity;
+        expect(fresh, 'a fresh entity was created').not.toBeNull();
+        expect(fresh).not.toBe(oldEntity);
+        expect(appElement.elementFromEntity(fresh!)).toBe(parentElement);
+        expect(uncaught.seen).toEqual([]);
+    });
+});

--- a/test/integration/pointer.test.ts
+++ b/test/integration/pointer.test.ts
@@ -1,3 +1,4 @@
+import type { Entity } from 'playcanvas';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { AppElement } from '../../src/app';
@@ -6,10 +7,14 @@ import { bootApp } from '../helpers/app';
 import { useGuard } from '../helpers/guard';
 
 
-/** A graph node stand-in. The pick only reads `name` and walks `parent`. */
-type Node = { name: string, parent: Node | null };
+/**
+ * A stand-in for a node inside a model's instantiated hierarchy. Element resolution matches
+ * nodes against the entity map by object identity and follows `parent`, so a plain object is
+ * never matched itself - the chain has to terminate at a real entity (or null) to resolve.
+ */
+type ModelNode = { name: string, parent: ModelNode | Entity | null };
 
-const node = (name: string, parent: Node | null = null): Node => ({ name, parent });
+const modelNode = (name: string, parent: ModelNode | Entity | null = null): ModelNode => ({ name, parent });
 
 /**
  * Builds a selection entry. `_pickNode` branches on `instanceof MeshInstance`, so a plain object
@@ -18,7 +23,7 @@ const node = (name: string, parent: Node | null = null): Node => ({ name, parent
  * @param target - The node the pick should report.
  * @returns The selection entry.
  */
-const hit = (target: Node) => ({ entity: target });
+const hit = (target: ModelNode | Entity) => ({ entity: target });
 
 /**
  * Creates a promise plus its resolver, for driving two picks to completion out of order.
@@ -38,7 +43,7 @@ const deferred = <T>() => {
  * APIs the element reached for.
  *
  * The null device renders nothing, so a real Picker can only ever return an empty selection. The
- * substitution keeps the assertions on the element's own logic - the hierarchy walk, the
+ * substitution keeps the assertions on the element's own logic - the element resolution, the
  * enter/leave bookkeeping and the ordering guard - rather than on the GPU.
  *
  * @param appElement - The booted pc-app.
@@ -82,8 +87,9 @@ describe('pc-app pointer picking', () => {
      * The camera is not decoration: the pick resolves one from the scene and gives up before
      * reading anything back if there is none.
      *
-     * @param name - The entity name, matched against the picked node's name.
-     * @returns The booted handle plus the canvas and a spy per pointer type.
+     * @param name - The entity name.
+     * @returns The booted handle plus the element, its entity, the canvas and a spy per pointer
+     * type.
      */
     const bootTarget = async (name = 'target') => {
         const handle = await bootApp(`
@@ -91,6 +97,8 @@ describe('pc-app pointer picking', () => {
             <pc-entity name="${name}"></pc-entity>
         `);
         const element = handle.get<EntityElement>(`pc-entity[name="${name}"]`);
+        const entity = element.entity;
+        if (!entity) throw new Error('bootTarget: the target entity was not created');
 
         const spies = {
             pointerenter: vi.fn(),
@@ -103,14 +111,14 @@ describe('pc-app pointer picking', () => {
         const canvas = handle.appElement.querySelector('canvas');
         if (!canvas) throw new Error('bootTarget: pc-app created no canvas');
 
-        return { ...handle, element, spies, canvas };
+        return { ...handle, element, entity, spies, canvas };
     };
 
     const move = (x: number, y: number) => new PointerEvent('pointermove', { clientX: x, clientY: y });
 
     it('dispatches pointerenter when a pick lands on the entity', async () => {
-        const { appElement, canvas, spies } = await bootTarget();
-        stubPicker(appElement, [[hit(node('target'))]]);
+        const { appElement, canvas, entity, spies } = await bootTarget();
+        stubPicker(appElement, [[hit(entity)]]);
 
         canvas.dispatchEvent(move(400, 300));
         await flush();
@@ -123,8 +131,8 @@ describe('pc-app pointer picking', () => {
         // The synchronous Picker.getSelection returns an empty selection on WebGPU rather than
         // failing, which silently disabled every onpointer* handler once WebGPU became the
         // resolved backend. Reaching for it again would reintroduce that, invisibly on WebGL2.
-        const { appElement, canvas } = await bootTarget();
-        const calls = stubPicker(appElement, [[hit(node('target'))]]);
+        const { appElement, canvas, entity } = await bootTarget();
+        const calls = stubPicker(appElement, [[hit(entity)]]);
 
         canvas.dispatchEvent(move(400, 300));
         await flush();
@@ -134,10 +142,11 @@ describe('pc-app pointer picking', () => {
     });
 
     it('walks up to the nearest ancestor that has a pc-entity', async () => {
-        // A picked GLB gives back its own internal nodes - Object_8 and friends - never the name
-        // on the pc-entity, so the walk is what makes a model pickable at all.
-        const { appElement, canvas, spies } = await bootTarget();
-        const inner = node('Object_8', node('GLTF_SceneRootNode', node('target')));
+        // A picked GLB gives back its own internal nodes - Object_8 and friends - which no
+        // element created, so the walk to the model's host entity is what makes a model pickable
+        // at all.
+        const { appElement, canvas, entity, spies } = await bootTarget();
+        const inner = modelNode('Object_8', modelNode('GLTF_SceneRootNode', entity));
         stubPicker(appElement, [[hit(inner)]]);
 
         canvas.dispatchEvent(move(400, 300));
@@ -147,8 +156,8 @@ describe('pc-app pointer picking', () => {
     });
 
     it('dispatches pointerleave once the pointer moves off the entity', async () => {
-        const { appElement, canvas, spies } = await bootTarget();
-        stubPicker(appElement, [[hit(node('target'))], []]);
+        const { appElement, canvas, entity, spies } = await bootTarget();
+        stubPicker(appElement, [[hit(entity)], []]);
 
         canvas.dispatchEvent(move(400, 300));
         await flush();
@@ -162,7 +171,7 @@ describe('pc-app pointer picking', () => {
     it('discards a hover pick that resolves after a newer one', async () => {
         // Moves arrive faster than a pick resolves, so results can land out of order. Applying a
         // stale one would flap the hover state against a pointer position already left behind.
-        const { appElement, canvas, spies } = await bootTarget();
+        const { appElement, canvas, entity, spies } = await bootTarget();
         const stale = deferred<ReturnType<typeof hit>[]>();
         const fresh = deferred<ReturnType<typeof hit>[]>();
         stubPicker(appElement, [stale.promise, fresh.promise]);
@@ -170,7 +179,7 @@ describe('pc-app pointer picking', () => {
         canvas.dispatchEvent(move(10, 10));   // pick 1, resolved last
         canvas.dispatchEvent(move(400, 300)); // pick 2, resolved first
 
-        fresh.resolve([hit(node('target'))]);
+        fresh.resolve([hit(entity)]);
         await flush();
         expect(spies.pointerenter, 'the newest pick applies').toHaveBeenCalledTimes(1);
 
@@ -182,21 +191,21 @@ describe('pc-app pointer picking', () => {
     });
 
     it('ignores a pick that resolves after the element has disconnected', async () => {
-        const { appElement, canvas, spies, unmount } = await bootTarget();
+        const { appElement, canvas, entity, spies, unmount } = await bootTarget();
         const pending = deferred<ReturnType<typeof hit>[]>();
         stubPicker(appElement, [pending.promise]);
 
         canvas.dispatchEvent(move(400, 300));
         unmount();
-        pending.resolve([hit(node('target'))]);
+        pending.resolve([hit(entity)]);
         await flush();
 
         expect(spies.pointerenter).not.toHaveBeenCalled();
     });
 
     it('dispatches pointerdown and pointerup on the picked entity', async () => {
-        const { appElement, canvas, spies } = await bootTarget();
-        stubPicker(appElement, [[hit(node('target'))], [hit(node('target'))]]);
+        const { appElement, canvas, entity, spies } = await bootTarget();
+        stubPicker(appElement, [[hit(entity)], [hit(entity)]]);
 
         canvas.dispatchEvent(new PointerEvent('pointerdown', { clientX: 400, clientY: 300 }));
         await flush();
@@ -205,5 +214,104 @@ describe('pc-app pointer picking', () => {
 
         expect(spies.pointerdown).toHaveBeenCalledTimes(1);
         expect(spies.pointerup).toHaveBeenCalledTimes(1);
+    });
+
+    it('dispatches pointerup on a listening ancestor of the picked node', async () => {
+        // A pointerup on a model's internal node used to be dropped: unlike down and move, up
+        // never walked the parent chain, so only a pick that returned the entity itself could
+        // reach a listener (#337).
+        const { appElement, canvas, entity, spies } = await bootTarget();
+        stubPicker(appElement, [[hit(modelNode('Object_8', entity))]]);
+
+        canvas.dispatchEvent(new PointerEvent('pointerup', { clientX: 400, clientY: 300 }));
+        await flush();
+
+        expect(spies.pointerup).toHaveBeenCalledTimes(1);
+    });
+
+    it('dispatches pointerdown on the nearest ancestor element with a listener', async () => {
+        // A hit on an element without a pointerdown listener keeps walking to a listening
+        // ancestor element rather than stopping at the first element found.
+        const { appElement, all } = await bootApp(`
+            <pc-entity name="camera"><pc-camera></pc-camera></pc-entity>
+            <pc-entity name="parent"><pc-entity name="child"></pc-entity></pc-entity>
+        `);
+        const parent = all<EntityElement>('pc-entity')[1];
+        const child = all<EntityElement>('pc-entity')[2];
+        const spy = vi.fn();
+        parent.addEventListener('pointerdown', spy);
+        const canvas = appElement.querySelector('canvas');
+        if (!canvas) throw new Error('pc-app created no canvas');
+        stubPicker(appElement, [[hit(child.entity!)]]);
+
+        canvas.dispatchEvent(new PointerEvent('pointerdown', { clientX: 400, clientY: 300 }));
+        await flush();
+
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('routes events to the element that owns the picked entity when names collide', async () => {
+        // Elements may share a name. The old name-based join resolved every hit to the first
+        // matching element in document order; identity keys cannot collide.
+        const { appElement, all } = await bootApp(`
+            <pc-entity name="camera"><pc-camera></pc-camera></pc-entity>
+            <pc-entity name="dup"></pc-entity>
+            <pc-entity name="dup"></pc-entity>
+        `);
+        const first = all<EntityElement>('pc-entity')[1];
+        const second = all<EntityElement>('pc-entity')[2];
+        const firstSpy = vi.fn();
+        const secondSpy = vi.fn();
+        first.addEventListener('pointerenter', firstSpy);
+        second.addEventListener('pointerenter', secondSpy);
+        const canvas = appElement.querySelector('canvas');
+        if (!canvas) throw new Error('pc-app created no canvas');
+        stubPicker(appElement, [[hit(second.entity!)]]);
+
+        canvas.dispatchEvent(move(400, 300));
+        await flush();
+
+        expect(secondSpy).toHaveBeenCalledTimes(1);
+        expect(firstSpy, 'the hit belongs to the second element, not the first with that name').not.toHaveBeenCalled();
+    });
+
+    it('picks an entity whose name contains a double quote', async () => {
+        // The old join interpolated the entity name into a CSS selector, so a quote threw a
+        // SyntaxError from inside the pointer handler. Identity lookup has no parse step.
+        const { appElement, get } = await bootApp(`
+            <pc-entity name="camera"><pc-camera></pc-camera></pc-entity>
+            <pc-entity name='say "hi"'></pc-entity>
+        `);
+        const element = get<EntityElement>('pc-entity:not([name="camera"])');
+        const spy = vi.fn();
+        element.addEventListener('pointerenter', spy);
+        const canvas = appElement.querySelector('canvas');
+        if (!canvas) throw new Error('pc-app created no canvas');
+        stubPicker(appElement, [[hit(element.entity!)]]);
+
+        canvas.dispatchEvent(move(400, 300));
+        await flush();
+
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('picks an entity that has no name attribute', async () => {
+        // A nameless entity was unpickable: the old join queried pc-entity[name="Untitled"],
+        // which matches no element when the attribute is absent.
+        const { appElement, get } = await bootApp(`
+            <pc-entity name="camera"><pc-camera></pc-camera></pc-entity>
+            <pc-entity></pc-entity>
+        `);
+        const element = get<EntityElement>('pc-entity:not([name])');
+        const spy = vi.fn();
+        element.addEventListener('pointerenter', spy);
+        const canvas = appElement.querySelector('canvas');
+        if (!canvas) throw new Error('pc-app created no canvas');
+        stubPicker(appElement, [[hit(element.entity!)]]);
+
+        canvas.dispatchEvent(move(400, 300));
+        await flush();
+
+        expect(spy).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
## What

`<pc-app>` now maintains a `Map<GraphNode, EntityElement>` — registered by `EntityElement` when it creates its entity, removed by the engine's per-entity `destroy` event — and the three pointer handlers resolve picked nodes through it by walking up the node's parent chain to the nearest registered element. The old `querySelector(`pc-entity[name="..."]`)` joins are gone.

## Why

The name-string join had four failure modes (the identity half of #340):

- Two entities sharing a name resolved every hit to the first matching element in document order.
- A `"` in an entity name broke the selector and threw a `SyntaxError` from inside the pointer handler.
- An entity with no `name` attribute was unpickable (the engine name `Untitled` matches no attribute selector).
- Each pointer event cost a DOM query per hierarchy level walked.

Identity keys can't collide, have no parse step, and cost O(depth) map lookups.

## Also in this change

- **`pointerup` gains the ancestor walk** that `pointerdown`/`pointermove` already had, so releasing over a model's internal node now reaches the host entity's listener. Fixes #337.
- **`elementFromEntity(entity)`** — public lookup on `AppElement`, the join point the pc-node RFC (#297) needs for binding and picking glTF nodes.
- **The descendant pre-null loop in `EntityElement.disconnectedCallback` is replaced by the `destroy` hook.** The engine destroys a subtree recursively and fires `destroy` per entity, so every descendant element resets itself directly — and whole-app teardown no longer calls `destroy()` a second time on already-destroyed entities.

## Tests

- New `test/integration/entity-map.test.ts`: `elementFromEntity` round-trip, reset on user-script `entity.destroy()`, emptied on teardown, fresh registration on subtree re-add.
- `pointer.test.ts` reworked to identity semantics (stub nodes now chain by `parent` to real entities) plus four new cases: the #337 pointerup walk, colliding names route to the owning element, a quoted name, and a nameless entity.
- Verified live on WebGPU (Tweening example, hover + pointerup through a GLB's internal `Object_8` node) and WebGL2 (enter/down/up on a box).

Part of #340 — the camera-selection half (multi-camera rect/priority picking) follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)