### PR TITLE
Refine pc-app attribute names and report late graphics writes

### DIFF
--- a/examples/first-person-teleport.html
+++ b/examples/first-person-teleport.html
@@ -16,7 +16,7 @@
         <link rel="stylesheet" href="css/example.css">
     </head>
     <body>
-        <pc-app antialias="false" stencil="false">
+        <pc-app antialias="false" stencil-buffer="false">
             <!-- Assets -->
             <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-controllers.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-menu.mjs"></pc-asset>

--- a/examples/splat-annotations.html
+++ b/examples/splat-annotations.html
@@ -16,7 +16,7 @@
         <link rel="stylesheet" href="css/example.css">
     </head>
     <body>
-        <pc-app antialias="false" depth="false" high-resolution="false" stencil="false">
+        <pc-app antialias="false" depth-buffer="false" max-pixel-ratio="1" stencil-buffer="false">
             <!-- Assets -->
             <pc-asset src="../node_modules/playcanvas/scripts/esm/annotations.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>

--- a/examples/splat-flipbook.html
+++ b/examples/splat-flipbook.html
@@ -16,7 +16,7 @@
         <link rel="stylesheet" href="css/example.css">
     </head>
     <body>
-        <pc-app antialias="false" depth="false" high-resolution="false" stencil="false">
+        <pc-app antialias="false" depth-buffer="false" max-pixel-ratio="1" stencil-buffer="false">
             <!-- Assets -->
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/gsplat/gsplat-flipbook.mjs"></pc-asset>

--- a/examples/splat-simple.html
+++ b/examples/splat-simple.html
@@ -16,7 +16,7 @@
         <link rel="stylesheet" href="css/example.css">
     </head>
     <body>
-        <pc-app antialias="false" depth="false" high-resolution="false" stencil="false">
+        <pc-app antialias="false" depth-buffer="false" max-pixel-ratio="1" stencil-buffer="false">
             <!-- Assets -->
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-controllers.mjs"></pc-asset>

--- a/src/app.ts
+++ b/src/app.ts
@@ -73,7 +73,7 @@ import { EntityElement } from './entity';
 import { LoadingBar } from './loading-bar';
 import { MaterialElement } from './material';
 import { ModuleElement } from './module';
-import { parseBool, parseEnum } from './parse';
+import { parseBool, parseEnum, parseNumber } from './parse';
 
 /**
  * The AppElement interface provides properties and methods for manipulating
@@ -98,13 +98,20 @@ class AppElement extends AsyncElement {
 
     private _antialias = true;
 
-    private _depth = true;
+    private _depthBuffer = true;
 
-    private _stencil = true;
+    private _stencilBuffer = true;
 
-    private _highResolution = true;
+    private _maxPixelRatio = Infinity;
 
     private _loadingBar = true;
+
+    /**
+     * Set once the graphics options above have been handed to `createGraphicsDevice`, after which
+     * writing any of them changes nothing. Guards the warning in {@link _warnIfBooted}, and is
+     * cleared on disconnect so a re-connected element boots from its current attributes.
+     */
+    private _optionsLocked = false;
 
     private _bar: LoadingBar | null = null;
 
@@ -200,15 +207,21 @@ class AppElement extends AsyncElement {
         };
         const deviceTypes = backendToDeviceTypes[this._backend] || [];
 
+        this._optionsLocked = true;
+
         const device = await createGraphicsDevice(this._canvas, {
             // @ts-ignore - alpha needs to be documented
             alpha: this._alpha,
             antialias: this._antialias,
-            depth: this._depth,
+            depth: this._depthBuffer,
             deviceTypes: deviceTypes,
-            stencil: this._stencil
+            stencil: this._stencilBuffer
         });
-        device.maxPixelRatio = this._highResolution ? window.devicePixelRatio : 1;
+
+        // Assigned rather than resolved to a number here: the engine caps against the live
+        // window.devicePixelRatio on every resize, so an uncapped Infinity keeps following the
+        // display when a window moves between monitors of differing density.
+        device.maxPixelRatio = this._maxPixelRatio;
 
         const createOptions = new AppOptions();
         createOptions.graphicsDevice = device;
