### PR TITLE
Defer pc-model readiness until instantiation and add load/error events

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -8,6 +8,21 @@ import { AsyncElement } from './async-element';
  * {@link https://developer.playcanvas.com/user-manual/web-components/tags/pc-model/ | `<pc-model>`} elements.
  * The ModelElement interface also inherits the properties and methods of the
  * {@link HTMLElement} interface.
+ *
+ * The element becomes ready once its container asset has loaded and the instantiated hierarchy has
+ * been added to the scene — `entity` is non-null by then. A failed load also settles readiness,
+ * with `entity` remaining `null`: readiness means the load settled, not that it succeeded — listen
+ * for `error`, or check `entity`, to tell the outcomes apart. Changing `asset` re-arms readiness
+ * and instantiates anew, so a `ready()` obtained after the change resolves against the new
+ * hierarchy. A `pc-model` outside a `pc-app`, or referencing an unknown asset id, warns and never
+ * becomes ready.
+ *
+ * @fires {Event} load - Fired each time a container asset finishes instantiating, including
+ * re-instantiation after `asset` changes. Does not bubble — listen on this element, or use a
+ * capture-phase listener on an ancestor.
+ * @fires {ErrorEvent} error - Fired when the container asset fails to load, with the engine's
+ * error in `message`. Does not bubble. The element still becomes ready — readiness means the load
+ * settled, not that it succeeded.
  */
 class ModelElement extends AsyncElement {
     private _asset = '';
@@ -23,11 +38,13 @@ class ModelElement extends AsyncElement {
     private _loadGeneration = 0;
 
     /**
-     * The pending asset-load subscription of the current load, if it is waiting for its asset.
-     * Held so that whatever supersedes the load can detach the handler from the asset, rather
-     * than leave it registered until the asset loads (or forever, if it never does).
+     * The pending asset subscriptions of the current load, if it is waiting for its asset. Held
+     * so that whatever supersedes the load can detach the handlers from the asset, rather than
+     * leave them registered until the asset settles (or forever, if it never does).
      */
     private _loadHandle: EventHandle | null = null;
+
+    private _errorHandle: EventHandle | null = null;
 
     /**
      * The root entity of the instantiated model. `null` until the container asset has loaded
@@ -39,20 +56,39 @@ class ModelElement extends AsyncElement {
     }
 
     connectedCallback() {
+        // A model outside an application is inert and never becomes ready, so awaiting it hangs.
+        // Warn rather than fail silently, naming the parent it requires, as every other misplaced
+        // element does.
+        if (!this.closestApp) {
+            const label = this._asset ? ` '${this._asset}'` : '';
+            console.warn(`pc-model${label} must be a descendant of pc-app - model not created`);
+            return;
+        }
         this._loadModel();
-        this._onReady();
     }
 
     disconnectedCallback() {
         this._loadGeneration++;
-        this._detachLoadHandler();
+        this._detachLoadHandlers();
         this._unloadModel();
         this._resetReady();
     }
 
-    private _detachLoadHandler() {
+    private _detachLoadHandlers() {
         this._loadHandle?.off();
         this._loadHandle = null;
+        this._errorHandle?.off();
+        this._errorHandle = null;
+    }
+
+    /**
+     * Resolves readiness and dispatches the `load` event. Called once the instantiated hierarchy
+     * has been parented — readiness means "in the scene graph", matching `pc-entity`, so a ready
+     * model's entity always has world transforms.
+     */
+    private _announceLoad() {
+        this._onReady();
+        this.dispatchEvent(new Event('load'));
     }
 
     private _instantiate(container: ContainerResource) {
@@ -78,6 +114,7 @@ class ModelElement extends AsyncElement {
                     return;
                 }
                 parentEntityElement.entity!.addChild(entity);
+                this._announceLoad();
             });
         } else {
             const appElement = this.closestApp;
@@ -87,6 +124,7 @@ class ModelElement extends AsyncElement {
                         return;
                     }
                     appElement.app!.root.addChild(entity);
+                    this._announceLoad();
                 });
             }
         }
