### PR TITLE
Add pc-node: declarative overrides for glTF hierarchies

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -67,6 +67,7 @@ import {
 import type { AssetElement } from './asset';
 import { AsyncElement } from './async-element';
 import type { EntityElement } from './entity';
+import type { EntityBaseElement } from './entity-base';
 import { LoadingBar } from './loading-bar';
 import type { MaterialElement } from './material';
 import type { ModuleElement } from './module';
@@ -133,10 +134,11 @@ class AppElement extends AsyncElement {
 
     /**
      * The elements backing this application's entities, keyed by the entity itself. Registered
-     * by EntityElement at creation and removed when an entity is destroyed, this joins engine
-     * scene nodes back to their owning elements by identity - never by name.
+     * by EntityElement at creation (and NodeElement at binding) and removed when an entity is
+     * destroyed or unbound, this joins engine scene nodes back to their owning elements by
+     * identity - never by name.
      */
-    private _entityElements = new Map<GraphNode, EntityElement>();
+    private _entityElements = new Map<GraphNode, EntityBaseElement>();
 
     private _picker: Picker | null = null;
 
@@ -148,7 +150,7 @@ class AppElement extends AsyncElement {
         pointermove: false
     };
 
-    private _hoveredEntity: EntityElement | null = null;
+    private _hoveredEntity: EntityBaseElement | null = null;
 
     // Identifies the newest in-flight hover pick, so out-of-order results can be discarded
     private _pickToken = 0;
@@ -493,9 +495,9 @@ class AppElement extends AsyncElement {
         // created from onpointer* attributes when their elements were first upgraded, or
         // listeners carried over from before a re-boot)
         pointerEventTypes.forEach((type) => {
-            const anyListeners = Array.from(this.querySelectorAll<EntityElement>('pc-entity')).some((entity) =>
-                entity._hasListeners(type)
-            );
+            const anyListeners = Array.from(
+                this.querySelectorAll<EntityBaseElement>('pc-entity, pc-node')
+            ).some((entity) => entity._hasListeners(type));
             if (anyListeners) {
                 this._onPointerListenerAdded(type);
             }
@@ -528,14 +530,14 @@ class AppElement extends AsyncElement {
     }
 
     /**
-     * Registers the element that created an entity. Called by EntityElement when it creates its
-     * entity.
+     * Registers the element that fronts an entity. Called by EntityElement when it creates its
+     * entity, and by NodeElement when it binds one.
      *
      * @param entity - The entity.
-     * @param element - The element that created it.
+     * @param element - The element that fronts it.
      * @internal
      */
-    _registerEntityElement(entity: Entity, element: EntityElement) {
+    _registerEntityElement(entity: Entity, element: EntityBaseElement) {
         this._entityElements.set(entity, element);
     }
 
@@ -550,27 +552,28 @@ class AppElement extends AsyncElement {
     }
 
     /**
-     * Returns the `<pc-entity>` element whose backing entity is `entity`, or `null` if the
-     * entity was not created by an element of this application - for example, a node inside a
-     * model's instantiated hierarchy, or an entity created through the engine API.
+     * Returns the `<pc-entity>` or `<pc-node>` element whose backing entity is `entity`, or
+     * `null` if the entity is not fronted by an element of this application - for example, an
+     * unbound node inside a model's instantiated hierarchy, or an entity created through the
+     * engine API.
      *
      * @param entity - The entity to look up.
-     * @returns The element backing the entity, or `null`.
+     * @returns The element fronting the entity, or `null`.
      */
-    elementFromEntity(entity: Entity): EntityElement | null {
+    elementFromEntity(entity: Entity): EntityBaseElement | null {
         return this._entityElements.get(entity) ?? null;
     }
 
     /**
      * Resolves the element that owns a picked node: the nearest node up the parent chain -
-     * starting with the node itself - that was created by a `<pc-entity>` of this application.
-     * A hit inside a model's instantiated hierarchy therefore resolves to the element hosting
-     * the model.
+     * starting with the node itself - that is fronted by a `<pc-entity>` or `<pc-node>` of this
+     * application. A hit inside a model's instantiated hierarchy therefore resolves to the
+     * nearest bound `<pc-node>`, or failing that the element hosting the model.
      *
      * @param node - The picked node, or `null`.
      * @returns The owning element, or `null`.
      */
-    private _elementFromNode(node: GraphNode | null): EntityElement | null {
+    private _elementFromNode(node: GraphNode | null): EntityBaseElement | null {
         while (node !== null) {
             const element = this._entityElements.get(node);
             if (element) {
@@ -589,7 +592,7 @@ class AppElement extends AsyncElement {
      * @param type - The pointer event type a listener is required for.
      * @returns The nearest listening element, or `null`.
      */
-    private _elementWithListener(node: GraphNode | null, type: string): EntityElement | null {
+    private _elementWithListener(node: GraphNode | null, type: string): EntityBaseElement | null {
         while (node !== null) {
             const element = this._entityElements.get(node);
             if (element?._hasListeners(type)) {
@@ -715,9 +718,9 @@ class AppElement extends AsyncElement {
     }
 
     private _onPointerListenerRemoved(type: string) {
-        const hasListeners = Array.from(this.querySelectorAll<EntityElement>('pc-entity')).some((entity) =>
-            entity._hasListeners(type)
-        );
+        const hasListeners = Array.from(
+            this.querySelectorAll<EntityBaseElement>('pc-entity, pc-node')
+        ).some((entity) => entity._hasListeners(type));
 
         if (!hasListeners && this._canvas) {
             this._hasPointerListeners[type] = false;

--- a/src/async-element.ts
+++ b/src/async-element.ts
@@ -1,5 +1,5 @@
 import type { AppElement } from './app';
-import type { EntityElement } from './entity';
+import type { EntityBaseElement } from './entity-base';
 
 /**
  * Base class for all PlayCanvas Web Components that initialize asynchronously.
@@ -33,12 +33,13 @@ class AsyncElement extends HTMLElement {
     }
 
     /**
-     * The nearest ancestor `<pc-entity>` element, or `null` if this element has no `<pc-entity>`
-     * ancestor. The search starts at the parent, so an element never resolves to itself.
-     * @returns The closest entity element, or `null`.
+     * The nearest ancestor element that fronts an entity — `<pc-entity>` or `<pc-node>` — or
+     * `null` if this element has no such ancestor. The search starts at the parent, so an element
+     * never resolves to itself.
+     * @returns The closest entity-fronting element, or `null`.
      */
-    get closestEntity(): EntityElement | null {
-        return (this.parentElement?.closest('pc-entity') as EntityElement | null) ?? null;
+    get closestEntity(): EntityBaseElement | null {
+        return (this.parentElement?.closest('pc-entity, pc-node') as EntityBaseElement | null) ?? null;
     }
 
     /**

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -71,21 +71,23 @@ class ComponentElement extends AsyncElement {
      * production builds, which would otherwise leave a silent null.
      */
     private _applyComponent() {
-        const entity = this._hostElement?.entity;
-        if (!entity) {
-            return;
-        }
+        const entity = this._hostElement?.entity ?? null;
         if (this._component && this._component.entity === entity) {
             return;
         }
 
         // A retarget leaves the previous component on a still-live entity - remove it so the
-        // decoration follows the element. A destroyed entity took its components with it.
+        // decoration follows the element, or vanishes with a dissolved binding. A destroyed
+        // entity took its components with it.
         const previous = this._component;
         if (previous?.entity && previous.entity.c[this._componentName] === previous) {
             previous.entity.removeComponent(this._componentName);
         }
         this._component = null;
+
+        if (!entity) {
+            return;
+        }
 
         if (entity.c[this._componentName]) {
             const label = this.id ? ` '${this.id}'` : '';
@@ -135,12 +137,27 @@ class ComponentElement extends AsyncElement {
             if (generation !== this._connectionGeneration) {
                 return;
             }
-            this._resetReady();
-            this._applyComponent();
-            this.initComponent();
-            this._onReady();
+            this._hostCycled();
         };
         entityElement.addEventListener('ready', this._hostReadyListener);
+    }
+
+    /**
+     * Re-evaluates this component against the host's current entity: applied to a new entity,
+     * moved from a still-live old one, or removed when the host no longer fronts an entity at
+     * all. Readiness follows - it cycles with a re-application and stays unresolved while the
+     * host is unbound. Called by the host-ready listener, and directly by a `<pc-node>`
+     * dissolving its binding: the one transition that fires no ready event to ride.
+     *
+     * @internal
+     */
+    _hostCycled() {
+        this._resetReady();
+        this._applyComponent();
+        if (this._hostElement?.entity) {
+            this.initComponent();
+            this._onReady();
+        }
     }
 
     /**

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -2,6 +2,7 @@ import type { Component } from 'playcanvas';
 
 import type { AppElement } from '../app';
 import { AsyncElement } from '../async-element';
+import type { EntityBaseElement } from '../entity-base';
 import { parseBool } from '../parse';
 
 /**
@@ -17,6 +18,18 @@ class ComponentElement extends AsyncElement {
     private _component: Component | null = null;
 
     private _appElement: AppElement | null = null;
+
+    /**
+     * The element hosting this component, held so the host's readiness cycles can be observed
+     * even after `closestEntity` would no longer resolve (during teardown).
+     */
+    private _hostElement: EntityBaseElement | null = null;
+
+    /**
+     * The listener re-applying this component when the host's readiness cycles. Held for
+     * removal on disconnect.
+     */
+    private _hostReadyListener: EventListener | null = null;
 
     /**
      * Incremented on every connect and disconnect. connectedCallback captures the value on entry
@@ -49,6 +62,42 @@ class ComponentElement extends AsyncElement {
         return {};
     }
 
+    /**
+     * Creates the component on the host's current entity, removing it first from a previous
+     * entity that is still alive (a retargeted `<pc-node>` moves its decorations with it). When
+     * the entity already has a component of this type — a glTF node arriving with its authored
+     * `render` component, say — warns and leaves `component` null. The element-level warning is
+     * load-bearing: the engine's own duplicate-addComponent warning is Debug-stripped from
+     * production builds, which would otherwise leave a silent null.
+     */
+    private _applyComponent() {
+        const entity = this._hostElement?.entity;
+        if (!entity) {
+            return;
+        }
+        if (this._component && this._component.entity === entity) {
+            return;
+        }
+
+        // A retarget leaves the previous component on a still-live entity - remove it so the
+        // decoration follows the element. A destroyed entity took its components with it.
+        const previous = this._component;
+        if (previous?.entity && previous.entity.c[this._componentName] === previous) {
+            previous.entity.removeComponent(this._componentName);
+        }
+        this._component = null;
+
+        if (entity.c[this._componentName]) {
+            const label = this.id ? ` '${this.id}'` : '';
+            console.warn(
+                `${this.tagName.toLowerCase()}${label} - '${entity.name}' already has a '${this._componentName}' component - component not added`
+            );
+            return;
+        }
+
+        this._component = entity.addComponent(this._componentName, this.getInitialComponentData());
+    }
+
     private async _addComponent() {
         const generation = this._connectionGeneration;
 
@@ -71,9 +120,27 @@ class ComponentElement extends AsyncElement {
             return;
         }
 
-        // Add the component to the entity
-        const data = this.getInitialComponentData();
-        this._component = entityElement.entity!.addComponent(this._componentName, data);
+        this._hostElement = entityElement;
+        this._applyComponent();
+
+        // Re-apply when the host's readiness cycles without this element disconnecting: a
+        // `<pc-node>` rebinding after its model reloads or retargets, or a re-created entity.
+        // The 'ready' event bubbles, so events from descendants pass through this host - only
+        // the host's own cycles count. Readiness is cycled here too, so decorations one level
+        // down re-apply the same way.
+        this._hostReadyListener = (event: Event) => {
+            if (event.target !== this._hostElement) {
+                return;
+            }
+            if (generation !== this._connectionGeneration) {
+                return;
+            }
+            this._resetReady();
+            this._applyComponent();
+            this.initComponent();
+            this._onReady();
+        };
+        entityElement.addEventListener('ready', this._hostReadyListener);
     }
 
     /**
@@ -110,6 +177,12 @@ class ComponentElement extends AsyncElement {
     disconnectedCallback() {
         // Invalidate any connectedCallback still suspended on an await
         this._connectionGeneration++;
+
+        if (this._hostElement && this._hostReadyListener) {
+            this._hostElement.removeEventListener('ready', this._hostReadyListener);
+        }
+        this._hostElement = null;
+        this._hostReadyListener = null;
 
         // Remove the component when the element is disconnected. Skip this when the owning
         // application has already been destroyed — removing a <pc-app> disconnects it before

--- a/src/entity-base.ts
+++ b/src/entity-base.ts
@@ -1,0 +1,136 @@
+import type { Entity } from 'playcanvas';
+
+import type { AppElement } from './app';
+import { AsyncElement } from './async-element';
+
+/**
+ * The attribute names of the inline `onpointer*` event handlers, shared by every element that
+ * fronts an engine entity. Spread into `observedAttributes` by subclasses.
+ * @ignore
+ */
+const POINTER_ATTRIBUTES = [
+    'onpointerenter',
+    'onpointerleave',
+    'onpointerdown',
+    'onpointerup',
+    'onpointermove'
+] as const;
+
+/**
+ * The base class for elements that front an engine {@link Entity}: `<pc-entity>`, which creates
+ * one, and `<pc-node>`, which binds to one inside a model's instantiated hierarchy. It carries
+ * what both need — the `entity` contract, registration with the owning application (which joins
+ * picked scene nodes back to elements by identity, never by name), and the pointer listener
+ * bookkeeping that lets the application lazily attach its canvas handlers.
+ */
+class EntityBaseElement extends AsyncElement {
+    protected _entity: Entity | null = null;
+
+    /**
+     * The application element this entity is registered with, cached at registration time so the
+     * entity can be unregistered even once this element has left the DOM.
+     */
+    protected _appElement: AppElement | null = null;
+
+    /**
+     * The pointer event listeners for the entity.
+     */
+    private _listeners: Record<string, EventListener[]> = {};
+
+    /**
+     * The event types for which an inline `onpointer*` attribute is currently present.
+     */
+    private _inlineHandlerTypes = new Set<string>();
+
+    /**
+     * The PlayCanvas entity instance. `null` until the element is ready, and again once the
+     * entity is gone — await {@link whenReady} or the element's `ready()` promise before
+     * accessing it.
+     * @returns The entity instance, or `null`.
+     */
+    get entity(): Entity | null {
+        return this._entity;
+    }
+
+    /**
+     * Registers `entity` as this element's backing entity with the owning application, which
+     * joins engine nodes back to elements by identity (never by name).
+     *
+     * @param entity - The entity to register.
+     */
+    protected _registerEntity(entity: Entity) {
+        this._appElement = this.closestApp;
+        this._appElement?._registerEntityElement(entity, this);
+    }
+
+    /**
+     * Removes the registration for `entity`.
+     *
+     * @param entity - The entity to unregister.
+     */
+    protected _unregisterEntity(entity: Entity) {
+        this._appElement?._unregisterEntityElement(entity);
+        this._appElement = null;
+    }
+
+    /**
+     * Tracks whether an inline `onpointer*` attribute is present. The browser itself compiles and
+     * runs these attributes — they are standard `GlobalEventHandlers`, so setting one replaces
+     * the previous handler and removing it removes the handler, exactly like `onclick` on any
+     * HTML element. But because they bypass {@link addEventListener}, the connect/disconnect
+     * bookkeeping that lets the application lazily attach its canvas pointer handlers must be
+     * kept in sync here.
+     *
+     * @param name - The attribute name (e.g. 'onpointerdown').
+     * @param value - The attribute value, or `null` when the attribute has been removed.
+     */
+    protected _updateInlineHandler(name: string, value: string | null) {
+        const type = name.substring(2);
+        const had = this._inlineHandlerTypes.has(type);
+        const has = value !== null;
+
+        if (has && !had) {
+            this._inlineHandlerTypes.add(type);
+            this.dispatchEvent(new CustomEvent(`${type}:connect`, { bubbles: true }));
+        } else if (!has && had) {
+            this._inlineHandlerTypes.delete(type);
+            this.dispatchEvent(new CustomEvent(`${type}:disconnect`, { bubbles: true }));
+        }
+    }
+
+    addEventListener(type: string, listener: EventListener, options?: boolean | AddEventListenerOptions) {
+        if (!this._listeners[type]) {
+            this._listeners[type] = [];
+        }
+        this._listeners[type].push(listener);
+        super.addEventListener(type, listener, options);
+        if (type.startsWith('pointer')) {
+            this.dispatchEvent(new CustomEvent(`${type}:connect`, { bubbles: true }));
+        }
+    }
+
+    removeEventListener(type: string, listener: EventListener, options?: boolean | EventListenerOptions) {
+        if (this._listeners[type]) {
+            this._listeners[type] = this._listeners[type].filter((l) => l !== listener);
+        }
+        super.removeEventListener(type, listener, options);
+        if (type.startsWith('pointer')) {
+            this.dispatchEvent(new CustomEvent(`${type}:disconnect`, { bubbles: true }));
+        }
+    }
+
+    /**
+     * Whether the element has a listener for an event type, registered either with
+     * {@link addEventListener} or with the matching inline `onpointer*` attribute. Read by the
+     * containing `<pc-app>` element to gate pointer event synthesis.
+     *
+     * @param type - The event type.
+     * @returns Whether a listener is registered.
+     * @internal
+     */
+    _hasListeners(type: string): boolean {
+        return Boolean(this._listeners[type]?.length) || this._inlineHandlerTypes.has(type);
+    }
+}
+
+export { EntityBaseElement, POINTER_ATTRIBUTES };

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -1,8 +1,7 @@
 import type { AppBase } from 'playcanvas';
 import { Entity, Vec3 } from 'playcanvas';
 
-import type { AppElement } from './app';
-import { AsyncElement } from './async-element';
+import { EntityBaseElement, POINTER_ATTRIBUTES } from './entity-base';
 import { parseBool, parseTags, parseVec3 } from './parse';
 
 /**
@@ -29,7 +28,7 @@ import { parseBool, parseTags, parseVec3 } from './parse';
  * @fires {PointerEvent} pointerdown - Fired when a pointer button is pressed over the entity.
  * @fires {PointerEvent} pointerup - Fired when a pointer button is released over the entity.
  */
-class EntityElement extends AsyncElement {
+class EntityElement extends EntityBaseElement {
     /**
      * Whether the entity is enabled.
      */
@@ -61,37 +60,9 @@ class EntityElement extends AsyncElement {
     private _tags: string[] = [];
 
     /**
-     * The pointer event listeners for the entity.
-     */
-    private _listeners: Record<string, EventListener[]> = {};
-
-    /**
-     * The event types for which an inline `onpointer*` attribute is currently present.
-     */
-    private _inlineHandlerTypes = new Set<string>();
-
-    /**
      * Whether the hierarchy has been built for this entity.
      */
     private _built = false;
-
-    private _entity: Entity | null = null;
-
-    /**
-     * The application element this entity is registered with, cached at creation time so the
-     * entity can be unregistered even once this element has left the DOM.
-     */
-    private _appElement: AppElement | null = null;
-
-    /**
-     * The PlayCanvas entity instance. `null` until the element is ready, and again once it has
-     * been removed from the document — await {@link whenReady} or the element's `ready()`
-     * promise before accessing it.
-     * @returns The entity instance, or `null`.
-     */
-    get entity(): Entity | null {
-        return this._entity;
-    }
 
     /**
      * Creates the backing entity. Called by the containing `<pc-app>` element during its boot
@@ -124,13 +95,11 @@ class EntityElement extends AsyncElement {
             entity.tags.add(this._tags);
         }
 
-        // Register with the owning application, which joins engine nodes back to elements by
-        // identity (never by name), and hook the entity's destruction. The engine fires 'destroy'
-        // for every entity in a destroyed subtree, so the element learns of its entity's death no
-        // matter who causes it: this element, an ancestor, the whole application, or a user
-        // script calling entity.destroy().
-        this._appElement = this.closestApp;
-        this._appElement?._registerEntityElement(entity, this);
+        // Register with the owning application and hook the entity's destruction. The engine
+        // fires 'destroy' for every entity in a destroyed subtree, so the element learns of its
+        // entity's death no matter who causes it: this element, an ancestor, the whole
+        // application, or a user script calling entity.destroy().
+        this._registerEntity(entity);
         entity.once('destroy', this._onEntityDestroy, this);
     }
 
@@ -144,27 +113,35 @@ class EntityElement extends AsyncElement {
      * @param entity - The entity that was destroyed.
      */
     private _onEntityDestroy(entity: Entity) {
-        this._appElement?._unregisterEntityElement(entity);
-        this._appElement = null;
+        this._unregisterEntity(entity);
         this._entity = null;
         this._built = false;
         this._resetReady();
     }
 
     /**
-     * Parents the backing entity: under the entity of the nearest ancestor `<pc-entity>` when
-     * there is one, and under the application root otherwise. Called by the containing `<pc-app>`
-     * element once a sweep has created every entity, so a parent's existence never depends on
-     * document order.
+     * Parents the backing entity: under the entity of the nearest ancestor `<pc-entity>` or
+     * `<pc-node>` when there is one, and under the application root otherwise. Called by the
+     * containing `<pc-app>` element once a sweep has created every entity, so a parent's
+     * existence never depends on document order.
      *
      * @param app - The application whose root adopts parentless entities.
      * @internal
      */
     _buildHierarchy(app: AppBase) {
         if (!this.entity || this._built) return;
-        this._built = true;
 
         const closestEntity = this.closestEntity;
+
+        // A host element without an entity is an unresolved `<pc-node>`: building now would
+        // mis-anchor this entity to the application root while the host is still resolving.
+        // Stay unbuilt - the host drives this subtree itself once it binds.
+        if (closestEntity && !closestEntity.entity) {
+            return;
+        }
+
+        this._built = true;
+
         if (closestEntity?.entity) {
             closestEntity.entity.addChild(this.entity);
         } else {
@@ -328,45 +305,8 @@ class EntityElement extends AsyncElement {
         return this._tags;
     }
 
-    /**
-     * Tracks whether an inline `onpointer*` attribute is present. The browser itself compiles and
-     * runs these attributes — they are standard `GlobalEventHandlers`, so setting one replaces
-     * the previous handler and removing it removes the handler, exactly like `onclick` on any
-     * HTML element. But because they bypass {@link addEventListener}, the connect/disconnect
-     * bookkeeping that lets the application lazily attach its canvas pointer handlers must be
-     * kept in sync here.
-     *
-     * @param name - The attribute name (e.g. 'onpointerdown').
-     * @param value - The attribute value, or `null` when the attribute has been removed.
-     */
-    private _updateInlineHandler(name: string, value: string | null) {
-        const type = name.substring(2);
-        const had = this._inlineHandlerTypes.has(type);
-        const has = value !== null;
-
-        if (has && !had) {
-            this._inlineHandlerTypes.add(type);
-            this.dispatchEvent(new CustomEvent(`${type}:connect`, { bubbles: true }));
-        } else if (!has && had) {
-            this._inlineHandlerTypes.delete(type);
-            this.dispatchEvent(new CustomEvent(`${type}:disconnect`, { bubbles: true }));
-        }
-    }
-
     static get observedAttributes() {
-        return [
-            'enabled',
-            'name',
-            'position',
-            'rotation',
-            'scale',
-            'tags',
-            'onpointerenter',
-            'onpointerleave',
-            'onpointerdown',
-            'onpointerup',
-            'onpointermove'
-        ];
+        return ['enabled', 'name', 'position', 'rotation', 'scale', 'tags', ...POINTER_ATTRIBUTES];
     }
 
     attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
@@ -397,40 +337,6 @@ class EntityElement extends AsyncElement {
                 this._updateInlineHandler(name, newValue);
                 break;
         }
-    }
-
-    addEventListener(type: string, listener: EventListener, options?: boolean | AddEventListenerOptions) {
-        if (!this._listeners[type]) {
-            this._listeners[type] = [];
-        }
-        this._listeners[type].push(listener);
-        super.addEventListener(type, listener, options);
-        if (type.startsWith('pointer')) {
-            this.dispatchEvent(new CustomEvent(`${type}:connect`, { bubbles: true }));
-        }
-    }
-
-    removeEventListener(type: string, listener: EventListener, options?: boolean | EventListenerOptions) {
-        if (this._listeners[type]) {
-            this._listeners[type] = this._listeners[type].filter((l) => l !== listener);
-        }
-        super.removeEventListener(type, listener, options);
-        if (type.startsWith('pointer')) {
-            this.dispatchEvent(new CustomEvent(`${type}:disconnect`, { bubbles: true }));
-        }
-    }
-
-    /**
-     * Whether the element has a listener for an event type, registered either with
-     * {@link addEventListener} or with the matching inline `onpointer*` attribute. Read by the
-     * containing `<pc-app>` element to gate pointer event synthesis.
-     *
-     * @param type - The event type.
-     * @returns Whether a listener is registered.
-     * @internal
-     */
-    _hasListeners(type: string): boolean {
-        return Boolean(this._listeners[type]?.length) || this._inlineHandlerTypes.has(type);
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,8 +35,10 @@ import { ScriptElement } from './components/script';
 import { SoundComponentElement } from './components/sound-component';
 import { SoundSlotElement } from './components/sound-slot';
 import { GSplatComponentElement } from './components/gsplat-component';
+import { EntityBaseElement } from './entity-base';
 import { MaterialElement } from './material';
 import { ModelElement } from './model';
+import { NodeElement } from './node';
 import { SceneElement } from './scene';
 import { SkyElement } from './sky';
 
@@ -69,6 +71,7 @@ declare global {
         'pc-material': MaterialElement;
         'pc-model': ModelElement;
         'pc-module': ModuleElement;
+        'pc-node': NodeElement;
         'pc-particles': ParticleSystemComponentElement;
         'pc-render': RenderComponentElement;
         'pc-rigidbody': RigidBodyComponentElement;
@@ -110,8 +113,10 @@ export {
     SoundComponentElement,
     SoundSlotElement,
     GSplatComponentElement,
+    EntityBaseElement,
     MaterialElement,
     ModelElement,
+    NodeElement,
     SceneElement,
     SkyElement,
     whenReady

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,0 +1,699 @@
+import type { Entity, EventHandle, GraphNode, Quat } from 'playcanvas';
+import { Vec3 } from 'playcanvas';
+
+import type { EntityElement } from './entity';
+import { EntityBaseElement, POINTER_ATTRIBUTES } from './entity-base';
+import { ModelElement } from './model';
+import { parseBool, parseTags, parseVec3 } from './parse';
+
+/**
+ * The binding states a `<pc-node>` element moves through. `pending` while the host has not yet
+ * instantiated (or no `name` is assigned), `bound` once a node has been resolved and decorated,
+ * `missing`/`ambiguous`/`duplicate` when resolution failed — each accompanied by a warning
+ * naming the cause.
+ */
+type NodeBindingState = 'pending' | 'bound' | 'missing' | 'ambiguous' | 'duplicate';
+
+/**
+ * The authored values a bound node's overrides displaced, captured per property when the first
+ * override of that property applies and restored when the override clears.
+ */
+type AuthoredState = {
+    enabled?: boolean;
+    position?: Vec3;
+    rotation?: Quat;
+    scale?: Vec3;
+    tags?: string[];
+};
+
+/**
+ * Computes the Levenshtein distance between two strings, for near-miss suggestions in the
+ * resolution warnings.
+ *
+ * @param a - The first string.
+ * @param b - The second string.
+ * @returns The edit distance.
+ */
+const levenshtein = (a: string, b: string): number => {
+    const row = Array.from({ length: b.length + 1 }, (_, i) => i);
+    for (let i = 1; i <= a.length; i++) {
+        let previous = row[0];
+        row[0] = i;
+        for (let j = 1; j <= b.length; j++) {
+            const current = row[j];
+            row[j] = Math.min(row[j] + 1, row[j - 1] + 1, previous + (a[i - 1] === b[j - 1] ? 0 : 1));
+            previous = current;
+        }
+    }
+    return row[b.length];
+};
+
+/**
+ * The NodeElement interface provides properties and methods for manipulating
+ * {@link https://developer.playcanvas.com/user-manual/web-components/tags/pc-node/ | `<pc-node>`}
+ * elements. The NodeElement interface also inherits the properties and methods of the
+ * {@link HTMLElement} interface.
+ *
+ * A `pc-node` is an override element: where `pc-entity` creates an entity, `pc-node` binds to a
+ * node a `pc-model` loaded and declares overrides against the authored asset — components to
+ * add, properties to change, content to attach. Attributes present apply as overrides; attributes
+ * absent leave authored values untouched, and removing an attribute (or assigning `null` to the
+ * matching property) restores the authored value.
+ *
+ * `name` selects among the host model's nodes (first match in depth-first order), nesting a
+ * `pc-node` inside another scopes the search to that subtree, and `index` picks among identically
+ * named matches. When `name` matches more than one node and no `index` is given, the element
+ * warns and binds nothing.
+ *
+ * The element becomes ready once bound. It never becomes ready while unresolved — a missing or
+ * ambiguous name warns and leaves the element pending, and descendants wait with it.
+ *
+ * The pointer events below are dispatched by the containing `<pc-app>` element when the pointer
+ * intersects the bound node's geometry, exactly as for `<pc-entity>`.
+ *
+ * @attribute {string} name - The name of the node to bind, resolved within the nearest ancestor
+ * `pc-model` (or `pc-node`) once it has instantiated.
+ * @attribute {number} index - Which match to bind when `name` matches more than one node,
+ * 0-based in depth-first order. Optional for a unique match; required for an ambiguous one.
+ * @attribute {boolean} enabled - Overrides the node's enabled state.
+ * @attribute {string} position - Overrides the node's local position, as an "x y z" triple.
+ * @attribute {string} rotation - Overrides the node's local rotation (Euler angles), as an
+ * "x y z" triple.
+ * @attribute {string} scale - Overrides the node's local scale, as an "x y z" triple.
+ * @attribute {string} tags - Overrides the node's tags, separated by spaces or commas.
+ * @attribute {string} onpointerenter - Script to run when the pointer moves onto the node.
+ * @attribute {string} onpointerleave - Script to run when the pointer moves off the node.
+ * @attribute {string} onpointermove - Script to run when the pointer moves over the node.
+ * @attribute {string} onpointerdown - Script to run when a pointer button is pressed over the
+ * node.
+ * @attribute {string} onpointerup - Script to run when a pointer button is released over the
+ * node.
+ * @fires {PointerEvent} pointerenter - Fired when the pointer moves onto the node.
+ * @fires {PointerEvent} pointerleave - Fired when the pointer moves off the node.
+ * @fires {PointerEvent} pointermove - Fired when the pointer moves over the node.
+ * @fires {PointerEvent} pointerdown - Fired when a pointer button is pressed over the node.
+ * @fires {PointerEvent} pointerup - Fired when a pointer button is released over the node.
+ */
+class NodeElement extends EntityBaseElement {
+    private _name = '';
+
+    private _index: number | null = null;
+
+    private _state: NodeBindingState = 'pending';
+
+    private _path: string | null = null;
+
+    /**
+     * The element whose entity roots this element's search: the nearest ancestor `pc-node`, or
+     * failing that the nearest ancestor `pc-model`. Resolved on connection.
+     */
+    private _host: ModelElement | NodeElement | null = null;
+
+    /**
+     * The listener following the host's binding cycles. Both host kinds announce each cycle
+     * with a `ready` event — `pc-model` on every instantiation, `pc-node` on every bind.
+     */
+    private _hostListener: EventListener | null = null;
+
+    /**
+     * The subscription to the bound entity's destruction, detached on unbind so a retargeted
+     * element cannot be reset by the eventual death of a node it no longer fronts.
+     */
+    private _destroyHandle: EventHandle | null = null;
+
+    /** The authored values displaced by this element's overrides, captured per property. */
+    private _authored: AuthoredState = {};
+
+    // Override values. `null` means "no override": the authored value stays in force.
+
+    private _enabled: boolean | null = null;
+
+    private _position: Vec3 | null = null;
+
+    private _rotation: Vec3 | null = null;
+
+    private _scale: Vec3 | null = null;
+
+    private _tags: string[] | null = null;
+
+    /**
+     * The binding state: `pending` until the host instantiates and `name` resolves, `bound`
+     * once decorated, `missing`/`ambiguous`/`duplicate` when resolution failed (each also
+     * warns). Useful for asserting a document's bindings programmatically.
+     * @returns The binding state.
+     */
+    get state(): NodeBindingState {
+        return this._state;
+    }
+
+    /**
+     * The path of the bound node below the search root, `/`-separated, or `null` while not
+     * bound.
+     * @returns The bound node's path, or `null`.
+     */
+    get path(): string | null {
+        return this._path;
+    }
+
+    connectedCallback() {
+        const host = (this.parentElement?.closest('pc-model, pc-node') ?? null) as
+            | ModelElement
+            | NodeElement
+            | null;
+        if (!host) {
+            const label = this._name ? ` '${this._name}'` : '';
+            console.warn(`pc-node${label} must be a descendant of pc-model - node not bound`);
+            return;
+        }
+
+        this._host = host;
+
+        // Follow the host's binding cycles. `ready` bubbles, so cycles of elements nested under
+        // the host pass through it - only the host's own count.
+        this._hostListener = (event: Event) => {
+            if (event.target !== this._host) {
+                return;
+            }
+            this._rebind();
+        };
+        host.addEventListener('ready', this._hostListener);
+
+        // The host may already be instantiated (an element inserted after load binds immediately)
+        this._rebind();
+    }
+
+    disconnectedCallback() {
+        if (this._host && this._hostListener) {
+            this._host.removeEventListener('ready', this._hostListener);
+        }
+        this._host = null;
+        this._hostListener = null;
+
+        // Removal reverts: the model owns the node, so the entity is left as authored. Children
+        // clean up through their own disconnect behavior.
+        this._unbind();
+        this._state = 'pending';
+    }
+
+    /**
+     * Re-resolves the binding against the host's current hierarchy: on connection, on a `name`
+     * or `index` change, and on every host cycle (a model [re]instantiating, an enclosing
+     * `pc-node` [re]binding). When re-resolution yields the entity already bound, the binding
+     * is retained untouched — a redundant edit must not flicker overrides through a revert.
+     */
+    private _rebind() {
+        const hostEntity = this._host?.entity ?? null;
+
+        if (!hostEntity || !this._name) {
+            // Host not instantiated (or nothing to look up yet): return to pending. An assigned
+            // name arriving later, or the host's next cycle, resolves it.
+            this._unbind();
+            this._state = 'pending';
+            return;
+        }
+
+        const target = this._resolve(hostEntity);
+
+        if (target && target === this._entity) {
+            this._path = this._pathOf(target, hostEntity);
+            return;
+        }
+
+        this._unbind();
+
+        if (!target) {
+            // _resolve warned and set the failure state
+            return;
+        }
+
+        this._bind(target, hostEntity);
+    }
+
+    /**
+     * Resolves `name` (and `index`) to an entity under `hostEntity`, warning and recording the
+     * failure state when it cannot.
+     *
+     * @param hostEntity - The root of the search.
+     * @returns The resolved entity, or `null`.
+     */
+    private _resolve(hostEntity: Entity): Entity | null {
+        const matches = hostEntity.find((node: GraphNode) => node.name === this._name) as Entity[];
+
+        if (matches.length === 0) {
+            const closest = this._closestName(hostEntity);
+            const hint = closest ? ` - closest match: '${closest}'` : '';
+            console.warn(`pc-node '${this._name}' not found in ${this._describeHost()}${hint}`);
+            this._state = 'missing';
+            return null;
+        }
+
+        let target: Entity;
+        if (this._index !== null) {
+            if (this._index >= matches.length) {
+                console.warn(
+                    `pc-node '${this._name}' index ${this._index} is out of range - ${matches.length} match(es) in ${this._describeHost()}`
+                );
+                this._state = 'missing';
+                return null;
+            }
+            target = matches[this._index];
+        } else if (matches.length > 1) {
+            // Ambiguity binds nothing: a fallback guess performs side effects on the wrong
+            // scene node, and would go wrong silently when a re-export introduces a duplicate
+            // name. The candidates tell the author exactly what to write.
+            const candidates = matches.map((m, i) => `[${i}] ${this._pathOf(m, hostEntity)}`).join(', ');
+            console.warn(
+                `pc-node '${this._name}' is ambiguous in ${this._describeHost()} - specify index: ${candidates}`
+            );
+            this._state = 'ambiguous';
+            return null;
+        } else {
+            target = matches[0];
+        }
+
+        const owner = this.closestApp?.elementFromEntity(target);
+        if (owner && owner !== this) {
+            console.warn(
+                `pc-node '${this._name}' resolves to a node already bound by another element - element ignored`
+            );
+            this._state = 'duplicate';
+            return null;
+        }
+
+        return target;
+    }
+
+    /**
+     * Binds `target`: registers it (making it a pick target), hooks its destruction, applies
+     * this element's overrides, announces readiness and builds the deferred child subtree.
+     *
+     * @param target - The entity to bind.
+     * @param hostEntity - The search root, for the path.
+     */
+    private _bind(target: Entity, hostEntity: Entity) {
+        this._entity = target;
+        this._registerEntity(target);
+        this._destroyHandle = target.once('destroy', this._onEntityDestroy, this);
+        this._state = 'bound';
+        this._path = this._pathOf(target, hostEntity);
+
+        this._applyOverrides();
+        this._onReady();
+        this._buildChildren();
+    }
+
+    /**
+     * Dissolves the current binding, restoring every authored value this element's overrides
+     * displaced and destroying the entities its child `pc-entity` elements created (they are
+     * re-created against the next binding). Safe to call in any state.
+     */
+    private _unbind() {
+        const entity = this._entity;
+        if (!entity) {
+            return;
+        }
+
+        this._revertOverrides();
+
+        // Attachment points anchor to the bound node, so they cannot outlive the binding. Each
+        // destroyed entity resets its element, which the next _buildChildren re-creates.
+        this.querySelectorAll<EntityElement>('pc-entity').forEach((child) => {
+            child.entity?.destroy();
+        });
+
+        this._destroyHandle?.off();
+        this._destroyHandle = null;
+        this._unregisterEntity(entity);
+        this._entity = null;
+        this._path = null;
+        this._authored = {};
+        this._resetReady();
+    }
+
+    /**
+     * Handles the destruction of the bound entity - its model unloading, reloading, or a script
+     * destroying it. There is nothing to revert on a destroyed entity; the element returns to
+     * pending and the host's next cycle re-resolves it.
+     */
+    private _onEntityDestroy(entity: Entity) {
+        this._destroyHandle = null;
+        this._unregisterEntity(entity);
+        this._entity = null;
+        this._path = null;
+        this._authored = {};
+        this._state = 'pending';
+        this._resetReady();
+    }
+
+    /**
+     * Creates and parents the entities of child `pc-entity` elements - the attachment points.
+     * Mirrors the runtime-insertion path in EntityElement.connectedCallback: children were
+     * deferred while this host was unresolved (or reset when a previous binding dissolved), and
+     * build here once it binds.
+     */
+    private _buildChildren() {
+        const app = this.closestApp?.app;
+        if (!app) {
+            return;
+        }
+        const childEntities = this.querySelectorAll<EntityElement>('pc-entity');
+        childEntities.forEach((child) => {
+            child._createEntity(app);
+        });
+        childEntities.forEach((child) => {
+            child._buildHierarchy(app);
+        });
+    }
+
+    /**
+     * Applies every override that is explicitly set, capturing the authored value it displaces.
+     */
+    private _applyOverrides() {
+        if (this._enabled !== null) {
+            this.enabled = this._enabled;
+        }
+        if (this._position !== null) {
+            this.position = this._position;
+        }
+        if (this._rotation !== null) {
+            this.rotation = this._rotation;
+        }
+        if (this._scale !== null) {
+            this.scale = this._scale;
+        }
+        if (this._tags !== null) {
+            this.tags = this._tags;
+        }
+    }
+
+    /**
+     * Restores every authored value this element's overrides displaced. The override values
+     * themselves are kept - they re-apply on the next binding.
+     */
+    private _revertOverrides() {
+        const entity = this._entity!;
+        const authored = this._authored;
+        if (authored.enabled !== undefined) {
+            entity.enabled = authored.enabled;
+        }
+        if (authored.position) {
+            entity.setLocalPosition(authored.position);
+        }
+        if (authored.rotation) {
+            entity.setLocalRotation(authored.rotation);
+        }
+        if (authored.scale) {
+            entity.setLocalScale(authored.scale);
+        }
+        if (authored.tags) {
+            entity.tags.clear();
+            entity.tags.add(authored.tags);
+        }
+        this._authored = {};
+    }
+
+    /**
+     * Renders the path of `node` below `root`, for the `path` property and the resolution
+     * warnings.
+     *
+     * @param node - The node to describe.
+     * @param root - The search root.
+     * @returns The `/`-separated path.
+     */
+    private _pathOf(node: GraphNode, root: GraphNode): string {
+        const parts: string[] = [];
+        for (let current: GraphNode | null = node; current && current !== root; current = current.parent) {
+            parts.unshift(current.name);
+        }
+        return parts.join('/') || node.name;
+    }
+
+    /**
+     * Describes the search root for warnings: the model's asset id, or the enclosing node's
+     * name.
+     * @returns The description.
+     */
+    private _describeHost(): string {
+        if (this._host instanceof ModelElement) {
+            return `model '${this._host.asset}'`;
+        }
+        return `pc-node '${this._host?.name ?? ''}' subtree`;
+    }
+
+    /**
+     * Finds the node name nearest to the missing `name`, for the miss warning. The names are
+     * already in hand from resolution, so the suggestion is nearly free.
+     *
+     * @param hostEntity - The root of the search.
+     * @returns The closest name within an edit distance of 2, or `null`.
+     */
+    private _closestName(hostEntity: Entity): string | null {
+        let best: string | null = null;
+        let bestDistance = 3;
+        hostEntity.find((node: GraphNode) => {
+            const distance = levenshtein(this._name, node.name);
+            if (distance < bestDistance) {
+                bestDistance = distance;
+                best = node.name;
+            }
+            return false;
+        });
+        return best;
+    }
+
+    /**
+     * Sets the name of the node to bind. A change retargets: the current binding's overrides
+     * revert and the new name resolves afresh. `name` on a `pc-node` is never a rename of the
+     * authored node - it is only ever a reference.
+     * @param value - The node name.
+     */
+    set name(value: string) {
+        this._name = value;
+        if (this.isConnected && this._host) {
+            this._rebind();
+        }
+    }
+
+    /**
+     * Gets the name of the node to bind.
+     * @returns The node name.
+     */
+    get name(): string {
+        return this._name;
+    }
+
+    /**
+     * Sets which match to bind when `name` matches more than one node, 0-based in depth-first
+     * order. A change retargets, like `name`. `null` means unset - required when the name is
+     * ambiguous, optional otherwise.
+     * @param value - The match index, or `null`.
+     */
+    set index(value: number | null) {
+        this._index = value;
+        if (this.isConnected && this._host) {
+            this._rebind();
+        }
+    }
+
+    /**
+     * Gets which match to bind.
+     * @returns The match index, or `null` when unset.
+     */
+    get index(): number | null {
+        return this._index;
+    }
+
+    /**
+     * Sets the enabled override. `null` clears it, restoring the authored state.
+     * @param value - The enabled state, or `null`.
+     */
+    set enabled(value: boolean | null) {
+        this._enabled = value;
+        const entity = this._state === 'bound' ? this._entity : null;
+        if (!entity) {
+            return;
+        }
+        if (value !== null) {
+            this._authored.enabled ??= entity.enabled;
+            entity.enabled = value;
+        } else if (this._authored.enabled !== undefined) {
+            entity.enabled = this._authored.enabled;
+            delete this._authored.enabled;
+        }
+    }
+
+    /**
+     * Gets the enabled override.
+     * @returns The enabled state, or `null` while no override is set.
+     */
+    get enabled(): boolean | null {
+        return this._enabled;
+    }
+
+    /**
+     * Sets the local position override. `null` clears it, restoring the authored position.
+     * @param value - The position, or `null`.
+     */
+    set position(value: Vec3 | null) {
+        this._position = value;
+        const entity = this._state === 'bound' ? this._entity : null;
+        if (!entity) {
+            return;
+        }
+        if (value !== null) {
+            this._authored.position ??= entity.getLocalPosition().clone();
+            entity.setLocalPosition(value);
+        } else if (this._authored.position) {
+            entity.setLocalPosition(this._authored.position);
+            delete this._authored.position;
+        }
+    }
+
+    /**
+     * Gets the local position override.
+     * @returns The position, or `null` while no override is set.
+     */
+    get position(): Vec3 | null {
+        return this._position;
+    }
+
+    /**
+     * Sets the local rotation override, as Euler angles in degrees. `null` clears it, restoring
+     * the authored rotation.
+     * @param value - The rotation, or `null`.
+     */
+    set rotation(value: Vec3 | null) {
+        this._rotation = value;
+        const entity = this._state === 'bound' ? this._entity : null;
+        if (!entity) {
+            return;
+        }
+        if (value !== null) {
+            // The authored rotation is cached as a quaternion: it restores exactly, where a
+            // round trip through Euler angles need not.
+            this._authored.rotation ??= entity.getLocalRotation().clone();
+            entity.setLocalEulerAngles(value);
+        } else if (this._authored.rotation) {
+            entity.setLocalRotation(this._authored.rotation);
+            delete this._authored.rotation;
+        }
+    }
+
+    /**
+     * Gets the local rotation override.
+     * @returns The rotation, or `null` while no override is set.
+     */
+    get rotation(): Vec3 | null {
+        return this._rotation;
+    }
+
+    /**
+     * Sets the local scale override. `null` clears it, restoring the authored scale.
+     * @param value - The scale, or `null`.
+     */
+    set scale(value: Vec3 | null) {
+        this._scale = value;
+        const entity = this._state === 'bound' ? this._entity : null;
+        if (!entity) {
+            return;
+        }
+        if (value !== null) {
+            this._authored.scale ??= entity.getLocalScale().clone();
+            entity.setLocalScale(value);
+        } else if (this._authored.scale) {
+            entity.setLocalScale(this._authored.scale);
+            delete this._authored.scale;
+        }
+    }
+
+    /**
+     * Gets the local scale override.
+     * @returns The scale, or `null` while no override is set.
+     */
+    get scale(): Vec3 | null {
+        return this._scale;
+    }
+
+    /**
+     * Sets the tags override. `null` clears it, restoring the authored tags.
+     * @param value - The tags, or `null`.
+     */
+    set tags(value: string[] | null) {
+        this._tags = value;
+        const entity = this._state === 'bound' ? this._entity : null;
+        if (!entity) {
+            return;
+        }
+        if (value !== null) {
+            this._authored.tags ??= entity.tags.list().slice();
+            entity.tags.clear();
+            entity.tags.add(value);
+        } else if (this._authored.tags) {
+            entity.tags.clear();
+            entity.tags.add(this._authored.tags);
+            delete this._authored.tags;
+        }
+    }
+
+    /**
+     * Gets the tags override.
+     * @returns The tags, or `null` while no override is set.
+     */
+    get tags(): string[] | null {
+        return this._tags;
+    }
+
+    static get observedAttributes() {
+        return ['enabled', 'index', 'name', 'position', 'rotation', 'scale', 'tags', ...POINTER_ATTRIBUTES];
+    }
+
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
+        switch (name) {
+            case 'enabled':
+                this.enabled = newValue === null ? null : parseBool(newValue, true);
+                break;
+            case 'index':
+                if (newValue === null) {
+                    this.index = null;
+                } else {
+                    // Number('') is 0, which would make index="" silently mean the first match
+                    const index = newValue.trim() === '' ? NaN : Number(newValue);
+                    if (!Number.isInteger(index) || index < 0) {
+                        // Invalid values are treated as absent: under ambiguity that means
+                        // unbound, the fail-safe direction.
+                        console.warn(`pc-node index '${newValue}' is not a non-negative integer - treated as absent`);
+                        this.index = null;
+                    } else {
+                        this.index = index;
+                    }
+                }
+                break;
+            case 'name':
+                this.name = newValue ?? '';
+                break;
+            case 'position':
+                this.position = newValue === null ? null : parseVec3(newValue, Vec3.ZERO, name);
+                break;
+            case 'rotation':
+                this.rotation = newValue === null ? null : parseVec3(newValue, Vec3.ZERO, name);
+                break;
+            case 'scale':
+                this.scale = newValue === null ? null : parseVec3(newValue, Vec3.ONE, name);
+                break;
+            case 'tags':
+                this.tags = newValue === null ? null : parseTags(newValue);
+                break;
+            case 'onpointerenter':
+            case 'onpointerleave':
+            case 'onpointerdown':
+            case 'onpointerup':
+            case 'onpointermove':
+                this._updateInlineHandler(name, newValue);
+                break;
+        }
+    }
+}
+
+customElements.define('pc-node', NodeElement);
+
+export { NodeElement };

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,6 +1,7 @@
 import type { Entity, EventHandle, GraphNode, Quat } from 'playcanvas';
 import { Vec3 } from 'playcanvas';
 
+import { ComponentElement } from './components/component';
 import type { EntityElement } from './entity';
 import { EntityBaseElement, POINTER_ATTRIBUTES } from './entity-base';
 import { ModelElement } from './model';
@@ -65,8 +66,9 @@ const levenshtein = (a: string, b: string): number => {
  * named matches. When `name` matches more than one node and no `index` is given, the element
  * warns and binds nothing.
  *
- * The element becomes ready once bound. It never becomes ready while unresolved — a missing or
- * ambiguous name warns and leaves the element pending, and descendants wait with it.
+ * The element becomes ready once bound, and never while unresolved — a missing or ambiguous
+ * name warns and records the failure in `state`, readiness stays unresolved, and descendants
+ * wait with it.
  *
  * The pointer events below are dispatched by the containing `<pc-app>` element when the pointer
  * intersects the bound node's geometry, exactly as for `<pc-entity>`.
@@ -304,8 +306,10 @@ class NodeElement extends EntityBaseElement {
 
     /**
      * Dissolves the current binding, restoring every authored value this element's overrides
-     * displaced and destroying the entities its child `pc-entity` elements created (they are
-     * re-created against the next binding). Safe to call in any state.
+     * displaced and removing the decorations this binding hosts: attachment entities are
+     * destroyed (re-created against the next binding) and component decorations are removed
+     * from the abandoned node. Both sweeps are scoped by `closestEntity`, so a still-bound
+     * nested `pc-node` keeps its own decorations. Safe to call in any state.
      */
     private _unbind() {
         const entity = this._entity;
@@ -318,7 +322,9 @@ class NodeElement extends EntityBaseElement {
         // Attachment points anchor to the bound node, so they cannot outlive the binding. Each
         // destroyed entity resets its element, which the next _buildChildren re-creates.
         this.querySelectorAll<EntityElement>('pc-entity').forEach((child) => {
-            child.entity?.destroy();
+            if (child.closestEntity === this) {
+                child.entity?.destroy();
+            }
         });
 
         this._destroyHandle?.off();
@@ -327,6 +333,16 @@ class NodeElement extends EntityBaseElement {
         this._entity = null;
         this._path = null;
         this._authored = {};
+
+        // Component decorations come off through the same hook the host-ready cycle uses. A
+        // dissolve that never rebinds fires no ready event, so the sweep is explicit - after
+        // `_entity` is cleared, so the hook sees a host without an entity.
+        this.querySelectorAll('*').forEach((child) => {
+            if (child instanceof ComponentElement && child.closestEntity === this) {
+                child._hostCycled();
+            }
+        });
+
         this._resetReady();
     }
 

--- a/test/helpers/dom.ts
+++ b/test/helpers/dom.ts
@@ -14,7 +14,7 @@ export type Mounted = {
 
 const mounted = new Set<Mounted>();
 
-const LIBRARY_SELECTOR = 'pc-app, pc-asset, pc-entity, pc-material, pc-model, pc-module, pc-scene, pc-sky';
+const LIBRARY_SELECTOR = 'pc-app, pc-asset, pc-entity, pc-material, pc-model, pc-module, pc-node, pc-scene, pc-sky';
 
 /**
  * Fails if a previous test left library elements in the document.

--- a/test/integration/node.test.ts
+++ b/test/integration/node.test.ts
@@ -1,0 +1,376 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CameraComponentElement } from '../../src/components/camera-component';
+import type { EntityElement } from '../../src/entity';
+import type { ModelElement } from '../../src/model';
+import type { NodeElement } from '../../src/node';
+import { bootApp } from '../helpers/app';
+import { mount } from '../helpers/dom';
+import { useGuard } from '../helpers/guard';
+import { expectNeverReady, readyWithin } from '../helpers/ready';
+
+/**
+ * A meshless glTF with the hierarchy the RFC's examples use. The two authored `Wheel` siblings
+ * do NOT survive parsing as duplicates: the engine's glb parser renames identically named
+ * SIBLINGS while building the hierarchy (`uniqueNames` in its node loop), so this instantiates
+ * as:
+ *
+ *     Chassis
+ *     ├── Wheel
+ *     ├── Wheel1   <- renamed by the engine
+ *     ├── Head
+ *     └── Spoiler
+ *
+ * Duplicate names under DIFFERENT parents survive (the rename is per-parent) - AXLES_SRC below
+ * covers that case, which is where ambiguity and `index` actually operate.
+ */
+const CAR_SRC = `data:application/json,${encodeURIComponent(JSON.stringify({
+    asset: { version: '2.0' },
+    scene: 0,
+    scenes: [{ nodes: [0] }],
+    nodes: [
+        { name: 'Chassis', children: [1, 2, 3, 4] },
+        { name: 'Wheel' },
+        { name: 'Wheel' },
+        { name: 'Head' },
+        { name: 'Spoiler' }
+    ]
+}))}`;
+
+/** Two identically named wheels in different assemblies, for the subtree-scoping tests. */
+const AXLES_SRC = `data:application/json,${encodeURIComponent(JSON.stringify({
+    asset: { version: '2.0' },
+    scene: 0,
+    scenes: [{ nodes: [0] }],
+    nodes: [
+        { name: 'Root', children: [1, 3] },
+        { name: 'FrontAxle', children: [2] },
+        { name: 'Wheel' },
+        { name: 'RearAxle', children: [4] },
+        { name: 'Wheel' }
+    ]
+}))}`;
+
+const CAR_ASSET = `<pc-asset id="car" type="container" src="${CAR_SRC}"></pc-asset>`;
+const AXLES_ASSET = `<pc-asset id="axles" type="container" src="${AXLES_SRC}"></pc-asset>`;
+
+describe('<pc-node>', () => {
+    const { uncaught, warnings } = useGuard();
+
+    /** Boots an app with the car model and the given pc-model children. */
+    const bootCar = async (modelChildren: string) => {
+        const booted = await bootApp(`${CAR_ASSET}<pc-model asset="car">${modelChildren}</pc-model>`);
+        return { ...booted, model: booted.get<ModelElement>('pc-model') };
+    };
+
+    /** Creates a pc-node with the given attributes and appends it to `parent`. */
+    const insertNode = (parent: Element, attributes: Record<string, string>) => {
+        const node = document.createElement('pc-node');
+        Object.entries(attributes).forEach(([key, value]) => node.setAttribute(key, value));
+        parent.appendChild(node);
+        return node;
+    };
+
+    describe('binding', () => {
+        it('binds a uniquely named node and registers it as a pick target', async () => {
+            const { appElement, get } = await bootCar('<pc-node name="Head"></pc-node>');
+            const node = get<NodeElement>('pc-node');
+
+            expect(node.state).toBe('bound');
+            expect(node.entity, 'the bound entity is the authored node').not.toBeNull();
+            expect(node.entity!.name).toBe('Head');
+            expect(node.path).toBe('Head');
+            expect(appElement.elementFromEntity(node.entity!), 'the identity map points back here').toBe(node);
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('binds immediately when inserted after the model has loaded', async () => {
+            const { model } = await bootCar('');
+
+            const node = insertNode(model, { name: 'Head' });
+
+            expect(node.state, 'no waiting - the hierarchy already exists').toBe('bound');
+            expect(node.entity!.name).toBe('Head');
+        });
+
+        it('applies component children to the bound node', async () => {
+            const { get } = await bootCar('<pc-node name="Head"><pc-camera></pc-camera></pc-node>');
+            const node = get<NodeElement>('pc-node');
+
+            expect(node.entity!.camera, 'the camera component landed on the glTF node').toBeDefined();
+        });
+
+        it('parents nested pc-entity content under the bound node', async () => {
+            const { get } = await bootCar('<pc-node name="Head"><pc-entity name="hat"></pc-entity></pc-node>');
+            const node = get<NodeElement>('pc-node');
+            const hat = get<EntityElement>('pc-entity[name="hat"]');
+
+            await readyWithin(hat);
+            expect(hat.entity!.parent, 'the attachment point anchors to the bound node').toBe(node.entity);
+        });
+
+        it('resolves a nested pc-node within the enclosing subtree', async () => {
+            // 'Wheel' appears once per axle: globally ambiguous, unique within RearAxle. Subtree
+            // scoping must bind the rear wheel without an ambiguity warning.
+            const { get } = await bootApp(
+                `${AXLES_ASSET}<pc-model asset="axles">
+                    <pc-node name="RearAxle"><pc-node name="Wheel"></pc-node></pc-node>
+                </pc-model>`
+            );
+            const wheel = get<NodeElement>('pc-node[name="Wheel"]');
+
+            expect(wheel.state).toBe('bound');
+            expect(wheel.entity!.parent!.name, 'the rear wheel, not the front one').toBe('RearAxle');
+        });
+    });
+
+    describe('resolution failures', () => {
+        it('warns with a near-miss suggestion and stays pending on a miss', async () => {
+            const { model } = await bootCar('');
+
+            const node = insertNode(model, { name: 'Weel' });
+
+            warnings.expect("pc-node 'Weel' not found in model 'car' - closest match: 'Wheel'");
+            expect(node.state).toBe('missing');
+            await expectNeverReady(node);
+        });
+
+        it('binds a sibling duplicate through the name the engine parser gave it', async () => {
+            // The parser renames identically named siblings (Wheel, Wheel1, ...), so sibling
+            // duplicates are addressed by their renamed names rather than by index. This pins
+            // that behavior: if the engine ever stops renaming, ambiguity semantics take over
+            // and this test will say so.
+            const { model } = await bootCar('');
+
+            const renamed = insertNode(model, { name: 'Wheel1' });
+            const original = insertNode(model, { name: 'Wheel' });
+
+            expect(renamed.state).toBe('bound');
+            expect(original.state).toBe('bound');
+            expect(renamed.entity, 'two siblings, two entities').not.toBe(original.entity);
+        });
+
+        it('warns listing candidate paths and binds nothing when the name is ambiguous', async () => {
+            // Cross-parent duplicates survive parsing (the rename is per-parent), so a wheel per
+            // axle is genuinely ambiguous from the model root
+            const { get } = await bootApp(`${AXLES_ASSET}<pc-model asset="axles"></pc-model>`);
+            const model = get<ModelElement>('pc-model');
+
+            const node = insertNode(model, { name: 'Wheel' });
+
+            warnings.expect(
+                "pc-node 'Wheel' is ambiguous in model 'axles' - specify index: [0] FrontAxle/Wheel, [1] RearAxle/Wheel"
+            );
+            expect(node.state).toBe('ambiguous');
+            expect(node.entity, 'ambiguity never binds a fallback').toBeNull();
+            await expectNeverReady(node);
+        });
+
+        it('selects among duplicate matches with index', async () => {
+            const { all } = await bootApp(
+                `${AXLES_ASSET}<pc-model asset="axles">
+                    <pc-node name="Wheel" index="0"></pc-node>
+                    <pc-node name="Wheel" index="1"></pc-node>
+                </pc-model>`
+            );
+            const [front, rear] = all<NodeElement>('pc-node');
+
+            expect(front.state).toBe('bound');
+            expect(rear.state).toBe('bound');
+            expect(front.entity!.parent!.name, 'index 0 is the first match in depth-first order').toBe('FrontAxle');
+            expect(rear.entity!.parent!.name, 'index 1 is the second').toBe('RearAxle');
+        });
+
+        it('warns and stays pending when index is out of range', async () => {
+            const { get } = await bootApp(`${AXLES_ASSET}<pc-model asset="axles"></pc-model>`);
+            const model = get<ModelElement>('pc-model');
+
+            const node = insertNode(model, { name: 'Wheel', index: '5' });
+
+            warnings.expect("pc-node 'Wheel' index 5 is out of range - 2 match(es) in model 'axles'");
+            expect(node.state).toBe('missing');
+            await expectNeverReady(node);
+        });
+
+        it('treats an invalid index as absent, with a warning', async () => {
+            const { model } = await bootCar('');
+
+            const node = insertNode(model, { name: 'Head', index: '1.5' });
+
+            warnings.expect("pc-node index '1.5' is not a non-negative integer - treated as absent");
+            expect(node.state, 'the unique name still binds without the index').toBe('bound');
+        });
+
+        it('warns and stays inert when a second element resolves to an already-bound node', async () => {
+            const { model, get } = await bootCar('<pc-node name="Head"></pc-node>');
+            const first = get<NodeElement>('pc-node');
+
+            const second = insertNode(model, { name: 'Head' });
+
+            warnings.expect("pc-node 'Head' resolves to a node already bound by another element - element ignored");
+            expect(second.state).toBe('duplicate');
+            expect(first.state, 'the first binding is untouched').toBe('bound');
+            await expectNeverReady(second);
+        });
+
+        it('warns and never becomes ready outside pc-model', async () => {
+            const handle = mount('<pc-node name="Head"></pc-node>');
+            const node = handle.get<NodeElement>('pc-node');
+
+            warnings.expect("pc-node 'Head' must be a descendant of pc-model - node not bound");
+            await expectNeverReady(node);
+        });
+
+        it('stays silently pending while no name is assigned', async () => {
+            const { model } = await bootCar('');
+
+            const node = insertNode(model, {});
+
+            expect(node.state).toBe('pending');
+            await expectNeverReady(node);
+        });
+    });
+
+    describe('overrides', () => {
+        it('applies attribute overrides and restores authored values on removal', async () => {
+            const { get } = await bootCar('<pc-node name="Head" enabled="false" position="1 2 3"></pc-node>');
+            const node = get<NodeElement>('pc-node');
+            const entity = node.entity!;
+
+            expect(entity.enabled, 'the enabled override applied').toBe(false);
+            expect(entity.getLocalPosition().x, 'the position override applied').toBe(1);
+
+            node.removeAttribute('enabled');
+            expect(entity.enabled, 'removal restores the authored state').toBe(true);
+
+            node.removeAttribute('position');
+            expect(entity.getLocalPosition().x, 'removal restores the authored position').toBe(0);
+        });
+
+        it('clears a property override with null-assignment', async () => {
+            const { get } = await bootCar('<pc-node name="Head"></pc-node>');
+            const node = get<NodeElement>('pc-node');
+
+            node.enabled = false;
+            expect(node.entity!.enabled).toBe(false);
+
+            node.enabled = null;
+            expect(node.entity!.enabled, 'null restores the authored state').toBe(true);
+            expect(node.enabled, 'the getter reports no override').toBeNull();
+        });
+
+        it('leaves authored values untouched while no override is set', async () => {
+            const { get } = await bootCar('<pc-node name="Head"></pc-node>');
+            const node = get<NodeElement>('pc-node');
+
+            // The element's own defaults must never write: an absent attribute means authored
+            expect(node.entity!.enabled).toBe(true);
+            expect(node.enabled).toBeNull();
+            expect(node.position).toBeNull();
+        });
+    });
+
+    describe('retargeting', () => {
+        it('moves overrides, components and attachments when name changes', async () => {
+            const { get } = await bootCar(
+                `<pc-node name="Head" enabled="false">
+                    <pc-camera></pc-camera>
+                    <pc-entity name="hat"></pc-entity>
+                </pc-node>`
+            );
+            const node = get<NodeElement>('pc-node');
+            const head = node.entity!;
+
+            node.setAttribute('name', 'Spoiler');
+
+            expect(node.state).toBe('bound');
+            expect(node.entity!.name).toBe('Spoiler');
+            expect(head.enabled, 'the override reverted on the old node').toBe(true);
+            expect(head.camera, 'the component left the old node').toBeUndefined();
+            expect(node.entity!.enabled, 'the override re-applied on the new node').toBe(false);
+            expect(node.entity!.camera, 'the component moved to the new node').toBeDefined();
+
+            const hat = get<EntityElement>('pc-entity[name="hat"]');
+            expect(hat.entity!.parent, 'the attachment point followed').toBe(node.entity);
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('retains the binding when re-resolution yields the same node', async () => {
+            const { get } = await bootCar('<pc-node name="Head" enabled="false"></pc-node>');
+            const node = get<NodeElement>('pc-node');
+            const entity = node.entity!;
+            const readyBefore = node.ready();
+
+            node.setAttribute('index', '0');
+
+            expect(node.entity, 'same entity, binding retained').toBe(entity);
+            expect(node.entity!.enabled, 'the override never flickered through a revert').toBe(false);
+            await expect(readyBefore, 'readiness never cycled').resolves.toBe(node);
+        });
+    });
+
+    describe('reload', () => {
+        it('rebinds and re-applies the whole decoration tree when the model reloads', async () => {
+            const { model, get } = await bootCar(
+                `<pc-node name="Head" enabled="false">
+                    <pc-camera></pc-camera>
+                    <pc-entity name="hat"></pc-entity>
+                </pc-node>`
+            );
+            const node = get<NodeElement>('pc-node');
+            const first = node.entity!;
+
+            // Re-setting the same asset id runs the full reload cycle
+            model.setAttribute('asset', 'car');
+            expect(node.entity, 'the old binding dissolved with the old hierarchy').toBeNull();
+
+            await readyWithin(node);
+            const second = node.entity!;
+
+            expect(second, 'a fresh entity from the new hierarchy').not.toBe(first);
+            expect(second.name).toBe('Head');
+            expect(second.enabled, 'the override re-applied').toBe(false);
+            expect(second.camera, 'the component re-applied').toBeDefined();
+
+            const hat = get<EntityElement>('pc-entity[name="hat"]');
+            await readyWithin(hat);
+            expect(hat.entity!.parent, 'the attachment point re-anchored').toBe(second);
+            expect(uncaught.seen).toEqual([]);
+        });
+    });
+
+    describe('removal', () => {
+        it('reverts overrides and removes decorations, leaving the authored node in place', async () => {
+            const { get } = await bootCar(
+                '<pc-node name="Head" enabled="false"><pc-camera></pc-camera></pc-node>'
+            );
+            const node = get<NodeElement>('pc-node');
+            const entity = node.entity!;
+
+            node.remove();
+
+            expect(entity.enabled, 'the override reverted').toBe(true);
+            expect(entity.camera, 'the component was removed').toBeUndefined();
+            expect(entity.parent, 'the authored node itself survives - the model owns it').not.toBeNull();
+            expect(node.state).toBe('pending');
+            expect(uncaught.seen).toEqual([]);
+        });
+    });
+});
+
+describe('component conflicts', () => {
+    const { warnings, uncaught } = useGuard();
+
+    it('warns and becomes ready with a null component when the type already exists', async () => {
+        const { all } = await bootApp(
+            '<pc-entity name="host"><pc-camera></pc-camera><pc-camera id="second"></pc-camera></pc-entity>'
+        );
+        const [first, second] = all<CameraComponentElement>('pc-camera');
+
+        await readyWithin(second);
+        expect(first.component, 'the first camera applied').not.toBeNull();
+        expect(second.component, 'the conflicting camera stayed null').toBeNull();
+        warnings.expect("pc-camera 'second' - 'host' already has a 'camera' component - component not added");
+        expect(uncaught.seen).toEqual([]);
+    });
+});

--- a/test/integration/node.test.ts
+++ b/test/integration/node.test.ts
@@ -295,6 +295,52 @@ describe('<pc-node>', () => {
             expect(uncaught.seen).toEqual([]);
         });
 
+        it('removes component decorations when the binding dissolves without a rebind', async () => {
+            const { get } = await bootCar('<pc-node name="Head"><pc-camera></pc-camera></pc-node>');
+            const node = get<NodeElement>('pc-node');
+            const head = node.entity!;
+            expect(head.camera).toBeDefined();
+
+            node.setAttribute('name', 'Nonexistent');
+
+            warnings.expect("pc-node 'Nonexistent' not found in model 'car'");
+            expect(node.state).toBe('missing');
+            expect(head.camera, 'the decoration left the abandoned node').toBeUndefined();
+
+            // Recovery: resolving again re-applies the decoration through the ready cycle
+            node.setAttribute('name', 'Head');
+            expect(node.state).toBe('bound');
+            expect(node.entity!.camera, 'the component re-applied on rebind').toBeDefined();
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it("leaves a still-bound nested pc-node's decorations alone when the ancestor unbinds", async () => {
+            const { get } = await bootApp(
+                `${AXLES_ASSET}<pc-model asset="axles">
+                    <pc-node name="RearAxle">
+                        <pc-node name="Wheel">
+                            <pc-camera></pc-camera>
+                            <pc-entity name="hub"></pc-entity>
+                        </pc-node>
+                    </pc-node>
+                </pc-model>`
+            );
+            const axle = get<NodeElement>('pc-node[name="RearAxle"]');
+            const wheel = get<NodeElement>('pc-node[name="Wheel"]');
+            const wheelEntity = wheel.entity!;
+            const hub = get<EntityElement>('pc-entity[name="hub"]');
+            expect(wheelEntity.camera).toBeDefined();
+
+            axle.setAttribute('name', 'Nope');
+
+            warnings.expect("pc-node 'Nope' not found in model 'axles'");
+            expect(axle.state).toBe('missing');
+            expect(wheel.state, 'the nested binding itself is untouched').toBe('bound');
+            expect(wheelEntity.camera, "the nested binding's component survives").toBeDefined();
+            expect(hub.entity?.parent, "the nested binding's attachment survives").toBe(wheelEntity);
+            expect(uncaught.seen).toEqual([]);
+        });
+
         it('retains the binding when re-resolution yields the same node', async () => {
             const { get } = await bootCar('<pc-node name="Head" enabled="false"></pc-node>');
             const node = get<NodeElement>('pc-node');

--- a/utils/cem/tags.mjs
+++ b/utils/cem/tags.mjs
@@ -12,8 +12,9 @@
 export const TAGS = [
     'pc-app', 'pc-asset', 'pc-button', 'pc-camera', 'pc-collision', 'pc-element', 'pc-entity',
     'pc-gsplat', 'pc-layoutchild', 'pc-layoutgroup', 'pc-light', 'pc-listener', 'pc-material',
-    'pc-model', 'pc-module', 'pc-particles', 'pc-render', 'pc-rigidbody', 'pc-scene', 'pc-screen',
-    'pc-script', 'pc-scripts', 'pc-scrollbar', 'pc-scrollview', 'pc-sky', 'pc-sound', 'pc-sounds'
+    'pc-model', 'pc-module', 'pc-node', 'pc-particles', 'pc-render', 'pc-rigidbody', 'pc-scene',
+    'pc-screen', 'pc-script', 'pc-scripts', 'pc-scrollbar', 'pc-scrollview', 'pc-sky', 'pc-sound',
+    'pc-sounds'
 ];
 
 /** The tags whose elements extend `ComponentElement`, and so inherit its `enabled` attribute. */

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -306,6 +306,7 @@ if (manifest) {
         ['pc-material', ['get', 'material', 'roughness', 'roughnessMap']],
         ['pc-model', ['entity', ...ASYNC_MEMBERS]],
         ['pc-module', []],
+        ['pc-node', ['addEventListener', 'entity', 'path', 'removeEventListener', 'state', ...ASYNC_MEMBERS]],
         ['pc-particles', ['component', 'pause', 'play', 'reset', 'stop', ...ASYNC_MEMBERS]],
         ['pc-scene', ['scene', ...ASYNC_MEMBERS]],
         ['pc-script', ['script', ...ASYNC_MEMBERS]],


### PR DESCRIPTION
## What

- New `<pc-node>` element — binds to a named node inside its `pc-model`'s instantiated hierarchy and declares overrides against the authored asset: components, property overrides (`enabled`, `position`, `rotation`, `scale`, `tags`), and attachment points (nested `pc-entity`/`pc-model`). The rule is one line: **`pc-entity` creates; `pc-node` overrides something a `pc-model` loaded.**
- **Resolution**: `name` (first match, depth-first), nested `pc-node` scopes the search to the enclosing subtree, `index` picks among duplicate matches. Every failure warns and refuses to bind: miss (with a near-miss suggestion), ambiguity (listing candidate paths with indices), out-of-range/invalid `index`, a node already bound by another element, and placement outside `pc-model`. Readonly `state`/`path` properties make bindings assertable without console parsing.
- **Override contract**: per-property tracking through both attribute and property surfaces; authored values cached at bind, restored on attribute removal, `null`-assignment (`node.enabled = null`), or unbind. `name`/`index` changes retarget (revert → re-resolve → re-apply), retaining the binding when resolution lands on the same entity. Model reloads dissolve bindings and converge the whole decoration tree to fresh-load state.
- **Pointer events**: bound nodes register in the entity→element identity map, so `onpointer*` on `pc-node` rides the existing pick resolution — hits on glTF sub-nodes resolve to the nearest bound `pc-node` instead of falling through to the element hosting the model.

## How

- `EntityBaseElement` extracted from `EntityElement` (entity contract, identity-map registration, pointer listener bookkeeping) — needed because `pc-node`'s nullable override accessors (`enabled: boolean | null`) can't widen `pc-entity`'s inherited types. `pc-entity`'s public API is unchanged.
- `ComponentElement` re-applies when its host's readiness cycles (target-checked listener on the host's `ready` event) — the RFC's "descendant re-decoration" mechanism. On retarget it removes itself from the still-live old entity first. A component type already present on the bound node warns and becomes ready with `component === null`; the element-level warning is load-bearing because the engine's duplicate-`addComponent` warning is `Debug`-stripped from production builds.
- `EntityElement._buildHierarchy` defers children of an unresolved host rather than mis-parenting them to the application root; the host builds its subtree when it binds.
- `closestEntity` and the two pointer-listener scans widen to `'pc-entity, pc-node'`; the boot sweeps are untouched (they query `pc-entity` and never see `pc-node`).

## Engine behavior discovered and pinned

The glb parser renames identically named **siblings** apart (`Wheel`, `Wheel1`, …) while building the hierarchy — per parent — so sibling duplicates never survive into instantiated hierarchies; duplicates under *different* parents do. A test pins this, so the suite will say so if the engine ever stops renaming. #297 has been updated accordingly.

## Testing

- 22 new integration tests: binding (including insert-after-load), all five warning classes, subtree scoping, `index` selection, overrides/revert/`null`-assignment, retargeting moving overrides+components+attachments, reload convergence, and removal semantics — plus a component-conflict test. Full suite: 600 tests green; lint, both type-check projects, and CEM validation (28 elements) clean.
- Real browser against the t-rex GLB: bound a skeleton bone 13 levels deep (`path` renders the full chain), verified identity-map pick registration, override apply/revert on the live animated entity, same-asset reload dissolve→rebind, and the near-miss warning text. Console clean.

Closes #297: with this, the RFC's design is settled and its core rollout is delivered — #352 landed the prerequisites, this lands the element. What remains is tracked in its own issues: the conveniences layer (`material` override, `hierarchy()`) in #354, and the mesh-collider dependency of the RFC's static-collider example in #350. The deferred path-syntax question stays recorded in the RFC, to be revisited only if nesting plus `index` prove insufficient in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
