### PR TITLE
Scope the readiness await in the DOM API example to the engine call

### DIFF
--- a/examples/spinning-cube-api.html
+++ b/examples/spinning-cube-api.html
@@ -21,19 +21,10 @@
 
             import { whenReady } from '@playcanvas/web-components';
 
-            // Use the DOM API to programmatically create the scene
+            // Build the scene with the DOM API - no waiting needed: elements appended
+            // while the application boots are picked up when it becomes ready
             const app = document.createElement('pc-app');
             document.body.appendChild(app);
-
-            await whenReady(app);
-
-            class Rotate extends Script { 
-                update(dt) {
-                    this.entity.rotate(10 * dt, 20 * dt, 30 * dt);
-                }
-            }                
-
-            registerScript(Rotate, 'rotate');
 
             const scene = document.createElement('pc-scene');
             app.appendChild(scene);
@@ -69,6 +60,19 @@
             const scriptsComponent = document.createElement('pc-scripts');
             cube.appendChild(scriptsComponent);
 
+            // Engine APIs are different: registerScript resolves the application's script
+            // registry, so it can only run once the application exists
+            await whenReady(app);
+
+            class Rotate extends Script {
+                update(dt) {
+                    this.entity.rotate(10 * dt, 20 * dt, 30 * dt);
+                }
+            }
+
+            registerScript(Rotate, 'rotate');
+
+            // Appended after registration, so the instance is created immediately
             const script = document.createElement('pc-script');
             script.setAttribute('name', 'rotate');
             scriptsComponent.appendChild(script);


### PR DESCRIPTION
The spinning-cube DOM API example awaited `whenReady(app)` immediately after appending `<pc-app>`, which reads as "always wait before building the tree". That overstates what the elements require — children appended while the application boots are collected when it becomes ready, exactly like declarative markup — and it hides *why* the await is there at all.

The example now builds the entire element tree with no await, and `whenReady` moves down to sit directly above the one call that needs it: `registerScript` without an explicit app argument resolves `AppBase.getApplication().scripts`, and no application exists until the element's boot creates one. The `<pc-script>` element stays after registration, since its instance is created on insertion.

## Verified

- **Tree-before-ready works**: all three entities, camera/light/render components, scene settings and the script instance come up, and the cube rotates (checked both live and by stepping `app.update()` manually with a canvas readback).
- **The await is genuinely load-bearing where it now sits**: removing it entirely makes the module throw a TypeError inside `registerScript` (`getApplication()` is `undefined` mid-boot), killing everything after that line.
- **The pc-script-after-registration ordering matters**: registering after an already-inserted `<pc-script>` only survives today by microtask interleaving — nothing retries instance creation when a script class registers late. The comments pin both orderings so a tidy-up refactor doesn't quietly depend on that.

The declarative examples (`spinning-cube.html`, UMD variant) have a different shape and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)