@@ -97,19 +135,35 @@ class ModelElement extends AsyncElement {
 
         // Supersede any load already in flight - only the newest load may instantiate
         const generation = ++this._loadGeneration;
-        this._detachLoadHandler();
+        this._detachLoadHandlers();
 
-        const appElement = await this.closestApp?.ready();
+        // Re-arm readiness so a waiter obtained after an asset change resolves against the new
+        // hierarchy. A no-op on first connection, where readiness is still pending.
+        this._resetReady();
+
+        const appElement = this.closestApp;
+        if (!appElement) {
+            // Outside pc-app; connectedCallback already warned. Reached through the asset setter.
+            return;
+        }
+
+        await appElement.ready();
 
         // The element may have been removed, or another load started, while we waited
         if (generation !== this._loadGeneration) {
             return;
         }
 
-        const app = appElement?.app;
+        const app = appElement.app;
 
         const asset = AssetElement.get(this._asset);
         if (!asset) {
+            // An empty id is a legitimate transient (the asset may be assigned later); a
+            // non-empty one that resolves to nothing is a dead end - say so rather than staying
+            // silently pending.
+            if (this._asset) {
+                console.warn(`pc-model could not find asset '${this._asset}' - model not created`);
+            }
             return;
         }
 
@@ -118,13 +172,27 @@ class ModelElement extends AsyncElement {
         } else {
             // The generation is re-checked even though a superseded handler is detached: the
             // detach relies on how the engine's event emitter treats removal, while the check
-            // holds on its own.
+            // holds on its own. Whichever of load/error fires first detaches the other.
             this._loadHandle = asset.once('load', () => {
-                this._loadHandle = null;
+                this._detachLoadHandlers();
                 if (generation !== this._loadGeneration) {
                     return;
                 }
                 this._instantiate(asset.resource as ContainerResource);
+            });
+            this._errorHandle = asset.once('error', (err: string | Error) => {
+                this._detachLoadHandlers();
+                if (generation !== this._loadGeneration) {
+                    return;
+                }
+                // A failed load settles readiness with a null entity, mirroring pc-asset:
+                // readiness means the load settled, not that it succeeded.
+                this.dispatchEvent(
+                    new ErrorEvent('error', {
+                        message: err instanceof Error ? err.message : String(err)
+                    })
+                );
+                this._onReady();
             });
             app!.assets.load(asset);
         }

--- a/test/helpers/dom.ts
+++ b/test/helpers/dom.ts
@@ -14,7 +14,7 @@ export type Mounted = {
 
 const mounted = new Set<Mounted>();
 
-const LIBRARY_SELECTOR = 'pc-app, pc-asset, pc-entity, pc-material, pc-module, pc-scene, pc-sky';
+const LIBRARY_SELECTOR = 'pc-app, pc-asset, pc-entity, pc-material, pc-model, pc-module, pc-scene, pc-sky';
 
 /**
  * Fails if a previous test left library elements in the document.

--- a/test/integration/model.test.ts
+++ b/test/integration/model.test.ts
@@ -4,25 +4,32 @@ import type { AppElement } from '../../src/app';
 import { bootApp, settle } from '../helpers/app';
 import { mount } from '../helpers/dom';
 import { useGuard } from '../helpers/guard';
-import { readyWithin } from '../helpers/ready';
+import { expectNeverReady, readyWithin } from '../helpers/ready';
 
 
 /**
  * The smallest valid glTF: no meshes, one named node. instantiateRenderEntity() still returns a
  * real entity hierarchy for it, which is all these tests need - and it loads from a data: URI,
  * so no I/O.
+ *
+ * @param nodeName - The name of the glTF's single node.
+ * @returns The data: URI.
  */
-const GLTF_SRC = `data:application/json,${encodeURIComponent(JSON.stringify({
+const containerSrc = (nodeName: string) => `data:application/json,${encodeURIComponent(JSON.stringify({
     asset: { version: '2.0' },
     scene: 0,
     scenes: [{ nodes: [0] }],
-    nodes: [{ name: 'model-root' }]
+    nodes: [{ name: nodeName }]
 }))}`;
+
+const GLTF_SRC = containerSrc('model-root');
 
 const ASSET_TAG = `<pc-asset id="m" type="container" src="${GLTF_SRC}"></pc-asset>`;
 
+const ASSET_TAG_B = `<pc-asset id="m2" type="container" src="${containerSrc('model-root-b')}"></pc-asset>`;
+
 describe('<pc-model>', () => {
-    const { uncaught } = useGuard();
+    const { errors, uncaught, warnings } = useGuard();
 
     const settleTask = () => new Promise((resolve) => {
         setTimeout(resolve, 0);
@@ -114,5 +121,133 @@ describe('<pc-model>', () => {
         expect(instantiations, 'the superseded load did not instantiate').toBe(1);
         expect(handle.get('pc-model').entity, 'the surviving load produced the entity').toBeTruthy();
         expect(uncaught.seen).toEqual([]);
+    });
+
+    describe('readiness', () => {
+        it('resolves ready only once the model is instantiated and parented', async () => {
+            const { appElement } = await bootApp(ASSET_TAG.replace('>', ' lazy>'));
+
+            const model = document.createElement('pc-model');
+            model.setAttribute('asset', 'm');
+            appElement.appendChild(model);
+
+            let ready = false;
+            model.ready().then(() => {
+                ready = true;
+            });
+
+            // Let the connect continuations run: the app-ready resume on the first hop, the asset
+            // subscription on the second. The data: fetch needs a macrotask, so the load cannot
+            // have completed yet.
+            await Promise.resolve();
+            await Promise.resolve();
+            expect(ready, 'not ready before the asset has loaded').toBe(false);
+            expect(model.entity, 'no entity before the asset has loaded').toBeNull();
+
+            await readyWithin(model);
+            expect(model.entity, 'ready implies an instantiated entity').not.toBeNull();
+            expect(model.entity!.parent, 'ready implies the entity is parented').toBe(appElement.app!.root);
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('stays pending without warning while no asset is assigned', async () => {
+            const { appElement } = await bootApp();
+
+            const model = document.createElement('pc-model');
+            appElement.appendChild(model);
+
+            // An unassigned asset is a legitimate transient (the property may be set later), so
+            // the element waits silently - the guard fails this test if anything warns.
+            await expectNeverReady(model);
+        });
+
+        it('warns and never becomes ready when no asset matches the id', async () => {
+            const { appElement } = await bootApp();
+
+            const model = document.createElement('pc-model');
+            model.setAttribute('asset', 'nope');
+            appElement.appendChild(model);
+
+            await expectNeverReady(model);
+            warnings.expect("pc-model could not find asset 'nope'");
+        });
+
+        it('warns and never becomes ready outside pc-app', async () => {
+            const handle = mount('<pc-model asset="m"></pc-model>');
+            const model = handle.get('pc-model');
+
+            warnings.expect("pc-model 'm' must be a descendant of pc-app");
+            await expectNeverReady(model);
+        });
+    });
+
+    describe('load and error events', () => {
+        it('fires load once instantiated, with the entity already available', async () => {
+            const { appElement } = await bootApp(ASSET_TAG);
+
+            const model = document.createElement('pc-model');
+            model.setAttribute('asset', 'm');
+            const seen: { entity: unknown; bubbles: boolean }[] = [];
+            model.addEventListener('load', (event) => {
+                seen.push({ entity: model.entity, bubbles: event.bubbles });
+            });
+            appElement.appendChild(model);
+
+            await readyWithin(model);
+            expect(seen).toHaveLength(1);
+            expect(seen[0].entity, 'the entity is set by the time load fires').toBe(model.entity);
+            expect(seen[0].bubbles, 'load does not bubble, mirroring pc-asset').toBe(false);
+            expect(model.entity).not.toBeNull();
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('fires error and still becomes ready when the container fails to load', async () => {
+            const { appElement } = await bootApp(
+                '<pc-asset id="bad" type="container" src="data:model/gltf-binary,notaglb" lazy></pc-asset>'
+            );
+
+            const model = document.createElement('pc-model');
+            model.setAttribute('asset', 'bad');
+            const seen: ErrorEvent[] = [];
+            model.addEventListener('error', (event) => seen.push(event as ErrorEvent));
+            appElement.appendChild(model);
+
+            await readyWithin(model);
+            expect(model.entity, 'readiness means the load settled, not that it succeeded').toBeNull();
+            expect(seen).toHaveLength(1);
+            expect(seen[0].message, 'the engine error is forwarded').not.toBe('');
+            expect(seen[0].bubbles).toBe(false);
+
+            // The engine logs the parse failure itself; the event above is the element's channel
+            errors.expect(/glb/i);
+            expect(uncaught.seen).toEqual([]);
+        });
+    });
+
+    describe('[asset]', () => {
+        it('re-instantiates and re-arms readiness when the asset changes', async () => {
+            const { appElement, get } = await bootApp(`${ASSET_TAG}${ASSET_TAG_B}<pc-model asset="m"></pc-model>`);
+            const model = get('pc-model');
+
+            const first = model.entity!;
+            expect(first.findByName('model-root'), 'the first model is instantiated').not.toBeNull();
+
+            let loads = 0;
+            model.addEventListener('load', () => {
+                loads += 1;
+            });
+
+            model.setAttribute('asset', 'm2');
+            expect(model.entity, 'the old hierarchy is torn down synchronously').toBeNull();
+
+            await readyWithin(model);
+            const second = model.entity!;
+            expect(second, 'a new hierarchy was instantiated').not.toBe(first);
+            expect(second.findByName('model-root-b'), 'the new hierarchy comes from the new asset').not.toBeNull();
+            expect(second.parent, 'the new hierarchy is parented').toBe(appElement.app!.root);
+            expect(first.parent, 'the old hierarchy left the scene').toBeNull();
+            expect(loads, 'each instantiation fires load').toBe(1);
+            expect(uncaught.seen).toEqual([]);
+        });
     });
 });


### PR DESCRIPTION
## What

- `<pc-model>` readiness now resolves once the container asset has loaded and the instantiated hierarchy has been **parented into the scene** — previously it resolved on connect, before any of that. `ready()` re-arms when `asset` changes, so a waiter obtained after a swap resolves against the new hierarchy.
- New non-bubbling **`load`/`error` events**, mirroring `pc-asset`'s shape. `load` fires on every instantiation, including re-instantiation after an `asset` change.
- A **failed load still settles readiness** with `entity` remaining `null` — `pc-asset`'s documented "readiness means the load settled, not that it succeeded" contract — so `whenReady('pc-model')` never hangs on a bad asset.
- Two new **warnings** join the teach-the-user set: `pc-model` outside `pc-app`, and a non-empty `asset` id that matches no `pc-asset`. An empty `asset` stays silently pending (assigning it later is a legitimate transient).

## Why

Step 1 of the #297 rollout: `pc-node` binds against the instantiated hierarchy after `pc-model` instantiates and rebinds on reload — the `load` event is that signal, and deferred readiness is what makes `(await whenReady('pc-model')).entity` meaningful. Useful standalone too: it unblocks imperative decoration of glTF hierarchies today.

## Reviewer notes

- The error path subscribes to the asset's `error` alongside `load`; whichever fires first detaches the other, and both re-check the load generation — the same supersession discipline the load path already had.
- Tests: 7 new integration tests in `model.test.ts` covering deferred readiness, both warnings, both events, error-still-settles, and the reload cycle. Drive-by: `pc-model` was missing from the test leak detector's selector in `test/helpers/dom.ts`.
- Verified beyond the suite: built bundle exercised in a real browser against `examples/animation.html` — ready resolves with the entity parented, an asset re-set tears down synchronously, re-fires `load`, and detaches the old hierarchy; console clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)