### PR TITLE
Refine pc-screen, pc-camera and pc-sky attribute names

### DIFF
--- a/examples/ui-scroll-view.html
+++ b/examples/ui-scroll-view.html
@@ -40,7 +40,7 @@
 
                 <!-- 2D screen-space UI -->
                 <pc-entity name="2D Screen">
-                    <pc-screen screen-space blend scale-blend="1" resolution="1280 720" reference-resolution="1280 720"></pc-screen>
+                    <pc-screen screen-space scale-mode="blend" scale-blend="1" resolution="1280 720" reference-resolution="1280 720"></pc-screen>
 
                     <!-- Scroll view -->
                     <pc-entity name="ScrollView">

--- a/src/components/camera-component.ts
+++ b/src/components/camera-component.ts
@@ -3,6 +3,11 @@ import { CameraComponent, Color, Vec4, GAMMA_NONE, GAMMA_SRGB, PROJECTION_ORTHOG
 import { ComponentElement } from './component';
 import { parseBool, parseColor, parseEnum, parseNumber, parseVec4 } from '../parse';
 
+const projections = new Map<'perspective' | 'orthographic', number>([
+    ['perspective', PROJECTION_PERSPECTIVE],
+    ['orthographic', PROJECTION_ORTHOGRAPHIC]
+]);
+
 const tonemaps = new Map<'none' | 'linear' | 'filmic' | 'hejl' | 'aces' | 'aces2' | 'neutral', number>([
     ['none', TONEMAP_NONE],
     ['linear', TONEMAP_LINEAR],
@@ -46,7 +51,7 @@ class CameraComponentElement extends ComponentElement {
 
     private _nearClip = 0.1;
 
-    private _orthographic = false;
+    private _projection: 'perspective' | 'orthographic' = 'perspective';
 
     private _orthoHeight = 10;
 
@@ -77,7 +82,7 @@ class CameraComponentElement extends ComponentElement {
             gammaCorrection: this._gamma === 'srgb' ? GAMMA_SRGB : GAMMA_NONE,
             horizontalFov: this._horizontalFov,
             nearClip: this._nearClip,
-            projection: this._orthographic ? PROJECTION_ORTHOGRAPHIC : PROJECTION_PERSPECTIVE,
+            projection: projections.get(this._projection),
             orthoHeight: this._orthoHeight,
             priority: this._priority,
             rect: this._rect,
@@ -353,25 +358,6 @@ class CameraComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the orthographic projection of the camera.
-     * @param value - The orthographic projection.
-     */
-    set orthographic(value) {
-        this._orthographic = value;
-        if (this.component) {
-            this.component.projection = value ? PROJECTION_ORTHOGRAPHIC : PROJECTION_PERSPECTIVE;
-        }
-    }
-
-    /**
-     * Gets the orthographic projection of the camera.
-     * @returns The orthographic projection.
-     */
-    get orthographic(): boolean {
-        return this._orthographic;
-    }
-
-    /**
      * Sets the orthographic height of the camera.
      * @param value - The orthographic height.
      */
@@ -407,6 +393,25 @@ class CameraComponentElement extends ComponentElement {
      */
     get priority(): number {
         return this._priority;
+    }
+
+    /**
+     * Sets the projection of the camera. Use `orthoHeight` to size an orthographic projection.
+     * @param value - The projection ('perspective' or 'orthographic').
+     */
+    set projection(value: 'perspective' | 'orthographic') {
+        this._projection = value;
+        if (this.component) {
+            this.component.projection = projections.get(value) ?? PROJECTION_PERSPECTIVE;
+        }
+    }
+
+    /**
+     * Gets the projection of the camera.
+     * @returns The projection.
+     */
+    get projection() {
+        return this._projection;
     }
 
     /**
@@ -481,9 +486,9 @@ class CameraComponentElement extends ComponentElement {
             'gamma',
             'horizontal-fov',
             'near-clip',
-            'orthographic',
             'ortho-height',
             'priority',
+            'projection',
             'rect',
             'scissor-rect',
             'tonemap'
@@ -530,14 +535,14 @@ class CameraComponentElement extends ComponentElement {
             case 'near-clip':
                 this.nearClip = parseNumber(newValue, 0.1, name);
                 break;
-            case 'orthographic':
-                this.orthographic = parseBool(newValue, false);
-                break;
             case 'ortho-height':
                 this.orthoHeight = parseNumber(newValue, 10, name);
                 break;
             case 'priority':
                 this.priority = parseNumber(newValue, 0, name);
+                break;
+            case 'projection':
+                this.projection = parseEnum(newValue, projections, 'perspective', name);
                 break;
             case 'rect':
                 this.rect = parseVec4(newValue, new Vec4(0, 0, 1, 1), name);

--- a/src/components/camera-component.ts
+++ b/src/components/camera-component.ts
@@ -82,11 +82,6 @@ class CameraComponentElement extends ComponentElement {
             gammaCorrection: this._gamma === 'srgb' ? GAMMA_SRGB : GAMMA_NONE,
             horizontalFov: this._horizontalFov,
             nearClip: this._nearClip,
-            // Coalesced because CameraComponentSystem gates on hasOwnProperty, which is true for a
-            // key explicitly set to undefined - so an out-of-union value reaching these maps (only
-            // possible from untyped JS, never from parseEnum) would assign undefined straight onto
-            // the component, whose projection setter does no validation of its own. The screen and
-            // scroll-view systems skip undefined instead, so their maps do not need this.
             projection: projections.get(this._projection) ?? PROJECTION_PERSPECTIVE,
             orthoHeight: this._orthoHeight,
             priority: this._priority,

--- a/src/components/camera-component.ts
+++ b/src/components/camera-component.ts
@@ -82,12 +82,17 @@ class CameraComponentElement extends ComponentElement {
             gammaCorrection: this._gamma === 'srgb' ? GAMMA_SRGB : GAMMA_NONE,
             horizontalFov: this._horizontalFov,
             nearClip: this._nearClip,
-            projection: projections.get(this._projection),
+            // Coalesced because CameraComponentSystem gates on hasOwnProperty, which is true for a
+            // key explicitly set to undefined - so an out-of-union value reaching these maps (only
+            // possible from untyped JS, never from parseEnum) would assign undefined straight onto
+            // the component, whose projection setter does no validation of its own. The screen and
+            // scroll-view systems skip undefined instead, so their maps do not need this.
+            projection: projections.get(this._projection) ?? PROJECTION_PERSPECTIVE,
             orthoHeight: this._orthoHeight,
             priority: this._priority,
             rect: this._rect,
             scissorRect: this._scissorRect,
-            toneMapping: tonemaps.get(this._tonemap)
+            toneMapping: tonemaps.get(this._tonemap) ?? TONEMAP_NONE
         };
     }
 

--- a/src/components/screen-component.ts
+++ b/src/components/screen-component.ts
@@ -44,9 +44,6 @@ class ScreenComponentElement extends ComponentElement {
             referenceResolution: this._referenceResolution,
             resolution: this._resolution,
             scaleBlend: this._scaleBlend,
-            // Coalesced for symmetry with the setter rather than out of necessity: ScreenComponentSystem
-            // skips an undefined scaleMode, so the component would keep its own default anyway. This
-            // just avoids depending on that.
             scaleMode: scaleModes.get(this._scaleMode) ?? SCALEMODE_NONE,
             screenSpace: this._screenSpace
         };

--- a/src/components/screen-component.ts
+++ b/src/components/screen-component.ts
@@ -44,7 +44,10 @@ class ScreenComponentElement extends ComponentElement {
             referenceResolution: this._referenceResolution,
             resolution: this._resolution,
             scaleBlend: this._scaleBlend,
-            scaleMode: scaleModes.get(this._scaleMode),
+            // Coalesced for symmetry with the setter rather than out of necessity: ScreenComponentSystem
+            // skips an undefined scaleMode, so the component would keep its own default anyway. This
+            // just avoids depending on that.
+            scaleMode: scaleModes.get(this._scaleMode) ?? SCALEMODE_NONE,
             screenSpace: this._screenSpace
         };
     }

--- a/src/components/screen-component.ts
+++ b/src/components/screen-component.ts
@@ -1,7 +1,16 @@
 import { SCALEMODE_BLEND, SCALEMODE_NONE, ScreenComponent, Vec2 } from 'playcanvas';
 
 import { ComponentElement } from './component';
-import { parseBool, parseNumber, parseVec2 } from '../parse';
+import { parseBool, parseEnum, parseNumber, parseVec2 } from '../parse';
+
+// The engine's SCALEMODE_* constants are the strings 'none' and 'blend', so this map happens to be
+// an identity. It is still the right shape: it supplies parseEnum's valid-name list, it is what the
+// manifest generator reads the enum values from, and it keeps the attribute vocabulary independent
+// of constants the engine is free to change.
+const scaleModes = new Map<'none' | 'blend', string>([
+    ['none', SCALEMODE_NONE],
+    ['blend', SCALEMODE_BLEND]
+]);
 
 /**
  * The ScreenComponentElement interface provides properties and methods for manipulating
@@ -20,7 +29,7 @@ class ScreenComponentElement extends ComponentElement {
 
     private _priority = 0;
 
-    private _blend = false;
+    private _scaleMode: 'none' | 'blend' = 'none';
 
     private _scaleBlend = 0.5;
 
@@ -35,7 +44,7 @@ class ScreenComponentElement extends ComponentElement {
             referenceResolution: this._referenceResolution,
             resolution: this._resolution,
             scaleBlend: this._scaleBlend,
-            scaleMode: this._blend ? SCALEMODE_BLEND : SCALEMODE_NONE,
+            scaleMode: scaleModes.get(this._scaleMode),
             screenSpace: this._screenSpace
         };
     }
@@ -81,6 +90,12 @@ class ScreenComponentElement extends ComponentElement {
         return this._resolution;
     }
 
+    /**
+     * Sets how the screen's `resolution` and `referenceResolution` are weighted against each other
+     * when `scaleMode` is `blend`, from 0 (follow the resolution) to 1 (follow the reference
+     * resolution). Ignored while `scaleMode` is `none`.
+     * @param value - The scale blend factor.
+     */
     set scaleBlend(value: number) {
         this._scaleBlend = value;
         if (this.component) {
@@ -88,19 +103,34 @@ class ScreenComponentElement extends ComponentElement {
         }
     }
 
+    /**
+     * Gets how the screen's resolutions are weighted against each other.
+     * @returns The scale blend factor.
+     */
     get scaleBlend() {
         return this._scaleBlend;
     }
 
-    set blend(value: boolean) {
-        this._blend = value;
+    /**
+     * Sets how the screen scales its contents. `none` renders at `resolution` and ignores
+     * `referenceResolution`; `blend` scales between the two, weighted by `scaleBlend`, which is what
+     * keeps a UI laid out at one resolution usable at another. Requires `screenSpace` - the engine
+     * forces `none` on a world-space screen, which does not support scaling.
+     * @param value - The scale mode ('none' or 'blend').
+     */
+    set scaleMode(value: 'none' | 'blend') {
+        this._scaleMode = value;
         if (this.component) {
-            this.component.scaleMode = this._blend ? SCALEMODE_BLEND : SCALEMODE_NONE;
+            this.component.scaleMode = scaleModes.get(value) ?? SCALEMODE_NONE;
         }
     }
 
-    get blend() {
-        return this._blend;
+    /**
+     * Gets how the screen scales its contents.
+     * @returns The scale mode.
+     */
+    get scaleMode() {
+        return this._scaleMode;
     }
 
     set screenSpace(value: boolean) {
@@ -117,12 +147,12 @@ class ScreenComponentElement extends ComponentElement {
     static get observedAttributes() {
         return [
             ...super.observedAttributes,
-            'blend',
             'screen-space',
             'resolution',
             'reference-resolution',
             'priority',
-            'scale-blend'
+            'scale-blend',
+            'scale-mode'
         ];
     }
 
@@ -142,8 +172,8 @@ class ScreenComponentElement extends ComponentElement {
             case 'scale-blend':
                 this.scaleBlend = parseNumber(newValue, 0.5, name);
                 break;
-            case 'blend':
-                this.blend = parseBool(newValue, false);
+            case 'scale-mode':
+                this.scaleMode = parseEnum(newValue, scaleModes, 'none', name);
                 break;
             case 'screen-space':
                 this.screenSpace = parseBool(newValue, false);

--- a/src/components/scrollview-component.ts
+++ b/src/components/scrollview-component.ts
@@ -99,7 +99,8 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets whether horizontal scrolling is enabled.
+     * Sets whether scrolling along the horizontal axis is enabled. This is a toggle, unlike the
+     * `orientation` of a `<pc-scrollbar>`, for which `horizontal` is one of the accepted values.
      * @param value - Whether horizontal scrolling is enabled.
      */
     set horizontal(value: boolean) {
@@ -110,7 +111,7 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets whether horizontal scrolling is enabled.
+     * Gets whether scrolling along the horizontal axis is enabled.
      * @returns Whether horizontal scrolling is enabled.
      */
     get horizontal() {
@@ -118,7 +119,8 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets whether vertical scrolling is enabled.
+     * Sets whether scrolling along the vertical axis is enabled. This is a toggle, unlike the
+     * `orientation` of a `<pc-scrollbar>`, for which `vertical` is one of the accepted values.
      * @param value - Whether vertical scrolling is enabled.
      */
     set vertical(value: boolean) {
@@ -129,7 +131,7 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets whether vertical scrolling is enabled.
+     * Gets whether scrolling along the vertical axis is enabled.
      * @returns Whether vertical scrolling is enabled.
      */
     get vertical() {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -129,7 +129,7 @@ export const parseEnum = <T extends string>(
     if (value === null) {
         return defaultValue;
     }
-    const names = Array.isArray(valid) ? valid : [...(valid as ReadonlyMap<T, unknown>).keys()];
+    const names: readonly T[] = Array.isArray(valid) ? valid : [...valid.keys()];
     if (names.includes(value as T)) {
         return value as T;
     }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -113,21 +113,23 @@ export const parseColor = <T extends Color | null>(value: string | null, default
  * the value is invalid — the latter also logs a warning listing the valid names.
  *
  * @param value - The attribute value to parse (`null` when the attribute is absent).
- * @param valid - The valid names: an array, or a map whose keys are the valid names.
+ * @param valid - The valid names: an array, or a map whose keys are the valid names. Only the keys
+ * are read, so the map's value type is unconstrained - engine enums are mostly numeric constants,
+ * but some (e.g. `SCALEMODE_BLEND`) are strings.
  * @param defaultValue - The value to use when the attribute is absent or invalid.
  * @param attribute - The attribute name, used in the warning message.
  * @returns The resolved enum name.
  */
 export const parseEnum = <T extends string>(
     value: string | null,
-    valid: readonly T[] | ReadonlyMap<T, number>,
+    valid: readonly T[] | ReadonlyMap<T, unknown>,
     defaultValue: T,
     attribute: string
 ): T => {
     if (value === null) {
         return defaultValue;
     }
-    const names = Array.isArray(valid) ? valid : [...(valid as ReadonlyMap<T, number>).keys()];
+    const names = Array.isArray(valid) ? valid : [...(valid as ReadonlyMap<T, unknown>).keys()];
     if (names.includes(value as T)) {
         return value as T;
     }

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -19,7 +19,7 @@ class SkyElement extends AsyncElement {
 
     private _rotation = new Vec3();
 
-    private _level = 0;
+    private _mipLevel = 0;
 
     private _lighting = false;
 
@@ -65,7 +65,7 @@ class SkyElement extends AsyncElement {
         this._scene.sky.node.setLocalScale(this._scale);
         this._scene.sky.center = this._center;
         this._scene.skyboxIntensity = this._intensity;
-        this._scene.skyboxMip = this._level;
+        this._scene.skyboxMip = this._mipLevel;
     }
 
     private async _loadSkybox() {
@@ -171,25 +171,6 @@ class SkyElement extends AsyncElement {
     }
 
     /**
-     * Sets the mip level of the skybox.
-     * @param value - The mip level.
-     */
-    set level(value: number) {
-        this._level = value;
-        if (this._scene) {
-            this._scene.skyboxMip = this._level;
-        }
-    }
-
-    /**
-     * Gets the mip level of the skybox.
-     * @returns The mip level.
-     */
-    get level() {
-        return this._level;
-    }
-
-    /**
      * Sets whether the skybox is used as a light source.
      * @param value - Whether to use lighting.
      */
@@ -203,6 +184,26 @@ class SkyElement extends AsyncElement {
      */
     get lighting() {
         return this._lighting;
+    }
+
+    /**
+     * Sets the mip level of the skybox, where 0 is the sharpest. Raising it selects a blurrier mip,
+     * which is how a skybox is softened without blurring the texture itself.
+     * @param value - The mip level.
+     */
+    set mipLevel(value: number) {
+        this._mipLevel = value;
+        if (this._scene) {
+            this._scene.skyboxMip = this._mipLevel;
+        }
+    }
+
+    /**
+     * Gets the mip level of the skybox.
+     * @returns The mip level.
+     */
+    get mipLevel() {
+        return this._mipLevel;
     }
 
     /**
@@ -267,7 +268,7 @@ class SkyElement extends AsyncElement {
     }
 
     static get observedAttributes() {
-        return ['asset', 'center', 'intensity', 'level', 'lighting', 'rotation', 'scale', 'type'];
+        return ['asset', 'center', 'intensity', 'lighting', 'mip-level', 'rotation', 'scale', 'type'];
     }
 
     attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
@@ -281,11 +282,11 @@ class SkyElement extends AsyncElement {
             case 'intensity':
                 this.intensity = parseNumber(newValue, 1, name);
                 break;
-            case 'level':
-                this.level = parseNumber(newValue, 0, name);
-                break;
             case 'lighting':
                 this.lighting = parseBool(newValue, false);
+                break;
+            case 'mip-level':
+                this.mipLevel = parseNumber(newValue, 0, name);
                 break;
             case 'rotation':
                 this.rotation = parseVec3(newValue, Vec3.ZERO, name);

--- a/test/elements/attribute-names.test.ts
+++ b/test/elements/attribute-names.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+
+import { useGuard } from '../helpers/guard';
+
+
+/**
+ * The attributes renamed to say what they control. Element tier, so no engine boots - these cover
+ * attributeChangedCallback and the accessors only. That the two new enums reach the right engine
+ * constants is covered by test/integration/renamed-attributes.test.ts.
+ *
+ * Each case asserts removal as well as parsing, because the default is what an author gets by
+ * omitting the attribute and is therefore the half a rename is most likely to get wrong.
+ */
+describe('renamed attributes', () => {
+    const { warnings } = useGuard();
+
+    describe('<pc-screen> scale-mode', () => {
+        it('replaces the boolean blend attribute with the engine\'s scale mode', () => {
+            const element = document.createElement('pc-screen');
+
+            expect(element.scaleMode).toBe('none');
+
+            element.setAttribute('scale-mode', 'blend');
+            expect(element.scaleMode).toBe('blend');
+
+            element.removeAttribute('scale-mode');
+            expect(element.scaleMode).toBe('none');
+        });
+
+        it('warns on an unknown scale mode and keeps the default', () => {
+            const element = document.createElement('pc-screen');
+
+            // 'true' is what an author porting `blend` from the old boolean would most plausibly
+            // reach for, so it is the value worth pinning as rejected rather than silently accepted.
+            element.setAttribute('scale-mode', 'true');
+            expect(element.scaleMode).toBe('none');
+            warnings.expect('Invalid value \'true\' for attribute \'scale-mode\'. Valid values: none, blend. Using \'none\'.');
+        });
+    });
+
+    describe('<pc-camera> projection', () => {
+        it('replaces the boolean orthographic attribute with the engine\'s projection', () => {
+            const element = document.createElement('pc-camera');
+
+            expect(element.projection).toBe('perspective');
+
+            element.setAttribute('projection', 'orthographic');
+            expect(element.projection).toBe('orthographic');
+
+            element.removeAttribute('projection');
+            expect(element.projection).toBe('perspective');
+        });
+
+        it('leaves ortho-height alone, which now mirrors the engine on its own', () => {
+            const element = document.createElement('pc-camera');
+
+            expect(element.orthoHeight).toBe(10);
+
+            element.setAttribute('ortho-height', '4');
+            expect(element.orthoHeight).toBe(4);
+        });
+
+        it('warns on an unknown projection and keeps the default', () => {
+            const element = document.createElement('pc-camera');
+
+            element.setAttribute('projection', 'ortho');
+            expect(element.projection).toBe('perspective');
+            warnings.expect('Invalid value \'ortho\' for attribute \'projection\'. Valid values: perspective, orthographic. Using \'perspective\'.');
+        });
+    });
+
+    describe('<pc-sky> mip-level', () => {
+        it('names the mip level rather than an unqualified level', () => {
+            const element = document.createElement('pc-sky');
+
+            expect(element.mipLevel).toBe(0);
+
+            element.setAttribute('mip-level', '3');
+            expect(element.mipLevel).toBe(3);
+
+            element.removeAttribute('mip-level');
+            expect(element.mipLevel).toBe(0);
+        });
+    });
+
+    it('no longer answers to the old names', () => {
+        // A stale attribute is inert rather than an error: observedAttributes never sees it, so
+        // nothing warns. That silence is why the rename needs the docs note - and why this asserts
+        // the property is untouched rather than merely that nothing threw.
+        const screen = document.createElement('pc-screen');
+        screen.setAttribute('blend', 'true');
+        expect(screen.scaleMode).toBe('none');
+        expect('blend' in screen).toBe(false);
+
+        const camera = document.createElement('pc-camera');
+        camera.setAttribute('orthographic', 'true');
+        expect(camera.projection).toBe('perspective');
+        expect('orthographic' in camera).toBe(false);
+
+        const sky = document.createElement('pc-sky');
+        sky.setAttribute('level', '3');
+        expect(sky.mipLevel).toBe(0);
+        expect('level' in sky).toBe(false);
+
+        expect(warnings.seen).toEqual([]);
+    });
+
+    it('leaves pc-scrollview aligned with the engine', () => {
+        // Deliberately NOT renamed to scroll-x / scroll-y. These mirror
+        // ScrollViewComponent.horizontal / .vertical, and the engine itself pairs those with
+        // ORIENTATION_HORIZONTAL, so the ambiguity with <pc-scrollbar>'s orientation values is
+        // inherited rather than introduced here - not enough to justify diverging.
+        const element = document.createElement('pc-scrollview');
+
+        expect(element.horizontal, 'both axes scroll by default').toBe(true);
+        expect(element.vertical).toBe(true);
+
+        element.setAttribute('horizontal', 'false');
+        expect(element.horizontal).toBe(false);
+
+        element.removeAttribute('horizontal');
+        expect(element.horizontal).toBe(true);
+    });
+});

--- a/test/integration/renamed-attributes.test.ts
+++ b/test/integration/renamed-attributes.test.ts
@@ -1,0 +1,87 @@
+import { PROJECTION_ORTHOGRAPHIC, PROJECTION_PERSPECTIVE, SCALEMODE_BLEND, SCALEMODE_NONE } from 'playcanvas';
+import { describe, expect, it } from 'vitest';
+
+import { bootApp } from '../helpers/app';
+import { useGuard } from '../helpers/guard';
+
+/**
+ * That the two renamed enums reach the engine constants they name.
+ *
+ * The element tier can only see the string the accessor stores, so a Map wired to the wrong constant
+ * - or a `getInitialComponentData` that still reads the old field - passes there and fails here.
+ * Both paths into the component are covered: the value present at creation, and a later write.
+ */
+describe('renamed enum attributes', () => {
+    useGuard();
+
+    it('maps pc-camera[projection] onto the engine projection', async () => {
+        const { get } = await bootApp(`
+            <pc-entity name="camera">
+                <pc-camera projection="orthographic" ortho-height="4"></pc-camera>
+            </pc-entity>
+        `);
+
+        const camera = get<HTMLElement & { component: { projection: number, orthoHeight: number } }>('pc-camera');
+
+        expect(camera.component.projection).toBe(PROJECTION_ORTHOGRAPHIC);
+        expect(camera.component.orthoHeight, 'ortho-height still reaches the component').toBe(4);
+    });
+
+    it('maps pc-screen[scale-mode] onto the engine scale mode', async () => {
+        // screen-space is load bearing, not decoration: the engine forces scaleMode to NONE on a
+        // world-space screen, which does not support scaling at all.
+        const { get } = await bootApp(`
+            <pc-entity name="screen">
+                <pc-screen screen-space scale-mode="blend" scale-blend="1"></pc-screen>
+            </pc-entity>
+        `);
+
+        const screen = get<HTMLElement & { component: { scaleMode: string, scaleBlend: number } }>('pc-screen');
+
+        expect(screen.component.scaleMode).toBe(SCALEMODE_BLEND);
+        expect(screen.component.scaleBlend, 'scale-blend is what scale-mode="blend" weights').toBe(1);
+    });
+
+    it('defaults both enums to the engine default when the attribute is absent', async () => {
+        const { get } = await bootApp(`
+            <pc-entity name="both">
+                <pc-camera></pc-camera>
+                <pc-screen screen-space></pc-screen>
+            </pc-entity>
+        `);
+
+        const camera = get<HTMLElement & { component: { projection: number } }>('pc-camera');
+        const screen = get<HTMLElement & { component: { scaleMode: string } }>('pc-screen');
+
+        expect(camera.component.projection).toBe(PROJECTION_PERSPECTIVE);
+        expect(screen.component.scaleMode).toBe(SCALEMODE_NONE);
+    });
+
+    it('applies a change written after the component exists', async () => {
+        const { get } = await bootApp(`
+            <pc-entity name="both">
+                <pc-camera></pc-camera>
+                <pc-screen screen-space></pc-screen>
+            </pc-entity>
+        `);
+
+        const camera = get<HTMLElement & { component: { projection: number } }>('pc-camera');
+        const screen = get<HTMLElement & { component: { scaleMode: string } }>('pc-screen');
+
+        camera.setAttribute('projection', 'orthographic');
+        screen.setAttribute('scale-mode', 'blend');
+
+        expect(camera.component.projection).toBe(PROJECTION_ORTHOGRAPHIC);
+        expect(screen.component.scaleMode).toBe(SCALEMODE_BLEND);
+    });
+
+    it('carries pc-sky[mip-level] through a real boot', async () => {
+        const { get } = await bootApp('<pc-scene><pc-sky mip-level="3"></pc-sky></pc-scene>');
+
+        // Only the element half is assertable here. <pc-sky> caches its scene inside _loadSkybox,
+        // which returns early when no asset resolves, so a skybox-less sky never holds a scene to
+        // write skyboxMip to. Staging one would mean loading a real texture and generating a cubemap
+        // on the null device; the attribute itself is covered in the element tier.
+        expect(get<HTMLElement & { mipLevel: number }>('pc-sky').mipLevel).toBe(3);
+    });
+});

--- a/test/integration/renamed-attributes.test.ts
+++ b/test/integration/renamed-attributes.test.ts
@@ -76,10 +76,10 @@ describe('renamed enum attributes', () => {
     });
 
     it('survives an out-of-union value assigned before the component exists', async () => {
-        // Only reachable from untyped JS - parseEnum can never yield a non-member - but the camera
-        // path is the one that punishes it. CameraComponentSystem gates on hasOwnProperty, which is
-        // true for a key explicitly set to undefined, and CameraComponent.projection does not
-        // validate, so a bare map lookup would put undefined straight onto the engine camera.
+        // Assigned as a property rather than an attribute because parseEnum can never yield a
+        // non-member, so untyped JS is the only way in. Camera is the component that punishes it:
+        // its system applies a key that is present but undefined, and its projection setter does
+        // not validate, so a bare map lookup reaches the engine as undefined.
         const camera = document.createElement('pc-camera') as HTMLElement & {
             projection: string,
             component: { projection: number }

--- a/test/integration/renamed-attributes.test.ts
+++ b/test/integration/renamed-attributes.test.ts
@@ -75,6 +75,24 @@ describe('renamed enum attributes', () => {
         expect(screen.component.scaleMode).toBe(SCALEMODE_BLEND);
     });
 
+    it('survives an out-of-union value assigned before the component exists', async () => {
+        // Only reachable from untyped JS - parseEnum can never yield a non-member - but the camera
+        // path is the one that punishes it. CameraComponentSystem gates on hasOwnProperty, which is
+        // true for a key explicitly set to undefined, and CameraComponent.projection does not
+        // validate, so a bare map lookup would put undefined straight onto the engine camera.
+        const camera = document.createElement('pc-camera') as HTMLElement & {
+            projection: string,
+            component: { projection: number }
+        };
+        (camera as unknown as Record<string, string>).projection = 'isometric';
+
+        const { get } = await bootApp('<pc-entity name="camera"></pc-entity>');
+        get('pc-entity').appendChild(camera);
+        await (camera as unknown as { ready(): Promise<unknown> }).ready();
+
+        expect(camera.component.projection).toBe(PROJECTION_PERSPECTIVE);
+    });
+
     it('carries pc-sky[mip-level] through a real boot', async () => {
         const { get } = await bootApp('<pc-scene><pc-sky mip-level="3"></pc-sky></pc-scene>');
 

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -158,6 +158,19 @@ if (manifest) {
     expectEnum('pc-light', 'shadow-type', 9, 'pcf3-32f');
     expectEnum('pc-scrollview', 'horizontal-scrollbar-visibility', 2, 'when-required');
 
+    // Two-value enums that replaced booleans. Both are named for the engine property they drive, so
+    // the description has to survive as well - the old names ('blend', 'orthographic') are what made
+    // pc-screen[blend] publish a description claiming it enabled alpha blending.
+    expectEnum('pc-screen', 'scale-mode', 2, 'none');
+    expectEnum('pc-camera', 'projection', 2, 'perspective');
+    for (const [tag, name, pattern] of [
+        ['pc-screen', 'scale-mode', /^How the screen scales/],
+        ['pc-camera', 'projection', /^The projection of the camera/]
+    ]) {
+        check(pattern.test(attribute(tag, name)?.description ?? ''),
+            `${tag}[${name}] lost its description: ${JSON.stringify(attribute(tag, name)?.description)}`);
+    }
+
     // The description comes from the getter's "Gets whether ..." JSDoc, so it exercises
     // toAttributeDescription's rewrite as well as the boolean default. Pinned because the terse
     // "The x flag." accessor style would make a useless tooltip for a behaviour switch.


### PR DESCRIPTION
An audit of all 27 elements (~280 attributes) found three names that did not say what they controlled. Each rename moves the element's surface **toward** the engine property it drives.

## Renames (breaking)

| Element | Before | After | Engine property |
| --- | --- | --- | --- |
| `pc-screen` | `blend` | `scale-mode` (`"none"` \| `"blend"`) | `scaleMode` |
| `pc-camera` | `orthographic` | `projection` (`"perspective"` \| `"orthographic"`) | `projection` |
| `pc-sky` | `level` | `mip-level` | `skyboxMip` |

### `pc-screen[blend]` → `scale-mode`

Not merely vague — actively misleading. It drives the engine's `scaleMode`, but the published documentation describes it as *"whether to enable alpha blending"*, which is what `pc-material[blend-type]` means. **The name misled whoever wrote the docs**, so users are being told the wrong thing today. Naming it for the engine property also puts it beside `scale-blend`, the number it weights, where the relationship is finally visible.

### `pc-camera[orthographic]` → `projection`

The element invented a boolean where the engine has an enum (`PROJECTION_PERSPECTIVE` / `PROJECTION_ORTHOGRAPHIC`). With the boolean gone, `ortho-height` stands alone as a faithful match for `orthoHeight` and needs no rename — so this is one breaking change, not two.

### `pc-sky[level]` → `mip-level`

`level` of what — intensity, detail, exposure? The manual already had to spell out "mipmap level to use for rendering".

## Two things surfaced while wiring these up

**`parseEnum` assumed every engine enum is numeric.** Its signature constrained the map to `ReadonlyMap<T, number>`, but `SCALEMODE_NONE` / `SCALEMODE_BLEND` are the *strings* `'none'` and `'blend'`, so the new map would not typecheck. The helper only ever reads the map's keys, so the constraint was an unnecessary assumption; it is now `ReadonlyMap<T, unknown>`. The `scaleModes` map is consequently an identity map, which is commented so nobody simplifies it away — it still supplies `parseEnum`'s valid-name list and is what the manifest generator derives the enum from.

**`scale-mode` requires `screen-space`.** A world-space screen does not support scaling and the engine forces `scaleMode` back to `NONE` on one ([component.js:322](https://github.com/playcanvas/engine/blob/main/src/framework/components/screen/component.js#L322)). My first test omitted `screen-space` and failed, which is exactly why the existing example pairs them. Now stated on the accessor and pinned by a test.

`pc-screen` also gains JSDoc on the two accessors involved. It was the only element in the library with none at all, so its attributes reached the manifest — and every editor tooltip built from it — with no descriptions.

## Deliberately not renamed

**`pc-scrollview[horizontal]` / `[vertical]`.** I proposed `scroll-x` / `scroll-y` and implemented it, then reverted. They do read as axis names rather than toggles, especially next to `horizontal-scrollbar` and the `orientation` attribute whose accepted *values* are `"horizontal"` and `"vertical"`. But they mirror `ScrollViewComponent.horizontal` / `.vertical`, and the engine pairs those with `ORIENTATION_HORIZONTAL` itself — so the ambiguity is inherited rather than introduced here. Markup readability is a preference; `pc-screen[blend]` cleared a much higher bar by producing wrong documentation. A JSDoc note distinguishing the toggles from `orientation`'s values is there instead.

Also considered and rejected: `-map-channel` (color channel) vs `-map-uv` (UV set) is confusable but engine-faithful across ~14 attributes; `pc-camera[gamma]`/`[tonemap]` shorten `gammaCorrection`/`toneMapping` but are idiomatic; `pc-asset[id]` overloading the global HTML `id` is load-bearing for `getEntity`; a `normal-map-intensity` alias for `pc-material[bumpiness]`; and a library-wide `observedAttributes` alphabetization sweep — 12 elements order theirs semantically (`min-width, min-height, max-width, max-height`), which alphabetizing would worsen.

## Verification

517 tests pass; lint, both type-check projects, and `npm run build` (which runs `cem analyze` plus `utils/cem/validate.mjs`) are clean.

New coverage in `test/elements/attribute-names.test.ts` and `test/integration/renamed-attributes.test.ts`: defaults, valid values, removal restoring the default, invalid-value warnings through `parseEnum`, and — the assertion the element tier cannot make — that both enums reach the right engine constant, via `getInitialComponentData` and via a later write. `utils/cem/validate.mjs` pins both enums' value sets, defaults, and descriptions.

Verified on a real WebGPU boot via `examples/ui-scroll-view.html`, not just the null device: `scale-mode="blend"` reaches `component.scaleMode`, a live `projection="orthographic"` flips the engine to `PROJECTION_ORTHOGRAPHIC`, `projection="isometric"` warns with the valid names and falls back, the old property names are gone, and the scroll view still locks its x axis (setting `scroll` to `(1, 1)` yields `(0, 1)`).

## Reviewer notes

- **Docs are not in this PR.** The `developer-site` changes are written locally but deliberately held back — say the word and I will raise them. They correct the wrong `pc-screen[blend]` description, add the rename admonitions, and note the `screen-space` requirement, in English and Japanese.
- Those admonitions currently say **0.11.0**, matching [#342](https://github.com/playcanvas/web-components/pull/342). If these land in different releases the markers need to diverge.
- Branched off `main`, so this is independent of #342 and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
