### PR TITLE
Default mesh collider geometry to the host's render component

### DIFF
--- a/src/components/collision-component.ts
+++ b/src/components/collision-component.ts
@@ -11,6 +11,12 @@ import { ComponentElement } from './component';
  * The CollisionComponentElement interface also inherits the properties and methods of the
  * {@link HTMLElement} interface.
  *
+ * For `type="mesh"`, the collision geometry defaults to the host entity's own render component
+ * (its render asset) — a collider matching the visible mesh, which is what a mesh collider on a
+ * glTF node means. The default resolves each time the component applies, so a `pc-node` that
+ * retargets or rebinds picks up the new node's geometry. An entity with no asset-backed render
+ * component warns, and the collider has no shape.
+ *
  * @category Components
  */
 class CollisionComponentElement extends ComponentElement {
@@ -46,6 +52,25 @@ class CollisionComponentElement extends ComponentElement {
             radius: this._radius,
             type: this._type
         };
+    }
+
+    protected initComponent() {
+        const component = this.component;
+        if (!component || this._type !== 'mesh' || component.renderAsset !== null) {
+            return;
+        }
+
+        // The engine's mesh collider only works with explicitly supplied geometry, and the
+        // element has no attribute to supply it - so default to the host entity's own visible
+        // geometry, the meaning a mesh collider on a glTF node carries.
+        const asset = component.entity.render?.asset ?? null;
+        if (asset === null) {
+            console.warn(
+                `pc-collision type="mesh" on '${component.entity.name}' found no asset-backed render component to take geometry from - collider has no shape`
+            );
+            return;
+        }
+        component.renderAsset = asset;
     }
 
     /**

--- a/src/components/collision-component.ts
+++ b/src/components/collision-component.ts
@@ -55,14 +55,23 @@ class CollisionComponentElement extends ComponentElement {
     }
 
     protected initComponent() {
+        this._applyMeshGeometryDefault();
+    }
+
+    /**
+     * Defaults a mesh collider's geometry to the host entity's own render component. The
+     * engine's mesh collider only works with explicitly supplied geometry, and the element has
+     * no attribute to supply it - so the host's visible geometry, the meaning a mesh collider
+     * on a glTF node carries, fills the gap. Runs on every application (so a rebound `pc-node`
+     * recomputes it) and on a runtime switch to `type="mesh"`; an explicitly assigned
+     * `renderAsset` is never overwritten.
+     */
+    private _applyMeshGeometryDefault() {
         const component = this.component;
         if (!component || this._type !== 'mesh' || component.renderAsset !== null) {
             return;
         }
 
-        // The engine's mesh collider only works with explicitly supplied geometry, and the
-        // element has no attribute to supply it - so default to the host entity's own visible
-        // geometry, the meaning a mesh collider on a glTF node carries.
         const asset = component.entity.render?.asset ?? null;
         if (asset === null) {
             console.warn(
@@ -162,6 +171,7 @@ class CollisionComponentElement extends ComponentElement {
         this._type = value;
         if (this.component) {
             this.component.type = value;
+            this._applyMeshGeometryDefault();
         }
     }
 

--- a/test/integration/collision-mesh.test.ts
+++ b/test/integration/collision-mesh.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CollisionComponentElement } from '../../src/components/collision-component';
+import type { NodeElement } from '../../src/node';
+import { bootApp } from '../helpers/app';
+import { useGuard } from '../helpers/guard';
+import { readyWithin } from '../helpers/ready';
+
+/**
+ * A glTF with actual geometry - one triangle shared by two meshes - so instantiation produces
+ * render components with render assets, which is what the mesh-collider default reads. The
+ * vertex buffer is built here rather than pasted as opaque base64 (via btoa: the test tsconfig
+ * deliberately carries no node types, so Buffer is unavailable).
+ */
+const positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+const positionsBase64 = btoa(String.fromCharCode(...new Uint8Array(positions.buffer)));
+const MESH_SRC = `data:application/json,${encodeURIComponent(JSON.stringify({
+    asset: { version: '2.0' },
+    scene: 0,
+    scenes: [{ nodes: [0] }],
+    nodes: [
+        { name: 'Root', children: [1, 2] },
+        { name: 'Body', mesh: 0 },
+        { name: 'Glass', mesh: 1 }
+    ],
+    meshes: [
+        { primitives: [{ attributes: { POSITION: 0 } }] },
+        { primitives: [{ attributes: { POSITION: 0 } }] }
+    ],
+    accessors: [
+        { bufferView: 0, componentType: 5126, count: 3, type: 'VEC3', min: [0, 0, 0], max: [1, 1, 0] }
+    ],
+    bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: positions.byteLength }],
+    buffers: [
+        {
+            uri: `data:application/octet-stream;base64,${positionsBase64}`,
+            byteLength: positions.byteLength
+        }
+    ]
+}))}`;
+
+const MESH_ASSET = `<pc-asset id="m" type="container" src="${MESH_SRC}"></pc-asset>`;
+
+describe('<pc-collision> mesh geometry default', () => {
+    const { uncaught, warnings } = useGuard();
+
+    it("defaults renderAsset to the bound node's render asset", async () => {
+        const { get } = await bootApp(
+            `${MESH_ASSET}<pc-model asset="m">
+                <pc-node name="Body"><pc-collision type="mesh"></pc-collision></pc-node>
+            </pc-model>`
+        );
+        const node = get<NodeElement>('pc-node');
+        const collision = get<CollisionComponentElement>('pc-collision');
+        await readyWithin(collision);
+
+        expect(node.entity!.render, 'the glTF node arrived with a render component').toBeDefined();
+        expect(collision.component!.renderAsset, 'geometry defaulted to the host render asset').toBe(
+            node.entity!.render!.asset
+        );
+        expect(collision.component!.renderAsset).not.toBeNull();
+        expect(uncaught.seen).toEqual([]);
+    });
+
+    it('recomputes the default when the pc-node retargets', async () => {
+        const { get } = await bootApp(
+            `${MESH_ASSET}<pc-model asset="m">
+                <pc-node name="Body"><pc-collision type="mesh"></pc-collision></pc-node>
+            </pc-model>`
+        );
+        const node = get<NodeElement>('pc-node');
+        const collision = get<CollisionComponentElement>('pc-collision');
+        await readyWithin(collision);
+        const bodyAsset = collision.component!.renderAsset;
+
+        node.setAttribute('name', 'Glass');
+
+        expect(node.entity!.name).toBe('Glass');
+        expect(collision.component!.renderAsset, 'the new binding gets the new geometry').toBe(
+            node.entity!.render!.asset
+        );
+        expect(collision.component!.renderAsset).not.toBe(bodyAsset);
+        expect(uncaught.seen).toEqual([]);
+    });
+
+    it('warns and leaves the collider shapeless when there is no render component', async () => {
+        const { get } = await bootApp('<pc-entity name="empty"><pc-collision type="mesh"></pc-collision></pc-entity>');
+        const collision = get<CollisionComponentElement>('pc-collision');
+        await readyWithin(collision);
+
+        warnings.expect(
+            `pc-collision type="mesh" on 'empty' found no asset-backed render component to take geometry from - collider has no shape`
+        );
+        expect(collision.component!.renderAsset).toBeNull();
+    });
+
+    it('warns for a primitive render component, which has no asset to collide against', async () => {
+        const { get } = await bootApp(
+            '<pc-entity name="prim"><pc-render type="box"></pc-render><pc-collision type="mesh"></pc-collision></pc-entity>'
+        );
+        const collision = get<CollisionComponentElement>('pc-collision');
+        await readyWithin(collision);
+
+        warnings.expect("pc-collision type=\"mesh\" on 'prim' found no asset-backed render component");
+        expect(collision.component!.renderAsset).toBeNull();
+    });
+
+    it('leaves non-mesh collider types alone', async () => {
+        const { get } = await bootApp('<pc-entity name="box"><pc-collision></pc-collision></pc-entity>');
+        const collision = get<CollisionComponentElement>('pc-collision');
+        await readyWithin(collision);
+
+        // No warning (the guard fails the test if one fires) and no geometry write
+        expect(collision.component!.renderAsset).toBeNull();
+        expect(collision.component!.type).toBe('box');
+    });
+});

--- a/test/integration/collision-mesh.test.ts
+++ b/test/integration/collision-mesh.test.ts
@@ -83,6 +83,28 @@ describe('<pc-collision> mesh geometry default', () => {
         expect(uncaught.seen).toEqual([]);
     });
 
+    it('applies the default when type changes to mesh at runtime', async () => {
+        const { get } = await bootApp(
+            `${MESH_ASSET}<pc-model asset="m">
+                <pc-node name="Body"><pc-collision></pc-collision></pc-node>
+            </pc-model>`
+        );
+        const node = get<NodeElement>('pc-node');
+        const collision = get<CollisionComponentElement>('pc-collision');
+        await readyWithin(collision);
+
+        expect(collision.component!.type, 'starts as the default box').toBe('box');
+        expect(collision.component!.renderAsset, 'no geometry default for a box').toBeNull();
+
+        collision.setAttribute('type', 'mesh');
+
+        expect(collision.component!.type).toBe('mesh');
+        expect(collision.component!.renderAsset, 'the runtime transition picked up the host geometry').toBe(
+            node.entity!.render!.asset
+        );
+        expect(uncaught.seen).toEqual([]);
+    });
+
     it('warns and leaves the collider shapeless when there is no render component', async () => {
         const { get } = await bootApp('<pc-entity name="empty"><pc-collision type="mesh"></pc-collision></pc-entity>');
         const collision = get<CollisionComponentElement>('pc-collision');


### PR DESCRIPTION
## What

`<pc-collision type="mesh">` was a silently dead configuration: the engine's mesh collider only works with explicitly supplied geometry (`renderAsset` et al), and the element had no attribute to supply it — exactly the gap `examples/assets/scripts/static-body.mjs` hand-rolls around. The component now defaults its `renderAsset` to the host entity's own render component at `initComponent` time — the meaning a mesh collider on a glTF node carries.

- Because `initComponent` re-runs whenever the host's readiness cycles (#353's re-decoration mechanism), a `pc-node` that retargets or rebinds recomputes the default against the new node's geometry.
- An entity with no asset-backed render component — none at all, or a primitive `pc-render`, which has no asset to collide against — warns and the collider stays shapeless. Non-mesh types are untouched.
- An explicitly assigned `renderAsset` is never overwritten (the default only fills `null`).

This unblocks the static-collider headline example of the pc-node RFC (#297), which is now pure markup:

```html
<pc-node name="Floor">
    <pc-collision type="mesh"></pc-collision>
    <pc-rigidbody type="static"></pc-rigidbody>
</pc-node>
```

## Design note

#350 recorded an alternative — an explicit opt-in attribute instead of a library-side default. This PR takes the default, on the grounds that it doesn't override any working engine behavior: `type="mesh"` without geometry does nothing today, so defaulting is giving the only sensible meaning to a dead configuration.

## Testing

- 5 new integration tests with a real-geometry glTF fixture (triangle buffer built in-test): default applied to a bound node's render asset, recomputed on `pc-node` retarget, both warning paths (no render component; primitive render without an asset), and non-mesh types untouched. Full suite: 607 tests green; lint, type-checks, and CEM validation clean.
- Real browser with real physics: on the fps-controller example's map GLB, a second declarative instantiation decorated with `<pc-node><pc-collision type="mesh">` produced an actual Ammo collision shape from the defaulted render asset, console clean.

Closes #350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)