### PR TITLE
Ship only public API in the typings and the manifest

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -115,7 +115,13 @@ class AppElement extends AsyncElement {
 
     private _bar: LoadingBar | null = null;
 
-    private _hierarchyReady = false;
+    /**
+     * Whether the application has created its initial entity hierarchy. Read by EntityElement to
+     * decide whether a newly connected element must create its entity itself or leave it to the
+     * boot sweep.
+     * @internal
+     */
+    _hierarchyReady = false;
 
     /**
      * Incremented on every connect and disconnect. Boot captures the value on entry and abandons
@@ -211,7 +217,7 @@ class AppElement extends AsyncElement {
         const moduleElements = this.querySelectorAll<ModuleElement>(':scope > pc-module');
 
         // Wait for all modules to load
-        await Promise.all(Array.from(moduleElements).map((module) => module.getLoadPromise()));
+        await Promise.all(Array.from(moduleElements).map((module) => module._getLoadPromise()));
 
         // The element may have been removed while the modules loaded. Nothing beyond the loading
         // bar exists yet, and disconnectedCallback has already destroyed that.
@@ -332,7 +338,7 @@ class AppElement extends AsyncElement {
         // Get all pc-asset elements that are direct children of the pc-app element
         const assetElements = this.querySelectorAll<AssetElement>(':scope > pc-asset');
         for (const assetElement of Array.from(assetElements)) {
-            assetElement.createAsset();
+            assetElement._createAsset();
             const asset = assetElement.asset;
             if (asset) {
                 app.assets.add(asset);
@@ -350,18 +356,18 @@ class AppElement extends AsyncElement {
         // Get all pc-material elements that are direct children of the pc-app element
         const materialElements = this.querySelectorAll<MaterialElement>(':scope > pc-material');
         Array.from(materialElements).forEach((materialElement) => {
-            materialElement.createMaterial();
+            materialElement._createMaterial();
         });
 
         // Create all entities
         const entityElements = this.querySelectorAll<EntityElement>('pc-entity');
         Array.from(entityElements).forEach((entityElement) => {
-            entityElement.createEntity(app);
+            entityElement._createEntity(app);
         });
 
         // Build hierarchy
         entityElements.forEach((entityElement) => {
-            entityElement.buildHierarchy(app);
+            entityElement._buildHierarchy(app);
         });
 
         // Building the hierarchy dispatched each entity's ready event synchronously, and a
@@ -460,13 +466,13 @@ class AppElement extends AsyncElement {
         }
     }
 
-    _onWindowResize() {
+    private _onWindowResize() {
         if (this.app) {
             this.app.resizeCanvas();
         }
     }
 
-    _pickerCreate() {
+    private _pickerCreate() {
         const { width, height } = this.app!.graphicsDevice;
         this._picker = new Picker(this.app!, width, height);
 
@@ -488,7 +494,7 @@ class AppElement extends AsyncElement {
         // listeners carried over from before a re-boot)
         pointerEventTypes.forEach((type) => {
             const anyListeners = Array.from(this.querySelectorAll<EntityElement>('pc-entity')).some((entity) =>
-                entity.hasListeners(type)
+                entity._hasListeners(type)
             );
             if (anyListeners) {
                 this._onPointerListenerAdded(type);
@@ -496,7 +502,7 @@ class AppElement extends AsyncElement {
         });
     }
 
-    _pickerDestroy() {
+    private _pickerDestroy() {
         if (this._canvas) {
             Object.entries(this._pointerHandlers).forEach(([type, handler]) => {
                 if (handler) {
@@ -527,7 +533,7 @@ class AppElement extends AsyncElement {
      *
      * @param entity - The entity.
      * @param element - The element that created it.
-     * @ignore
+     * @internal
      */
     _registerEntityElement(entity: Entity, element: EntityElement) {
         this._entityElements.set(entity, element);
@@ -537,7 +543,7 @@ class AppElement extends AsyncElement {
      * Removes the registration for a destroyed entity. Called by EntityElement.
      *
      * @param entity - The entity.
-     * @ignore
+     * @internal
      */
     _unregisterEntityElement(entity: Entity) {
         this._entityElements.delete(entity);
@@ -586,7 +592,7 @@ class AppElement extends AsyncElement {
     private _elementWithListener(node: GraphNode | null, type: string): EntityElement | null {
         while (node !== null) {
             const element = this._entityElements.get(node);
-            if (element?.hasListeners(type)) {
+            if (element?._hasListeners(type)) {
                 return element;
             }
             node = node.parent;
@@ -632,7 +638,7 @@ class AppElement extends AsyncElement {
         return item instanceof MeshInstance ? item.node : (item as GSplatComponent).entity;
     }
 
-    async _onPointerMove(event: PointerEvent) {
+    private async _onPointerMove(event: PointerEvent) {
         if (!this._picker || !this.app) return;
 
         // Moves arrive faster than a pick resolves, so results can land out of order. Only the
@@ -648,10 +654,10 @@ class AppElement extends AsyncElement {
 
         // Handle enter/leave events
         if (this._hoveredEntity !== newHoverEntity) {
-            if (this._hoveredEntity && this._hoveredEntity.hasListeners('pointerleave')) {
+            if (this._hoveredEntity && this._hoveredEntity._hasListeners('pointerleave')) {
                 this._hoveredEntity.dispatchEvent(new PointerEvent('pointerleave', event));
             }
-            if (newHoverEntity && newHoverEntity.hasListeners('pointerenter')) {
+            if (newHoverEntity && newHoverEntity._hasListeners('pointerenter')) {
                 newHoverEntity.dispatchEvent(new PointerEvent('pointerenter', event));
             }
         }
@@ -660,12 +666,12 @@ class AppElement extends AsyncElement {
         this._hoveredEntity = newHoverEntity;
 
         // Handle pointermove event
-        if (newHoverEntity && newHoverEntity.hasListeners('pointermove')) {
+        if (newHoverEntity && newHoverEntity._hasListeners('pointermove')) {
             newHoverEntity.dispatchEvent(new PointerEvent('pointermove', event));
         }
     }
 
-    async _onPointerDown(event: PointerEvent) {
+    private async _onPointerDown(event: PointerEvent) {
         if (!this._picker || !this.app) return;
 
         const node = await this._pickNode(event);
@@ -677,7 +683,7 @@ class AppElement extends AsyncElement {
         }
     }
 
-    async _onPointerUp(event: PointerEvent) {
+    private async _onPointerUp(event: PointerEvent) {
         if (!this._picker || !this.app) return;
 
         const node = await this._pickNode(event);
@@ -689,7 +695,7 @@ class AppElement extends AsyncElement {
         }
     }
 
-    _onPointerListenerAdded(type: string) {
+    private _onPointerListenerAdded(type: string) {
         if (!this._hasPointerListeners[type] && this._canvas) {
             this._hasPointerListeners[type] = true;
 
@@ -708,9 +714,9 @@ class AppElement extends AsyncElement {
         }
     }
 
-    _onPointerListenerRemoved(type: string) {
+    private _onPointerListenerRemoved(type: string) {
         const hasListeners = Array.from(this.querySelectorAll<EntityElement>('pc-entity')).some((entity) =>
-            entity.hasListeners(type)
+            entity._hasListeners(type)
         );
 
         if (!hasListeners && this._canvas) {
@@ -814,15 +820,6 @@ class AppElement extends AsyncElement {
      */
     get depthBuffer() {
         return this._depthBuffer;
-    }
-
-    /**
-     * Gets the hierarchy ready flag.
-     * @returns The hierarchy ready flag.
-     * @ignore
-     */
-    get hierarchyReady() {
-        return this._hierarchyReady;
     }
 
     /**

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -132,7 +132,7 @@ class AssetElement extends AsyncElement {
             const app = appElement.app;
             if (!app) return; // pc-app is re-connecting; its own boot will create this asset
 
-            this.createAsset();
+            this._createAsset();
             if (this.asset) {
                 app.assets.add(this.asset); // add() auto-loads when preload is true
                 if (!this.lazy) {
@@ -141,14 +141,14 @@ class AssetElement extends AsyncElement {
             }
         }
 
-        // Never ready if createAsset failed (unsupported asset type)
+        // Never ready if _createAsset failed (unsupported asset type)
         if (this.asset) {
             this._onReady();
         }
     }
 
     disconnectedCallback() {
-        this.destroyAsset();
+        this._destroyAsset();
         // Re-arm readiness so a re-inserted element announces the asset it creates then
         this._resetReady();
     }
@@ -165,7 +165,14 @@ class AssetElement extends AsyncElement {
         );
     }
 
-    createAsset() {
+    /**
+     * Creates the asset from the element's attributes. Called by the containing `<pc-app>`
+     * element during its boot sweep, and on connection for elements inserted while the
+     * application is already running.
+     *
+     * @internal
+     */
+    _createAsset() {
         const id = this.getAttribute('id') || '';
         const src = this.getAttribute('src') || '';
         let type = this.getAttribute('type');
@@ -267,7 +274,7 @@ class AssetElement extends AsyncElement {
         return data;
     }
 
-    destroyAsset() {
+    private _destroyAsset() {
         if (this.asset) {
             // A caller that keeps the Asset alive must not dispatch on a removed element
             this.asset.off('load', this._onAssetLoad, this);
@@ -298,6 +305,13 @@ class AssetElement extends AsyncElement {
         return this._lazy;
     }
 
+    /**
+     * Returns the {@link Asset} created by the `<pc-asset>` element with the given `id`, or
+     * `undefined` if there is no such element or its asset has not been created yet.
+     *
+     * @param id - The `id` of the `<pc-asset>` element.
+     * @returns The asset, or `undefined`.
+     */
     static get(id: string) {
         const assetElement = document.querySelector<AssetElement>(`pc-asset[id="${id}"]`);
         return assetElement?.asset;

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -53,7 +53,7 @@ class ButtonComponentElement extends ComponentElement {
         super('button');
     }
 
-    getInitialComponentData() {
+    protected getInitialComponentData() {
         const data: Record<string, any> = {
             active: this._active,
             hitPadding: this._hitPadding,

--- a/src/components/camera-component.ts
+++ b/src/components/camera-component.ts
@@ -85,7 +85,7 @@ class CameraComponentElement extends ComponentElement {
         super('camera');
     }
 
-    getInitialComponentData() {
+    protected getInitialComponentData() {
         return {
             clearColor: this._clearColor,
             clearColorBuffer: this._clearColorBuffer,

--- a/src/components/collision-component.ts
+++ b/src/components/collision-component.ts
@@ -35,7 +35,7 @@ class CollisionComponentElement extends ComponentElement {
         super('collision');
     }
 
-    getInitialComponentData() {
+    protected getInitialComponentData() {
         return {
             axis: this._axis,
             angularOffset: this._angularOffset,

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -39,12 +39,17 @@ class ComponentElement extends AsyncElement {
         this._componentName = componentName;
     }
 
-    // Method to be overridden by subclasses to provide initial component data
-    getInitialComponentData() {
+    /**
+     * Returns the data the component is created with. Overridden by subclasses to supply the
+     * initial values of their cached properties.
+     *
+     * @returns The initial component data.
+     */
+    protected getInitialComponentData() {
         return {};
     }
 
-    async addComponent() {
+    private async _addComponent() {
         const generation = this._connectionGeneration;
 
         const entityElement = this.closestEntity;
@@ -71,7 +76,11 @@ class ComponentElement extends AsyncElement {
         this._component = entityElement.entity!.addComponent(this._componentName, data);
     }
 
-    initComponent() {
+    /**
+     * Configures the newly added component. Overridden by subclasses whose setup goes beyond
+     * the initial data — child-element handling, asset resolution and the like.
+     */
+    protected initComponent() {
         // optional hook
     }
 
@@ -88,7 +97,7 @@ class ComponentElement extends AsyncElement {
             return;
         }
 
-        await this.addComponent();
+        await this._addComponent();
 
         if (generation !== this._connectionGeneration) {
             return;

--- a/src/components/element-component.ts
+++ b/src/components/element-component.ts
@@ -72,7 +72,7 @@ class ElementComponentElement extends ComponentElement {
         super('element');
     }
 
-    initComponent() {
+    protected initComponent() {
         const component = this.component as any;
         if (!component) {
             return;
@@ -91,7 +91,7 @@ class ElementComponentElement extends ComponentElement {
         component._dirtifyMask?.();
     }
 
-    getInitialComponentData() {
+    protected getInitialComponentData() {
         const data: Record<string, any> = {
             anchor: this._anchor,
             autoWidth: this._autoWidth,

--- a/src/components/gsplat-component.ts
+++ b/src/components/gsplat-component.ts
@@ -31,7 +31,7 @@ class GSplatComponentElement extends ComponentElement {
         super('gsplat');
     }
 
-    getInitialComponentData() {
+    protected getInitialComponentData() {
         return {
             asset: AssetElement.get(this._asset),
             castShadows: this._castShadows,

--- a/src/components/layoutchild-component.ts
+++ b/src/components/layoutchild-component.ts
@@ -32,7 +32,7 @@ class LayoutChildComponentElement extends ComponentElement {
         super('layoutchild');
     }
 
-    getInitialComponentData() {
+    protected getInitialComponentData() {
         return {
             minWidth: this._minWidth,
             minHeight: this._minHeight,

--- a/src/components/layoutgroup-component.ts
+++ b/src/components/layoutgroup-component.ts
@@ -58,7 +58,7 @@ class LayoutGroupComponentElement extends ComponentElement {
         super('layoutgroup');
     }
 
-    getInitialComponentData() {
+    protected getInitialComponentData() {
         return {
             orientation: orientations.get(this._orientation),
             reverseX: this._reverseX,

--- a/src/components/light-component.ts
+++ b/src/components/light-component.ts
@@ -92,7 +92,7 @@ class LightComponentElement extends ComponentElement {
         super('light');
     }
 
-    getInitialComponentData() {
+    protected getInitialComponentData() {
         return {
             castShadows: this._castShadows,
             color: this._color,

--- a/src/components/particlesystem-component.ts
+++ b/src/components/particlesystem-component.ts
@@ -20,7 +20,7 @@ class ParticleSystemComponentElement extends ComponentElement {
         super('particlesystem');
     }
 
-    getInitialComponentData() {
+    protected getInitialComponentData() {
         const asset = AssetElement.get(this._asset);
         if (!asset) {
             return {};

--- a/src/components/render-component.ts
+++ b/src/components/render-component.ts
@@ -31,7 +31,7 @@ class RenderComponentElement extends ComponentElement {
         super('render');
     }
 
-    getInitialComponentData() {
+    protected getInitialComponentData() {
         return {
             type: this._type,
             castShadows: this._castShadows,

--- a/src/components/rigidbody-component.ts
+++ b/src/components/rigidbody-component.ts
@@ -64,7 +64,7 @@ class RigidBodyComponentElement extends ComponentElement {
         super('rigidbody');
     }
 
-    getInitialComponentData() {
+    protected getInitialComponentData() {
         return {
             angularDamping: this._angularDamping,
             angularFactor: this._angularFactor,

--- a/src/components/screen-component.ts
+++ b/src/components/screen-component.ts
@@ -40,7 +40,7 @@ class ScreenComponentElement extends ComponentElement {
         super('screen');
     }
 
-    getInitialComponentData() {
+    protected getInitialComponentData() {
         return {
             priority: this._priority,
             referenceResolution: this._referenceResolution,

--- a/src/components/script-component.ts
+++ b/src/components/script-component.ts
@@ -274,7 +274,7 @@ class ScriptComponentElement extends ComponentElement {
         return super.connectedCallback();
     }
 
-    initComponent() {
+    protected initComponent() {
         // Handle initial script elements
         this.querySelectorAll<ScriptElement>(':scope > pc-script').forEach((scriptElement) => {
             this.createScript(scriptElement);

--- a/src/components/script.ts
+++ b/src/components/script.ts
@@ -43,7 +43,7 @@ class ScriptElement extends AsyncElement {
 
     /**
      * The Script instance created for this element by its parent `<pc-scripts>` element.
-     * @ignore
+     * @internal
      */
     _script: Script | null = null;
 
@@ -152,7 +152,7 @@ class ScriptElement extends AsyncElement {
      * Called by the parent `<pc-scripts>` element when the script instance has been created.
      * Creation can happen more than once per connection (a runtime `name` change recreates the
      * instance), but `_onReady` signals readiness at most once per cycle.
-     * @ignore
+     * @internal
      */
     _onScriptCreated() {
         this._onReady();

--- a/src/components/scrollbar-component.ts
+++ b/src/components/scrollbar-component.ts
@@ -32,7 +32,7 @@ class ScrollbarComponentElement extends ComponentElement {
         super('scrollbar');
     }
 
-    getInitialComponentData() {
+    protected getInitialComponentData() {
         const data: Record<string, any> = {
             orientation: orientations.get(this._orientation),
             value: this._value,

--- a/src/components/scrollview-component.ts
+++ b/src/components/scrollview-component.ts
@@ -63,7 +63,7 @@ class ScrollViewComponentElement extends ComponentElement {
         super('scrollview');
     }
 
-    getInitialComponentData() {
+    protected getInitialComponentData() {
         const data: Record<string, any> = {
             horizontal: this._horizontal,
             vertical: this._vertical,

--- a/src/components/sound-component.ts
+++ b/src/components/sound-component.ts
@@ -32,7 +32,7 @@ class SoundComponentElement extends ComponentElement {
         super('sound');
     }
 
-    getInitialComponentData() {
+    protected getInitialComponentData() {
         return {
             distanceModel: this._distanceModel,
             maxDistance: this._maxDistance,

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -93,7 +93,14 @@ class EntityElement extends AsyncElement {
         return this._entity;
     }
 
-    createEntity(app: AppBase) {
+    /**
+     * Creates the backing entity. Called by the containing `<pc-app>` element during its boot
+     * sweep, and on connection for elements inserted while the application is already running.
+     *
+     * @param app - The application to create the entity in.
+     * @internal
+     */
+    _createEntity(app: AppBase) {
         // Guard against double creation. When a subtree is inserted at runtime (e.g. cloning a
         // `<template>`), an ancestor's connectedCallback eagerly creates descendant entities; the
         // descendants' own connectedCallbacks would otherwise create them a second time.
@@ -129,7 +136,7 @@ class EntityElement extends AsyncElement {
 
     /**
      * Handles the destruction of the backing entity. Resets the element so a later re-insertion
-     * starts clean: `_built` must be cleared alongside `_entity`, or buildHierarchy would bail
+     * starts clean: `_built` must be cleared alongside `_entity`, or _buildHierarchy would bail
      * and a re-created entity would never be parented. Readiness is re-armed for the same
      * reason — with the entity gone, a resolved ready promise would resume its awaiters against
      * a null `entity`.
@@ -144,7 +151,16 @@ class EntityElement extends AsyncElement {
         this._resetReady();
     }
 
-    buildHierarchy(app: AppBase) {
+    /**
+     * Parents the backing entity: under the entity of the nearest ancestor `<pc-entity>` when
+     * there is one, and under the application root otherwise. Called by the containing `<pc-app>`
+     * element once a sweep has created every entity, so a parent's existence never depends on
+     * document order.
+     *
+     * @param app - The application whose root adopts parentless entities.
+     * @internal
+     */
+    _buildHierarchy(app: AppBase) {
         if (!this.entity || this._built) return;
         this._built = true;
 
@@ -172,19 +188,19 @@ class EntityElement extends AsyncElement {
         }
 
         // If app is already running, create entity immediately
-        if (closestApp.hierarchyReady) {
+        if (closestApp._hierarchyReady) {
             const app = closestApp.app!;
 
-            this.createEntity(app);
-            this.buildHierarchy(app);
+            this._createEntity(app);
+            this._buildHierarchy(app);
 
             // Handle any child entities that might exist
             const childEntities = this.querySelectorAll<EntityElement>('pc-entity');
             childEntities.forEach((child) => {
-                child.createEntity(app);
+                child._createEntity(app);
             });
             childEntities.forEach((child) => {
-                child.buildHierarchy(app);
+                child._buildHierarchy(app);
             });
         }
     }
@@ -404,7 +420,16 @@ class EntityElement extends AsyncElement {
         }
     }
 
-    hasListeners(type: string): boolean {
+    /**
+     * Whether the element has a listener for an event type, registered either with
+     * {@link addEventListener} or with the matching inline `onpointer*` attribute. Read by the
+     * containing `<pc-app>` element to gate pointer event synthesis.
+     *
+     * @param type - The event type.
+     * @returns Whether a listener is registered.
+     * @internal
+     */
+    _hasListeners(type: string): boolean {
         return Boolean(this._listeners[type]?.length) || this._inlineHandlerTypes.has(type);
     }
 }

--- a/src/material.ts
+++ b/src/material.ts
@@ -295,7 +295,7 @@ class MaterialElement extends HTMLElement {
 
     private _useLighting = true;
 
-    // Diverges from the engine default of false - see the class docblock and createMaterial()
+    // Diverges from the engine default of false - see the class docblock and _createMaterial()
     private _useMetalness = true;
 
     private _useMetalnessSpecularColor = false;
@@ -315,6 +315,10 @@ class MaterialElement extends HTMLElement {
 
     private _glossConflictWarned = false;
 
+    /**
+     * The material. `null` until the containing application has created it — an element present
+     * at startup has its material once the application is ready.
+     */
     material: StandardMaterial | null = null;
 
     async connectedCallback() {
@@ -335,11 +339,18 @@ class MaterialElement extends HTMLElement {
         // elements inserted (or re-inserted) after the app is already running
         if (!this.material) {
             if (!appElement.app) return; // pc-app is re-connecting; its own boot will create this
-            this.createMaterial();
+            this._createMaterial();
         }
     }
 
-    createMaterial() {
+    /**
+     * Creates the material from the element's cached properties. Called by the containing
+     * `<pc-app>` element during its boot sweep, and on connection for elements inserted while
+     * the application is already running.
+     *
+     * @internal
+     */
+    _createMaterial() {
         const material = new StandardMaterial();
         this.material = material;
 
@@ -499,7 +510,7 @@ class MaterialElement extends HTMLElement {
      * @param id - The id of the `pc-asset`, or an empty string to clear the slot.
      * @param slot - The material property to write.
      */
-    setMap(id: string, slot: TextureSlot) {
+    private _setMap(id: string, slot: TextureSlot) {
         // Drop any load still pending for this slot - its texture is no longer the one we want
         this._mapHandles.get(slot)?.off();
         this._mapHandles.delete(slot);
@@ -606,7 +617,7 @@ class MaterialElement extends HTMLElement {
      */
     set aoMap(value: string) {
         this._aoMap = value;
-        this.setMap(value, 'aoMap');
+        this._setMap(value, 'aoMap');
     }
 
     /**
@@ -864,7 +875,7 @@ class MaterialElement extends HTMLElement {
      */
     set diffuseMap(value: string) {
         this._diffuseMap = value;
-        this.setMap(value, 'diffuseMap');
+        this._setMap(value, 'diffuseMap');
     }
 
     /**
@@ -1021,7 +1032,7 @@ class MaterialElement extends HTMLElement {
      */
     set emissiveMap(value: string) {
         this._emissiveMap = value;
-        this.setMap(value, 'emissiveMap');
+        this._setMap(value, 'emissiveMap');
     }
 
     /**
@@ -1219,7 +1230,7 @@ class MaterialElement extends HTMLElement {
      */
     set glossMap(value: string) {
         this._glossMap = value;
-        this.setMap(value, 'glossMap');
+        this._setMap(value, 'glossMap');
     }
 
     /**
@@ -1336,7 +1347,7 @@ class MaterialElement extends HTMLElement {
      */
     set heightMap(value: string) {
         this._heightMap = value;
-        this.setMap(value, 'heightMap');
+        this._setMap(value, 'heightMap');
     }
 
     /**
@@ -1493,7 +1504,7 @@ class MaterialElement extends HTMLElement {
      */
     set metalnessMap(value: string) {
         this._metalnessMap = value;
-        this.setMap(value, 'metalnessMap');
+        this._setMap(value, 'metalnessMap');
     }
 
     /**
@@ -1610,7 +1621,7 @@ class MaterialElement extends HTMLElement {
      */
     set normalMap(value: string) {
         this._normalMap = value;
-        this.setMap(value, 'normalMap');
+        this._setMap(value, 'normalMap');
     }
 
     /**
@@ -1708,7 +1719,7 @@ class MaterialElement extends HTMLElement {
     set occludeDirect(value: boolean) {
         this._occludeDirect = value;
         if (this.material) {
-            // @ts-ignore see createMaterial() - the engine mistypes occludeDirect as a number
+            // @ts-ignore see _createMaterial() - the engine mistypes occludeDirect as a number
             this.material.occludeDirect = value;
             this._scheduleUpdate();
         }
@@ -1810,7 +1821,7 @@ class MaterialElement extends HTMLElement {
      */
     set opacityMap(value: string) {
         this._opacityMap = value;
-        this.setMap(value, 'opacityMap');
+        this._setMap(value, 'opacityMap');
     }
 
     /**
@@ -2164,6 +2175,13 @@ class MaterialElement extends HTMLElement {
         return this._useTonemap;
     }
 
+    /**
+     * Returns the {@link StandardMaterial} created by the `<pc-material>` element with the given
+     * `id`, or `undefined` if there is no such element or its material has not been created yet.
+     *
+     * @param id - The `id` of the `<pc-material>` element.
+     * @returns The material, or `undefined`.
+     */
     static get(id: string) {
         const materialElement = document.querySelector<MaterialElement>(`pc-material[id="${id}"]`);
         return materialElement?.material;

--- a/src/module.ts
+++ b/src/module.ts
@@ -43,7 +43,14 @@ class ModuleElement extends HTMLElement {
         }
     }
 
-    public getLoadPromise(): Promise<void> {
+    /**
+     * Returns the promise that settles when the module has loaded. Awaited by the containing
+     * `<pc-app>` element before it creates its graphics device.
+     *
+     * @returns The load promise.
+     * @internal
+     */
+    _getLoadPromise(): Promise<void> {
         return this.loadPromise;
     }
 }

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -78,7 +78,7 @@ class SceneElement extends AsyncElement {
         }
 
         this._scene = app.scene;
-        this.updateSceneSettings();
+        this._updateSceneSettings();
 
         this._onReady();
     }
@@ -91,7 +91,7 @@ class SceneElement extends AsyncElement {
         this._resetReady();
     }
 
-    updateSceneSettings() {
+    private _updateSceneSettings() {
         if (this._scene) {
             this._scene.fog.type = this._fog;
             this._scene.fog.color = this._fogColor;

--- a/test/README.md
+++ b/test/README.md
@@ -31,7 +31,7 @@ this.
 `console.warn` and returns a promise that _never settles_. Two consequences:
 
 - Every wait goes through `readyWithin()`, never a bare `await element.ready()`. On timeout it
-  reports connection state, `closestApp`, `closestEntity`, `hierarchyReady` and every warning seen
+  reports connection state, `closestApp`, `closestEntity`, `_hierarchyReady` and every warning seen
   so far, instead of a bare 10-second timeout.
 - Negative cases are asserted with the console guard or `expectNeverReady()`, never with
   `expect(...).toThrow()`.
@@ -76,7 +76,7 @@ and its boot queries would find nothing.
 **Settle before tearing down.** `<pc-app>` resolves its own ready promise from inside the
 `app.preload()` callback, _before_ its descendants' async `connectedCallback`s have finished. So
 `bootApp()` awaits `settle()` over the whole subtree, not just the app. Removing a tree in that
-window makes `addComponent` and `addSlot` dereference nulls.
+window makes `_addComponent` and `addSlot` dereference nulls.
 
 **Per-file isolation is mandatory.** `src/` performs 27 `customElements.define()` calls at module
 scope and a second define for the same tag throws. Vitest's default per-file isolation gives each

--- a/test/elements/entity.test.ts
+++ b/test/elements/entity.test.ts
@@ -38,7 +38,7 @@ describe('<pc-entity>', () => {
         it.for(['', '   ', ',', 'enemy,', ',enemy', 'enemy,,flying'])('discards empty names in %o', (value) => {
             // Both tags call sites now route through parseTags, which drops empty names. Before
             // that, `tags=""` set the element property to [''] - a single blank tag - while
-            // createEntity's `if (tags)` truthiness check skipped it entirely, so the element and
+            // _createEntity's `if (tags)` truthiness check skipped it entirely, so the element and
             // its backing entity disagreed. See the integration test for the agreement assertion.
             const element = create();
             element.setAttribute('tags', value);

--- a/test/helpers/app.ts
+++ b/test/helpers/app.ts
@@ -33,7 +33,7 @@ export type BootOptions = {
  *
  * This is load bearing rather than convenient. <pc-app> resolves its own ready promise from inside
  * the app.preload() callback, which is BEFORE its descendants' async connectedCallbacks have run to
- * completion. Tearing the tree down in that window makes ComponentElement.addComponent()
+ * completion. Tearing the tree down in that window makes ComponentElement._addComponent()
  * dereference an entity that is already null, and SoundSlotElement.connectedCallback() dereference
  * a component that is already null - both surfacing as unhandled rejections that fail the whole
  * file. Measured: removing the tree immediately after `await appElement.ready()` produces 2-3 such

--- a/test/helpers/ready.ts
+++ b/test/helpers/ready.ts
@@ -70,7 +70,7 @@ export const readyWithin = async <T extends AsyncElement>(element: T, timeout = 
             `  closestApp:     ${describeElement(element.closestApp)}`,
             `  closestEntity:  ${describeElement(element.closestEntity)}`,
             `  app created:    ${Boolean(element.closestApp?.app)}`,
-            `  hierarchyReady: ${element.closestApp?.hierarchyReady ?? 'n/a'}`,
+            `  hierarchyReady: ${element.closestApp?._hierarchyReady ?? 'n/a'}`,
             warnings.length
                 ? `  warnings so far:\n${warnings.map((message) => `    - ${message}`).join('\n')}`
                 : '  warnings so far: (none)',

--- a/test/integration/entity-properties.test.ts
+++ b/test/integration/entity-properties.test.ts
@@ -12,7 +12,7 @@ import { readyWithin } from '../helpers/ready';
  * The imperative construction path: a scene assembled with document.createElement and property
  * assignments rather than markup, which is what examples/spinning-cube-api.html demonstrates.
  *
- * createEntity used to seed the entity by reading the attributes back, so anything assigned through
+ * _createEntity used to seed the entity by reading the attributes back, so anything assigned through
  * the property API before the entity existed was silently discarded - every value below came out as
  * its default. It now reads the cached fields, which hold the parsed attribute value and the
  * property value alike, since attributeChangedCallback routes attributes through the same setters.
@@ -64,7 +64,7 @@ describe('<pc-entity> pre-boot property values', () => {
     });
 
     it('lets a property assigned before boot override the attribute it shadows', async () => {
-        // The sharpest form of the defect: with an attribute present, re-reading it in createEntity
+        // The sharpest form of the defect: with an attribute present, re-reading it in _createEntity
         // beat the later property assignment, so the entity silently used the stale markup value.
         const { element } = await bootWith((entity) => {
             entity.setAttribute('position', '1 1 1');

--- a/test/integration/entity-tags.test.ts
+++ b/test/integration/entity-tags.test.ts
@@ -7,13 +7,13 @@ import { useGuard } from '../helpers/guard';
 import { readyWithin } from '../helpers/ready';
 
 /**
- * `tags` is set from two independent places - createEntity, which runs when the app builds the
+ * `tags` is set from two independent places - _createEntity, which runs when the app builds the
  * hierarchy, and attributeChangedCallback, which runs on upgrade and on every later change. Both now
  * route through parseTags, so these tests assert the thing that actually matters: that the element's
  * `tags` property and the backing entity's tags agree, whichever path produced them.
  *
  * Before parseTags they disagreed for any value containing an empty name. `tags=""` set the element
- * property to [''] - one blank tag - while createEntity's `if (tags)` truthiness check skipped the
+ * property to [''] - one blank tag - while _createEntity's `if (tags)` truthiness check skipped the
  * value entirely, leaving the entity with none.
  */
 describe('<pc-entity> tags', () => {

--- a/test/integration/lifecycle.test.ts
+++ b/test/integration/lifecycle.test.ts
@@ -61,7 +61,7 @@ describe('<pc-app> lifecycle', () => {
         await expectNeverReady(appElement);
 
         expect(appElement.app, 'the application is destroyed').toBeNull();
-        expect(appElement.hierarchyReady).toBe(false);
+        expect(appElement._hierarchyReady).toBe(false);
         expect(entityElement.entity, 'no orphan entity was created').toBeNull();
         expect(uncaught.seen).toEqual([]);
     });
@@ -69,7 +69,7 @@ describe('<pc-app> lifecycle', () => {
     it('abandons boot when a ready listener removes pc-app during the hierarchy build', async () => {
         // Building the hierarchy dispatches each entity's ready event synchronously from inside
         // boot, so a listener can tear the element down mid-sweep. The teardown's reset must
-        // survive the rest of the boot: hierarchyReady flipping back to true would send the
+        // survive the rest of the boot: _hierarchyReady flipping back to true would send the
         // descendants of a later re-insertion down the runtime-insertion path into a null app.
         const handle = mount(`
             <pc-app backend="null">
@@ -85,7 +85,7 @@ describe('<pc-app> lifecycle', () => {
         await expectNeverReady(appElement);
 
         expect(appElement.app, 'the application is destroyed').toBeNull();
-        expect(appElement.hierarchyReady, 'the reset survives the abandoned boot').toBe(false);
+        expect(appElement._hierarchyReady, 'the reset survives the abandoned boot').toBe(false);
         expect(uncaught.seen).toEqual([]);
 
         // And the element recovers: re-inserting it boots afresh, entities and all.
@@ -112,24 +112,24 @@ describe('<pc-app> lifecycle', () => {
         await expectNeverReady(appElement);
 
         expect(appElement.app, 'the application is destroyed').toBeNull();
-        expect(appElement.hierarchyReady).toBe(false);
+        expect(appElement._hierarchyReady).toBe(false);
         expect(appElement.loadProgress, 'preload never ran against the destroyed application').toBe(0);
         expect(uncaught.seen).toEqual([]);
     });
 
-    it('resets hierarchyReady and re-arms readiness when pc-app is removed', async () => {
-        // Descendants branch on both of these: a stale hierarchyReady sends a re-inserted
+    it('resets _hierarchyReady and re-arms readiness when pc-app is removed', async () => {
+        // Descendants branch on both of these: a stale _hierarchyReady sends a re-inserted
         // pc-entity down the runtime-insertion path against a null app, and a stale-resolved
         // ready promise resumes awaiting descendants against the same.
         const { appElement, unmount } = await bootApp('<pc-entity name="e"></pc-entity>');
 
-        expect(appElement.hierarchyReady).toBe(true);
+        expect(appElement._hierarchyReady).toBe(true);
 
         unmount();
         await settleTask();
 
         expect(appElement.app, 'the application is destroyed').toBeNull();
-        expect(appElement.hierarchyReady, 'the hierarchy is no longer claimed live').toBe(false);
+        expect(appElement._hierarchyReady, 'the hierarchy is no longer claimed live').toBe(false);
 
         // The ready promise is pending again, so a descendant awaiting it parks until the
         // element is next inserted and booted, rather than resuming against the null app above.
@@ -164,7 +164,7 @@ describe('<pc-app> lifecycle', () => {
         expect(app, 'and it is not the destroyed one').not.toBe(firstApp);
         app!.autoRender = false;
 
-        expect(appElement.hierarchyReady).toBe(true);
+        expect(appElement._hierarchyReady).toBe(true);
         expect(appElement.querySelectorAll('canvas'), 'exactly one canvas').toHaveLength(1);
         expect(appReadyEvents, 'readiness was announced again').toBe(1);
 

--- a/test/integration/teardown.test.ts
+++ b/test/integration/teardown.test.ts
@@ -155,7 +155,7 @@ describe('teardown', () => {
 
         // The nested entity comes back too, and is re-parented rather than merely recreated.
         // disconnectedCallback resets _built alongside _entity on every descendant, so
-        // buildHierarchy no longer bails on a stale _built and leaves the child orphaned -
+        // _buildHierarchy no longer bails on a stale _built and leaves the child orphaned -
         // created, never parented, and never ready again.
         const parentEntity = app.root.findByName('parent');
         const childEntity = app.root.findByName('child');
@@ -168,7 +168,7 @@ describe('teardown', () => {
 
     it('restores every level when a three-deep pc-entity subtree is removed and re-added', async () => {
         // The two-level case above cannot distinguish "descendants are reset" from "the first
-        // descendant is reset". This also pins buildHierarchy's dependence on document order:
+        // descendant is reset". This also pins _buildHierarchy's dependence on document order:
         // connectedCallback builds the querySelectorAll result in sequence, so each level has to be
         // parented before the level below it looks up closestEntity.
         const { app, all } = await bootApp(`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     ],
     "declaration": true,
     "declarationDir": "./dist",
+    "stripInternal": true,
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,

--- a/typedoc.json
+++ b/typedoc.json
@@ -52,6 +52,7 @@
     "exclude": [
         "**/node_modules/**"
     ],
+    "excludeInternal": true,
     "excludeNotDocumented": true,
     "externalSymbolLinkMappings": {
         "playcanvas": {
@@ -70,7 +71,9 @@
             "RigidBodyComponent": "https://api.playcanvas.com/engine/classes/RigidBodyComponent.html",
             "Scene": "https://api.playcanvas.com/engine/classes/Scene.html",
             "ScreenComponent": "https://api.playcanvas.com/engine/classes/ScreenComponent.html",
+            "Script": "https://api.playcanvas.com/engine/classes/Script.html",
             "ScriptComponent": "https://api.playcanvas.com/engine/classes/ScriptComponent.html",
+            "StandardMaterial": "https://api.playcanvas.com/engine/classes/StandardMaterial.html",
             "SoundComponent": "https://api.playcanvas.com/engine/classes/SoundComponent.html",
             "SoundSlot": "https://api.playcanvas.com/engine/classes/SoundSlot.html",
             "Vec2": "https://api.playcanvas.com/engine/classes/Vec2.html",

--- a/utils/cem/cleanup-plugin.mjs
+++ b/utils/cem/cleanup-plugin.mjs
@@ -1,8 +1,13 @@
 /**
  * Custom Elements Manifest plugin that tidies the assembled manifest.
  *
- * Three things need correcting after analysis:
+ * A few things need correcting after analysis:
  *
+ * - Only public API ships as a member. The analyzer already omits members tagged `@ignore` or
+ *   `@internal`, but it keeps `private` and `protected` ones (merely marking their `privacy`),
+ *   and it keeps underscore-prefixed members that carry no marker at all. Manifest consumers
+ *   such as editor plugins and Storybook surface every member they are given, so anything that
+ *   is not public API is dropped here.
  * - `src/entity.ts` dispatches internal wiring events with computed names (`` `${type}:connect` ``)
  *   that cannot be resolved statically, so whatever the analyzer makes of them is dropped.
  * - `src/app.ts` dispatches the pointer events *onto* `<pc-entity>` elements rather than onto
@@ -137,6 +142,23 @@ export const manifestCleanupPlugin = () => ({
     packageLinkPhase({ customElementsManifest }) {
         const declarations = collectDeclarations(customElementsManifest);
 
+        // Keep only public API in the members list. Privacy modifiers cover `private` and
+        // `protected`; the underscore test covers internal members that TypeScript cannot mark,
+        // because they are the cross-module contract between elements (`_createEntity` and the
+        // like) - those normally carry `@internal`, which the analyzer omits on its own, so the
+        // name test is the backstop for one that loses its tag.
+        for (const { declaration } of declarations.values()) {
+            if (!declaration.members) {
+                continue;
+            }
+            declaration.members = declaration.members.filter(member => member.name &&
+                !member.name.startsWith('_') &&
+                (member.privacy ?? 'public') === 'public');
+            if (declaration.members.length === 0) {
+                delete declaration.members;
+            }
+        }
+
         for (const { declaration } of declarations.values()) {
             if (!declaration.events) {
                 continue;
@@ -172,6 +194,7 @@ export const manifestCleanupPlugin = () => ({
         for (const { declaration } of declarations.values()) {
             declaration.attributes?.sort(byName);
             declaration.events?.sort(byName);
+            declaration.members?.sort(byName);
         }
 
         rewriteDescriptions(customElementsManifest);

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -244,6 +244,107 @@ if (manifest) {
     check(strayAssetEvents.length === 0,
         `pc-app should not declare asset events: ${strayAssetEvents.join(', ')}`);
 
+    // ---- Members: the manifest's public API surface ----
+    //
+    // cleanup-plugin.mjs drops every member that is not public API (private and protected
+    // members, plus underscore-prefixed internals). That filter has two failure modes, and each
+    // direction is pinned here: under-filtering ships an internal member as API, and
+    // over-filtering silently drops a real public member - which no other check would notice.
+
+    // Under-filtering: nothing non-public survives, in any class of any module (the base
+    // classes have no tag, so the per-element map below never sees them)
+    for (const module of manifest.modules ?? []) {
+        for (const declaration of module.declarations ?? []) {
+            if (declaration.kind !== 'class') {
+                continue;
+            }
+            for (const member of declaration.members ?? []) {
+                check(Boolean(member.name) && !member.name.startsWith('_'),
+                    `${declaration.name}.${member.name} is underscore-internal but ships in the manifest`);
+                check((member.privacy ?? 'public') === 'public',
+                    `${declaration.name}.${member.name} is ${member.privacy} but ships in the manifest`);
+            }
+        }
+    }
+
+    // Over-filtering, part 1: every attribute's backing accessor is still a member. pc-entity's
+    // onpointer* attributes are exempt - they are handled by a dispatch helper rather than by
+    // accessors, so the fieldName the attributes plugin falls back to names a member that has
+    // never existed.
+    const PHANTOM_FIELDS = new Set(pointerEvents.map(name => `on${name}`));
+    for (const [tag, declaration] of elements) {
+        const members = new Set((declaration.members ?? []).map(member => member.name));
+        for (const item of declaration.attributes ?? []) {
+            if (!item.fieldName || PHANTOM_FIELDS.has(item.name)) {
+                continue;
+            }
+            check(members.has(item.fieldName),
+                `${tag}[${item.name}] is backed by '${item.fieldName}', which is missing from the members`);
+        }
+    }
+
+    // Over-filtering, part 2: the members that do not back an attribute are pinned exactly, per
+    // element, so dropping one (or leaking a new public-looking internal) fails the build. A
+    // genuinely new public member belongs in this list.
+    const ASYNC_MEMBERS = ['closestApp', 'closestEntity', 'ready'];
+    const EXTRA_MEMBERS = new Map([
+        ['pc-app', ['app', 'elementFromEntity', 'loadProgress', ...ASYNC_MEMBERS]],
+        ['pc-asset', ['asset', 'get', ...ASYNC_MEMBERS]],
+        ['pc-camera', ['component', 'endXr', 'startXr', 'xrAvailable', ...ASYNC_MEMBERS]],
+        ['pc-entity', ['addEventListener', 'entity', 'removeEventListener', ...ASYNC_MEMBERS]],
+        // roughness and roughnessMap are the alias accessors: their attributes resolve to the
+        // gloss fields, so no attribute claims them as its backing member
+        ['pc-material', ['get', 'material', 'roughness', 'roughnessMap']],
+        ['pc-model', ['entity', ...ASYNC_MEMBERS]],
+        ['pc-module', []],
+        ['pc-particles', ['component', 'pause', 'play', 'reset', 'stop', ...ASYNC_MEMBERS]],
+        ['pc-scene', ['scene', ...ASYNC_MEMBERS]],
+        ['pc-script', ['script', ...ASYNC_MEMBERS]],
+        ['pc-sound', ['soundSlot', ...ASYNC_MEMBERS]]
+    ]);
+    for (const tag of COMPONENT_TAGS) {
+        if (!EXTRA_MEMBERS.has(tag)) {
+            EXTRA_MEMBERS.set(tag, ['component', ...ASYNC_MEMBERS]);
+        }
+    }
+    for (const tag of TAGS) {
+        if (!EXTRA_MEMBERS.has(tag)) {
+            EXTRA_MEMBERS.set(tag, ASYNC_MEMBERS);
+        }
+    }
+    for (const [tag, declaration] of elements) {
+        const backing = new Set((declaration.attributes ?? []).map(item => item.fieldName));
+        const extras = (declaration.members ?? [])
+            .map(member => member.name)
+            .filter(name => !backing.has(name))
+            .sort();
+        const expected = [...EXTRA_MEMBERS.get(tag)].sort();
+        check(extras.join() === expected.join(),
+            `${tag} non-attribute members are [${extras.join(', ')}], expected [${expected.join(', ')}]`);
+    }
+
+    // The base classes and whenReady sit outside the per-tag map, but their surface is
+    // inherited by (or waits on) every element, so losing it would break all of them at once
+    const classes = new Map();
+    for (const module of manifest.modules ?? []) {
+        for (const declaration of module.declarations ?? []) {
+            if (declaration.kind === 'class') {
+                classes.set(declaration.name, declaration);
+            }
+        }
+    }
+    for (const [name, expected] of [
+        ['AsyncElement', ASYNC_MEMBERS],
+        ['ComponentElement', ['component', 'enabled', ...ASYNC_MEMBERS]]
+    ]) {
+        const actual = (classes.get(name)?.members ?? []).map(member => member.name).sort();
+        check(actual.join() === [...expected].sort().join(),
+            `${name} members are [${actual.join(', ')}], expected [${expected.join(', ')}]`);
+    }
+    check((manifest.modules ?? []).some(module => (module.declarations ?? [])
+        .some(declaration => declaration.kind === 'function' && declaration.name === 'whenReady')),
+    "the manifest lost the 'whenReady' function declaration");
+
     // Global invariants
     for (const [tag, declaration] of elements) {
         for (const item of declaration.attributes ?? []) {


### PR DESCRIPTION
Fixes #326.

Three categories of internal member shipped as public API in `dist/*.d.ts` and `dist/custom-elements.json`. This PR settles the convention the issue left open, applies it, and locks the surface with a validator so it cannot silently regress. The manifest drops from **974 members to 411**, all public; every `@internal` member is gone from the typings and the docs.

## The convention

**Package-internal cross-module members keep plain member access, but are underscore-prefixed and tagged `/** @internal */`.** TypeScript has no package visibility, so the tag does the work on every surface:

- `stripInternal: true` in `tsconfig.json` removes them from `dist/*.d.ts`
- the CEM analyzer already omits `@internal`/`@ignore` members natively (which is why `_script` was never in the manifest — only the `.d.ts` leaked it)
- `excludeInternal: true` in `typedoc.json` keeps them out of the docs

The Symbol/WeakMap and restructuring options were not pursued: they only fit the `ScriptElement` state channel, leave the method-shaped members (`createEntity` et al.) unsolved, and carry behavioral risk for no extra hiding once the tag strips all three surfaces.

## What changed

- **Category 1** — the 8 `AppElement` pointer/picker handlers become `private`, joining `_getPickerCoordinates`.
- **Category 2** — `ScriptElement._script` and `_onScriptCreated` swap `@ignore` for `@internal`, as do `_registerEntityElement` and `_unregisterEntityElement`.
- **Category 3** — the genuine cross-module channel is renamed to match the existing internal naming: `_createEntity`, `_buildHierarchy`, `_hasListeners`, `_createAsset`, `_createMaterial`, `_getLoadPromise`. Members with no cross-module callers become `private` outright: `_addComponent` (its second caller has since gone), `_updateSceneSettings`, `_destroyAsset`, `_setMap`. `initComponent` and `getInitialComponentData` become `protected` across all 19 declarations — they are the subclass hook contract, which `private` cannot express.
- The `hierarchyReady` getter is deleted: the `_hierarchyReady` field it wrapped is now the `@internal` member itself, and tests read the field directly.
- `AssetElement.get`, `MaterialElement.get` and `MaterialElement.material` **stay public** and gain doc comments — resolving an id to its engine object is genuinely useful API, and documenting them makes the classification deliberate.

## The validator

`cleanup-plugin.mjs` drops `private`, `protected` and underscore-prefixed members from the manifest (the name test is the backstop for an internal member that loses its tag). `validate.mjs` then pins the surface in **both directions**, because the dangerous failure mode is the filter silently taking a real public member with it:

- no shipped member may be non-public or underscore-prefixed, in any class of any module;
- every attribute's backing accessor (`fieldName`) must exist as a member — pc-entity's `onpointer*` attributes exempted, since their fallback `fieldName` names a member that has never existed;
- the members that back no attribute must exactly match a golden list per element (plus pins for `AsyncElement`, `ComponentElement` and `whenReady`), so both drops and new leaks fail the build.

Both directions are mutation-tested: making the filter drop `fov` fails with `pc-camera[fov] is backed by 'fov', which is missing from the members`; disabling the privacy filter fails with 77 leak errors.

## Reviewer notes

- `_hasListeners` and `_destroyAsset`/`_setMap` are not in the issue's Category 3 table but are the same category (public-looking, internal plumbing), so they got the same treatment.
- `roughness`/`roughnessMap` are pinned as public members: they are the documented alias accessors, and their attributes resolve to the `gloss` fields, so no attribute claims them as its backing member.
- The `.d.ts` still contains `private _foo;` stubs — standard tsc emission, not callable; only `@internal` members are stripped entirely.
- The bundled editor integrations (`vscode.html-custom-data.json`, `web-types.json`) carry attributes and events only, so IDE autocomplete is unaffected; the consumers that change are the `.d.ts` and manifest readers such as lit-analyzer.
- Two pre-existing TypeDoc `{@link}` warnings are fixed by adding `Script` and `StandardMaterial` to the external symbol link mappings.

Build + manifest validation, 529 tests, lint, type-check, docs and publint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)