@@ -352,6 +365,7 @@ class AppElement extends AsyncElement {
     }
 
     disconnectedCallback() {
+        this._optionsLocked = false;
         this._pickerDestroy();
 
         // Clean up the application. Destroying it destroys every entity, whose destroy hooks
@@ -638,15 +652,30 @@ class AppElement extends AsyncElement {
     }
 
     /**
-     * Sets the alpha flag.
+     * Warns that a graphics option was written too late to have any effect. These options are read
+     * once, when the element connects and creates its graphics device, so a later write updates
+     * only the element's own property - silently, without this.
+     *
+     * @param name - The name of the option, as its attribute.
+     */
+    private _warnIfBooted(name: string) {
+        if (this._optionsLocked) {
+            console.warn(`Attribute '${name}' on <pc-app> is only read when the application boots, so this change has no effect. Set it before the element is connected, or remove and re-insert the element to reboot with the new value.`);
+        }
+    }
+
+    /**
+     * Sets whether the frame buffer has an alpha channel, which is what lets the page show through
+     * wherever the scene has not drawn. Read only when the application boots.
      * @param value - The alpha flag.
      */
     set alpha(value: boolean) {
+        this._warnIfBooted('alpha');
         this._alpha = value;
     }
 
     /**
-     * Gets the alpha flag.
+     * Gets whether the frame buffer has an alpha channel.
      * @returns The alpha flag.
      */
     get alpha() {
@@ -654,15 +683,16 @@ class AppElement extends AsyncElement {
     }
 
     /**
-     * Sets the antialias flag.
+     * Sets whether the frame buffer is anti-aliased. Read only when the application boots.
      * @param value - The antialias flag.
      */
     set antialias(value: boolean) {
+        this._warnIfBooted('antialias');
         this._antialias = value;
     }
 
     /**
-     * Gets the antialias flag.
+     * Gets whether the frame buffer is anti-aliased.
      * @returns The antialias flag.
      */
     get antialias() {
@@ -671,10 +701,11 @@ class AppElement extends AsyncElement {
 
     /**
      * Sets the graphics backend. Defaults to 'webgpu', which falls back to 'webgl2' if WebGPU
-     * is not supported by the browser.
+     * is not supported by the browser. Read only when the application boots.
      * @param value - The graphics backend ('webgpu', 'webgl2', or 'null').
      */
     set backend(value: 'webgpu' | 'webgl2' | 'null') {
+        this._warnIfBooted('backend');
         this._backend = value;
     }
 
@@ -687,19 +718,21 @@ class AppElement extends AsyncElement {
     }
 
     /**
-     * Sets the depth flag.
-     * @param value - The depth flag.
+     * Sets whether the frame buffer has a depth buffer, which the renderer needs to resolve which
+     * surface is nearest the camera. Read only when the application boots.
+     * @param value - The depth buffer flag.
      */
-    set depth(value: boolean) {
-        this._depth = value;
+    set depthBuffer(value: boolean) {
+        this._warnIfBooted('depth-buffer');
+        this._depthBuffer = value;
     }
 
     /**
-     * Gets the depth flag.
-     * @returns The depth flag.
+     * Gets whether the frame buffer has a depth buffer.
+     * @returns The depth buffer flag.
      */
-    get depth() {
-        return this._depth;
+    get depthBuffer() {
+        return this._depthBuffer;
     }
 
     /**
@@ -709,26 +742,6 @@ class AppElement extends AsyncElement {
      */
     get hierarchyReady() {
         return this._hierarchyReady;
-    }
-
-    /**
-     * Sets the high resolution flag. When true, the application will render at the device's
-     * physical resolution. When false, the application will render at CSS resolution.
-     * @param value - The high resolution flag.
-     */
-    set highResolution(value: boolean) {
-        this._highResolution = value;
-        if (this.app) {
-            this.app.graphicsDevice.maxPixelRatio = value ? window.devicePixelRatio : 1;
-        }
-    }
-
-    /**
-     * Gets the high resolution flag.
-     * @returns The high resolution flag.
-     */
-    get highResolution() {
-        return this._highResolution;
     }
 
     /**
@@ -757,23 +770,49 @@ class AppElement extends AsyncElement {
     }
 
     /**
-     * Sets the stencil flag.
-     * @param value - The stencil flag.
+     * Sets the cap on the pixel ratio the application renders at. The canvas is sized by the
+     * smaller of this value and the display's own device pixel ratio, so the default of `Infinity`
+     * renders at full physical resolution, `1` renders at CSS resolution, and an intermediate
+     * value such as `2` keeps a dense display sharp without paying for every one of its pixels.
+     * Must be greater than 0. Unlike the other graphics options, this applies immediately.
+     * @param value - The maximum pixel ratio.
      */
-    set stencil(value: boolean) {
-        this._stencil = value;
+    set maxPixelRatio(value: number) {
+        this._maxPixelRatio = value;
+        if (this.app) {
+            this.app.graphicsDevice.maxPixelRatio = value;
+            this.app.resizeCanvas();
+        }
     }
 
     /**
-     * Gets the stencil flag.
-     * @returns The stencil flag.
+     * Gets the cap on the pixel ratio the application renders at.
+     * @returns The maximum pixel ratio.
      */
-    get stencil() {
-        return this._stencil;
+    get maxPixelRatio() {
+        return this._maxPixelRatio;
+    }
+
+    /**
+     * Sets whether the frame buffer has a stencil buffer, which stencil-based effects and UI
+     * masking need. Read only when the application boots.
+     * @param value - The stencil buffer flag.
+     */
+    set stencilBuffer(value: boolean) {
+        this._warnIfBooted('stencil-buffer');
+        this._stencilBuffer = value;
+    }
+
+    /**
+     * Gets whether the frame buffer has a stencil buffer.
+     * @returns The stencil buffer flag.
+     */
+    get stencilBuffer() {
+        return this._stencilBuffer;
     }
 
     static get observedAttributes() {
-        return ['alpha', 'antialias', 'backend', 'depth', 'stencil', 'high-resolution', 'loading-bar'];
+        return ['alpha', 'antialias', 'backend', 'depth-buffer', 'loading-bar', 'max-pixel-ratio', 'stencil-buffer'];
     }
 
     attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
@@ -787,17 +826,17 @@ class AppElement extends AsyncElement {
             case 'backend':
                 this.backend = parseEnum(newValue, ['webgpu', 'webgl2', 'null'], 'webgpu', name);
                 break;
-            case 'depth':
-                this.depth = parseBool(newValue, true);
-                break;
-            case 'high-resolution':
-                this.highResolution = parseBool(newValue, true);
+            case 'depth-buffer':
+                this.depthBuffer = parseBool(newValue, true);
                 break;
             case 'loading-bar':
                 this.loadingBar = parseBool(newValue, true);
                 break;
-            case 'stencil':
-                this.stencil = parseBool(newValue, true);
+            case 'max-pixel-ratio':
+                this.maxPixelRatio = parseNumber(newValue, Infinity, name);
+                break;
+            case 'stencil-buffer':
+                this.stencilBuffer = parseBool(newValue, true);
                 break;
         }
     }

--- a/test/elements/app-graphics.test.ts
+++ b/test/elements/app-graphics.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { useGuard } from '../helpers/guard';
+
+
+/**
+ * The graphics options on an unconnected <pc-app>. No engine boots in this tier, so these cover
+ * attributeChangedCallback and the accessors only - what the options do to a real graphics device
+ * is covered by test/integration/graphics-options.test.ts.
+ */
+describe('<pc-app> graphics attributes', () => {
+    const { warnings } = useGuard();
+
+    it('names the frame buffer options after the buffer each one allocates', () => {
+        const element = document.createElement('pc-app');
+
+        // The pairing with pc-camera's clear-depth-buffer / clear-stencil-buffer is what these
+        // names exist for, and is pinned in utils/cem/validate.mjs.
+        expect(element.depthBuffer).toBe(true);
+        expect(element.stencilBuffer).toBe(true);
+
+        element.setAttribute('depth-buffer', 'false');
+        element.setAttribute('stencil-buffer', 'false');
+        expect(element.depthBuffer).toBe(false);
+        expect(element.stencilBuffer).toBe(false);
+
+        element.removeAttribute('depth-buffer');
+        element.removeAttribute('stencil-buffer');
+        expect(element.depthBuffer).toBe(true);
+        expect(element.stencilBuffer).toBe(true);
+    });
+
+    it('defaults max-pixel-ratio to uncapped', () => {
+        const element = document.createElement('pc-app');
+
+        // Infinity rather than window.devicePixelRatio: the cap is compared against the live ratio
+        // on every resize, so not capping at all is what keeps a window that moves between displays
+        // of differing density rendering at the density it is actually on.
+        expect(element.maxPixelRatio).toBe(Infinity);
+
+        element.setAttribute('max-pixel-ratio', '2');
+        expect(element.maxPixelRatio).toBe(2);
+
+        element.removeAttribute('max-pixel-ratio');
+        expect(element.maxPixelRatio).toBe(Infinity);
+    });
+
+    it('warns and stays uncapped on a malformed max-pixel-ratio', () => {
+        const element = document.createElement('pc-app');
+
+        element.setAttribute('max-pixel-ratio', 'high');
+        expect(element.maxPixelRatio).toBe(Infinity);
+        warnings.expect('Invalid value \'high\' for attribute \'max-pixel-ratio\'. Expected a finite number. Using \'Infinity\'.');
+    });
+
+    it('does not warn about the boot-only options before the element connects', () => {
+        const element = document.createElement('pc-app');
+
+        // Every one of these is read once, inside connectedCallback. Writing them beforehand is the
+        // only way they ever take effect, so it must stay silent - the warning is for writes that
+        // arrive too late, and this is the path that proves it is not merely always-on.
+        element.setAttribute('alpha', 'false');
+        element.setAttribute('antialias', 'false');
+        element.setAttribute('backend', 'webgl2');
+        element.setAttribute('depth-buffer', 'false');
+        element.setAttribute('stencil-buffer', 'false');
+
+        expect(warnings.seen).toEqual([]);
+    });
+});

--- a/test/helpers/app.ts
+++ b/test/helpers/app.ts
@@ -20,7 +20,7 @@ export interface BootedApp extends Mounted {
 }
 
 export interface BootOptions {
-    /** Extra attributes for the `<pc-app>` element, for example `high-resolution="false"`. */
+    /** Extra attributes for the `<pc-app>` element, for example `max-pixel-ratio="1"`. */
     appAttributes?: string;
     /** Per-element ready deadline in milliseconds. */
     timeout?: number;

--- a/test/integration/graphics-options.test.ts
+++ b/test/integration/graphics-options.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { bootApp } from '../helpers/app';
+import { useGuard } from '../helpers/guard';
+
+/**
+ * What <pc-app>'s graphics options do to a real graphics device.
+ *
+ * The pixel-ratio cases stub window.devicePixelRatio to 2 to stand in for a dense display -
+ * test/setup/dom.ts declares it writable for exactly this - and read the resulting canvas size back
+ * off the device. jsdom's own value is 1, so without the stub every cap would be indistinguishable
+ * from every other.
+ */
+describe('<pc-app> graphics options', () => {
+    const { warnings } = useGuard();
+
+    it('renders at the display density when no cap is set', async () => {
+        vi.stubGlobal('devicePixelRatio', 2);
+
+        const { app } = await bootApp();
+
+        // 800x600 is test/setup/dom.ts's DEFAULT_VIEWPORT, at the full ratio of 2.
+        expect(app.graphicsDevice.maxPixelRatio).toBe(Infinity);
+        expect(app.graphicsDevice.width).toBe(1600);
+        expect(app.graphicsDevice.height).toBe(1200);
+    });
+
+    it('caps the render resolution at max-pixel-ratio', async () => {
+        vi.stubGlobal('devicePixelRatio', 2);
+
+        const { app } = await bootApp('', { appAttributes: 'max-pixel-ratio="1"' });
+
+        // The cap, not the display, decides: CSS resolution on a 2x display.
+        expect(app.graphicsDevice.width).toBe(800);
+        expect(app.graphicsDevice.height).toBe(600);
+    });
+
+    it('takes the smaller of the cap and the display density', async () => {
+        vi.stubGlobal('devicePixelRatio', 2);
+
+        const { app } = await bootApp('', { appAttributes: 'max-pixel-ratio="4"' });
+
+        // A cap above the display's own ratio is not an upscale - the engine takes the minimum.
+        expect(app.graphicsDevice.width).toBe(1600);
+        expect(app.graphicsDevice.height).toBe(1200);
+    });
+
+    it('applies a max-pixel-ratio change after boot', async () => {
+        vi.stubGlobal('devicePixelRatio', 2);
+
+        const { appElement, app } = await bootApp('', { appAttributes: 'max-pixel-ratio="1"' });
+        expect(app.graphicsDevice.width).toBe(800);
+
+        appElement.setAttribute('max-pixel-ratio', '2');
+
+        // Raising the cap resizes there and then, rather than waiting for the next window resize.
+        expect(app.graphicsDevice.maxPixelRatio).toBe(2);
+        expect(app.graphicsDevice.width).toBe(1600);
+        expect(app.graphicsDevice.height).toBe(1200);
+    });
+
+    it('warns when a boot-only option is written after boot', async () => {
+        const { appElement, app } = await bootApp();
+
+        appElement.setAttribute('antialias', 'false');
+
+        // The property does change - it is only the device that cannot - so the warning is the sole
+        // signal that the write achieved nothing.
+        expect(appElement.antialias).toBe(false);
+        expect(app.graphicsDevice.isNull).toBe(true);
+        warnings.expect('Attribute \'antialias\' on <pc-app> is only read when the application boots');
+    });
+
+    it('warns once per late write, for every boot-only option', async () => {
+        const { appElement } = await bootApp();
+
+        appElement.setAttribute('alpha', 'false');
+        appElement.setAttribute('backend', 'webgl2');
+        appElement.setAttribute('depth-buffer', 'false');
+        appElement.setAttribute('stencil-buffer', 'false');
+
+        // Written through the property rather than the attribute, so the guard covers the JS path
+        // too: the setter is where the check lives precisely so both reach it.
+        appElement.antialias = false;
+
+        warnings.expect(/^Attribute '(alpha|antialias|backend|depth-buffer|stencil-buffer)' on <pc-app> is only read/, 5);
+    });
+
+    it('reboots from its current attributes when reconnected', async () => {
+        const { appElement, container } = await bootApp();
+
+        appElement.remove();
+
+        // Disconnecting releases the options, so the same write that warned above is now the
+        // supported way to change one.
+        appElement.setAttribute('antialias', 'false');
+        expect(warnings.seen).toEqual([]);
+
+        // Awaited through the event rather than ready(), which latches: the promise resolved on the
+        // first boot and stays resolved, so awaiting it here would return before the second boot had
+        // created anything.
+        const rebooted = new Promise<void>((resolve) => {
+            appElement.addEventListener('ready', () => resolve(), { once: true });
+        });
+        container.appendChild(appElement);
+        await rebooted;
+
+        expect(appElement.antialias).toBe(false);
+        expect(appElement.app?.graphicsDevice.isNull).toBe(true);
+    });
+});

--- a/test/setup/dom.ts
+++ b/test/setup/dom.ts
@@ -89,8 +89,10 @@ HTMLCanvasElement.prototype.getContext = function getContext() {
 };
 
 /**
- * jsdom already reports 1, but AppElement maps the `high-resolution` attribute straight onto
- * device.maxPixelRatio, so tests need to be able to move it.
+ * jsdom already reports 1, which is also the ratio the canvas assertions in
+ * test/integration/environment.test.ts are written against. Declared writable because AppElement
+ * leaves device.maxPixelRatio uncapped by default, so this is what actually decides the canvas
+ * size, and a test covering `max-pixel-ratio` has to be able to move it.
  */
 Object.defineProperty(window, 'devicePixelRatio', {
     configurable: true,

--- a/utils/cem/attributes-plugin.mjs
+++ b/utils/cem/attributes-plugin.mjs
@@ -270,6 +270,12 @@ const renderDefault = (ts, expression) => {
             return undefined;
     }
 
+    // A numeric attribute whose default is "no limit", e.g. pc-app's max-pixel-ratio. Published so
+    // the tooltip states the default rather than leaving it blank; nobody is expected to type it.
+    if (ts.isIdentifier(expression) && expression.text === 'Infinity') {
+        return 'Infinity';
+    }
+
     // Negative numbers, e.g. the -9.81 in `new Vec3(0, -9.81, 0)`
     if (ts.isPrefixUnaryExpression(expression) &&
         expression.operator === ts.SyntaxKind.MinusToken &&

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -165,6 +165,18 @@ if (manifest) {
     check(/^Whether .* built-in loading bar/.test(attribute('pc-app', 'loading-bar')?.description ?? ''),
         `pc-app[loading-bar] lost its descriptive tooltip: ${JSON.stringify(attribute('pc-app', 'loading-bar')?.description)}`);
 
+    // pc-app's frame buffer options. Named for the buffer each one allocates, matching pc-camera's
+    // clear-depth-buffer / clear-stencil-buffer, so the pairing is pinned at both ends.
+    expectAttribute('pc-app', 'depth-buffer', { type: 'boolean', default: 'true', fieldName: 'depthBuffer' });
+    expectAttribute('pc-app', 'stencil-buffer', { type: 'boolean', default: 'true', fieldName: 'stencilBuffer' });
+    for (const name of ['clear-depth-buffer', 'clear-stencil-buffer']) {
+        check(Boolean(attribute('pc-camera', name)), `pc-camera is missing the '${name}' attribute`);
+    }
+
+    // The only default in the library that is not a value a user would ever type: Infinity means
+    // "no cap", which renderDefault has a dedicated branch for.
+    expectAttribute('pc-app', 'max-pixel-ratio', { type: 'number', default: 'Infinity', fieldName: 'maxPixelRatio' });
+
     // Attributes read with getAttribute, so declared with @attribute
     for (const name of ['name', 'glue', 'wasm', 'fallback']) {
         expectAttribute('pc-module', name, { type: 'string' });


### PR DESCRIPTION
An audit of `<pc-app>`'s attribute surface. Three names did not say what they controlled, and one class of write failed silently.

## Renames (breaking)

| Before | After |
| --- | --- |
| `depth` | `depth-buffer` |
| `stencil` | `stencil-buffer` |
| `high-resolution="false"` | `max-pixel-ratio="1"` |

Bare `depth` does not say *buffer allocation* — the user manual had to spell it out as "allocates a depth buffer" — and `pc-camera` already established the vocabulary with `clear-color-buffer` / `clear-depth-buffer` / `clear-stencil-buffer`. The new names make `pc-app` self-documenting and consistent with its sibling.

`alpha` and `antialias` are deliberately left alone despite the same argument applying: both match the WebGL context-attribute names verbatim, which is the mental model anyone reaching for them already has.

## `high-resolution` → `max-pixel-ratio`

The old name was vague ("high" relative to what?) and the boolean threw away the useful middle ground — capping a dense phone display at `2` was unexpressible, only all-or-nothing. It also clashed in vocabulary with `pc-screen`'s `resolution` / `reference-resolution`, which mean something else.

Two behavioral improvements come with it:

- **The default is now uncapped (`Infinity`)** rather than snapshotting `window.devicePixelRatio` at boot. The engine takes `Math.min(maxPixelRatio, devicePixelRatio)` on every resize, so leaving it uncapped keeps a window that moves between displays of differing density rendering at the density it is actually on. The old snapshot went stale.
- **The setter now resizes the canvas.** Previously it moved `graphicsDevice.maxPixelRatio` but left the canvas at its old size until the next window resize, so a live change appeared to do nothing.

## Late writes to boot-only options now warn

`alpha`, `antialias`, `backend`, `depth-buffer` and `stencil-buffer` are read exactly once, inside `connectedCallback`. They are nonetheless observed attributes with public setters, so `app.antialias = false` or a `setAttribute` after boot looked like it worked while changing nothing.

Each now warns, naming the attribute and pointing at the remove-and-re-insert path. The check lives in the setter, so the JS property path is covered as well as the attribute path. It stays quiet before connect — the only time those writes do anything — and is released on disconnect, so a reconnected element genuinely reboots from its current attributes.

They cannot simply be dropped from `observedAttributes`: that is how the backing fields get populated before connect.

## Deliberately not changed

**Boolean polarity.** The splat examples read `antialias="false" depth-buffer="false" stencil-buffer="false"` — negations spelled the long way, because every `pc-app` boolean defaults to `true`, inverting HTML's bare-attribute convention. Tempting to fix with `no-antialias`, but there are 29 default-`true` booleans across 10 files (`cast-shadows`, `enabled`, `receive-shadows`, …). `pc-app` is conforming; changing it alone would make things worse.

**`backend="null"`.** In an HTML attribute `null` reads as "unset" rather than "the no-op test device", but it matches `DEVICETYPE_NULL` and is baked into the whole test suite. Addressed in the docs instead, which now mark it as existing for headless testing.

**No range validation on `max-pixel-ratio`.** A value of `0` would give a 0×0 canvas, but every other numeric attribute in the library (`intensity`, `fov`, `mass`, `radius`) hands nonsense straight to the engine. Consistency won; the constraint is documented instead.

## Tests

11 new cases in `test/elements/app-graphics.test.ts` and `test/integration/graphics-options.test.ts`, covering the renames, the uncapped default, malformed-value fallback, the cap actually sizing the canvas on a stubbed 2× display, the live change, the warning on both the attribute and property paths, and the reconnect reboot. `utils/cem/validate.mjs` pins the new names, the `depth-buffer` / `clear-depth-buffer` pairing at both ends, and the `Infinity` default.

517 tests pass; lint, type-check and CEM validation are clean.

Also verified in a real browser on the WebGPU backend: `initOptions.depth` / `.stencil` / `.antialias` all arrive `false` from the renamed attributes, `max-pixel-ratio` propagates live to the device (including fractional values), removal restores uncapped, and both warnings fire exactly once per write.

## Reviewer notes

- **The docs live in a separate repo.** `developer-site` needs a companion PR: `pc-app.md` gains the missing `loading-bar` row (it shipped, is used in `examples/solar-system.html` and is asserted by the CEM validator, but was never documented), a Loading bar section covering the three CSS custom properties, a note on which attributes are boot-only, and the rename warning. Japanese translation updated to match. Those edits are written and staged locally — say the word and I will raise them.
- The rename warning in the manual says **0.11.0**, assuming the next release off 0.10.1. Worth confirming.
- Unrelated, found while working here: `AsyncElement`'s ready promise **latches**. It resolves on the first boot and never re-arms, so `await appElement.ready()` on a reconnected element returns immediately, before the second boot has created anything — `app` is still `null` at that point. The reconnect test works around it by listening for the `ready` event, which *is* re-dispatched. Worth fixing before 1.0.0, since it is a behavioral break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
