### PR TITLE
Hide the baked ground text in the car configurator, add a shadow catcher

### DIFF
--- a/examples/car-configurator.html
+++ b/examples/car-configurator.html
@@ -58,10 +58,7 @@
                         <pc-script name="xrSession"></pc-script>
                     </pc-scripts>
                 </pc-entity>
-                <!-- Light (intensity 0: casts the shadow without touching the IBL studio look).
-                     A directional light shines along its entity's -Y, so an unrotated one already
-                     points straight down; this tilts it to a 65 degree elevation for a subtly
-                     directional shadow, keeping it near-overhead to match the studio HDRI. -->
+                <!-- Light (shadow only) -->
                 <pc-entity name="light" rotation="-25 -35 0">
                     <pc-light cast-shadows intensity="0" shadow-distance="24" shadow-intensity="0.65" shadow-resolution="2048" shadow-type="vsm-16f" vsm-blur-size="15"></pc-light>
                 </pc-entity>

--- a/examples/car-configurator.html
+++ b/examples/car-configurator.html
@@ -59,7 +59,10 @@
                 </pc-entity>
                 <!-- Car -->
                 <pc-entity name="car" position="0 0.625 0" rotation="0 -90 0">
-                    <pc-model asset="car"></pc-model>
+                    <pc-model asset="car">
+                        <!-- The GLB bakes caption text into its ground plane - hide it -->
+                        <pc-node name="Plane" enabled="false"></pc-node>
+                    </pc-model>
                     <pc-scripts>
                         <pc-script name="chooseColor"></pc-script>
                     </pc-scripts>

--- a/examples/car-configurator.html
+++ b/examples/car-configurator.html
@@ -58,9 +58,11 @@
                         <pc-script name="xrSession"></pc-script>
                     </pc-scripts>
                 </pc-entity>
-                <!-- Light (intensity 0: casts the shadow without touching the IBL studio look) -->
-                <pc-entity name="light">
-                    <pc-light cast-shadows intensity="0" shadow-distance="30" shadow-intensity="0.6" shadow-resolution="1024" shadow-type="vsm-16f"></pc-light>
+                <!-- Light (intensity 0: casts the shadow without touching the IBL studio look).
+                     The rotation matters: an unrotated directional light points along -Z, so it
+                     would graze the ground plane instead of casting onto it. -->
+                <pc-entity name="light" rotation="-60 -35 0">
+                    <pc-light cast-shadows intensity="0" shadow-distance="24" shadow-intensity="0.65" shadow-resolution="2048" shadow-type="vsm-16f" vsm-blur-size="15"></pc-light>
                 </pc-entity>
                 <!-- Car -->
                 <pc-entity name="car" position="0 0.625 0" rotation="0 -90 0">
@@ -76,7 +78,7 @@
                 <!-- Shadow Catcher -->
                 <pc-entity name="shadow catcher">
                     <pc-scripts>
-                        <pc-script name="shadowCatcher" scale="10 10 10"></pc-script>
+                        <pc-script name="shadowCatcher" scale="24 24 24"></pc-script>
                     </pc-scripts>
                 </pc-entity>
                 <!-- XR -->

--- a/examples/car-configurator.html
+++ b/examples/car-configurator.html
@@ -22,6 +22,7 @@
             <!-- Assets -->
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-frame.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/shadow-catcher.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-controllers.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-menu.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-navigation.mjs"></pc-asset>
@@ -57,14 +58,25 @@
                         <pc-script name="xrSession"></pc-script>
                     </pc-scripts>
                 </pc-entity>
+                <!-- Light (intensity 0: casts the shadow without touching the IBL studio look) -->
+                <pc-entity name="light">
+                    <pc-light cast-shadows intensity="0" shadow-distance="30" shadow-intensity="0.6" shadow-resolution="1024" shadow-type="vsm-16f"></pc-light>
+                </pc-entity>
                 <!-- Car -->
                 <pc-entity name="car" position="0 0.625 0" rotation="0 -90 0">
                     <pc-model asset="car">
-                        <!-- The GLB bakes caption text into its ground plane - hide it -->
+                        <!-- The GLB bakes caption text (and a shadow) into its ground plane - hide
+                             it and let the shadow catcher below provide a real one instead -->
                         <pc-node name="Plane" enabled="false"></pc-node>
                     </pc-model>
                     <pc-scripts>
                         <pc-script name="chooseColor"></pc-script>
+                    </pc-scripts>
+                </pc-entity>
+                <!-- Shadow Catcher -->
+                <pc-entity name="shadow catcher">
+                    <pc-scripts>
+                        <pc-script name="shadowCatcher" scale="10 10 10"></pc-script>
                     </pc-scripts>
                 </pc-entity>
                 <!-- XR -->

--- a/examples/car-configurator.html
+++ b/examples/car-configurator.html
@@ -59,9 +59,10 @@
                     </pc-scripts>
                 </pc-entity>
                 <!-- Light (intensity 0: casts the shadow without touching the IBL studio look).
-                     The rotation matters: an unrotated directional light points along -Z, so it
-                     would graze the ground plane instead of casting onto it. -->
-                <pc-entity name="light" rotation="-60 -35 0">
+                     A directional light shines along its entity's -Y, so an unrotated one already
+                     points straight down; this tilts it to a 65 degree elevation for a subtly
+                     directional shadow, keeping it near-overhead to match the studio HDRI. -->
+                <pc-entity name="light" rotation="-25 -35 0">
                     <pc-light cast-shadows intensity="0" shadow-distance="24" shadow-intensity="0.65" shadow-resolution="2048" shadow-type="vsm-16f" vsm-blur-size="15"></pc-light>
                 </pc-entity>
                 <!-- Car -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "jsdom": "30.0.1",
         "mediabunny": "1.52.3",
         "opentype.js": "2.0.0",
-        "playcanvas": "2.21.3",
+        "playcanvas": "2.22.0-beta.10",
         "prettier": "3.9.6",
         "publint": "0.3.23",
         "rollup": "4.62.4",
@@ -8379,9 +8379,9 @@
       }
     },
     "node_modules/playcanvas": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.21.3.tgz",
-      "integrity": "sha512-+AKl0yeNUBo9JSjMRNi2Sz24KhWDhBVMtvhonbeRnKD6FGhNK0O76zvqOu3zgXZxUEzF54h4QGpruhNUkKvsUQ==",
+      "version": "2.22.0-beta.10",
+      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.22.0-beta.10.tgz",
+      "integrity": "sha512-A8IX205QiqtzBfBHUz4NmVnUeP91JE0ITcb9XnJxEa85fXMTnbae4qKVeFwYpEd1cbZo2IlfHbyIzO2IZyj8/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "jsdom": "30.0.1",
     "mediabunny": "1.52.3",
     "opentype.js": "2.0.0",
-    "playcanvas": "2.21.3",
+    "playcanvas": "2.22.0-beta.10",
     "prettier": "3.9.6",
     "publint": "0.3.23",
     "rollup": "4.62.4",


### PR DESCRIPTION
## What

The Porsche GLB bakes caption text into a ground-aligned plane (`Root/Plane` — perfectly flat, at y≈0), which reads as stray floating text under the car.

1. **Hide the plane** with a `pc-node` override — the first in-repo use of the element for its hide-a-part case (#297):

```html
<pc-model asset="car">
    <pc-node name="Plane" enabled="false"></pc-node>
</pc-model>
```

2. **Replace the shadow it took with it.** The same plane carried the model's baked contact shadow (one mesh, one texture — not separable), so a shadow-only directional light plus the engine's `shadowCatcher` script puts a real-time shadow back. The light has `intensity="0"`, the pattern the shadow-catcher script itself documents: it casts the shadow without contributing illumination, so the IBL studio look is unchanged.

3. **Bump the engine to `2.22.0-beta.10`** for engine [#9124](https://github.com/playcanvas/engine/pull/9124) ("Discard out of range depth in VSM shadow casters") — degenerate triangles can hand the shadow caster depth outside `[0, 1]` or `NaN`, the exponential warp turns those into huge values, and the VSM blur spreads them over a large area. Exactly this configuration, since the light uses `shadow-type="vsm-16f"`.

4. **Improve the shadow's look.** The shadow map was undersized: `shadow-distance="30"` spent a 1024² map on a frustum six times the car's length. It is now 24 units at 2048², which roughly quadruples texel density — 24 rather than tighter because `shadow-distance` is measured from the camera and `zoom-range` tops out at 15, so 16 clipped the shadow when zoomed out (verified by scrolling to full zoom-out). `vsm-blur-size="15"` and `shadow-intensity="0.65"` soften what is now a much sharper shadow, and the catcher grows to 24 so its edge stays out of frame. The light is tilted to a 65° elevation (`rotation="-25 -35 0"`) for a subtle directional offset while staying near-overhead, consistent with the studio HDRI.

`pcss-32f` was tried for contact-hardening penumbra, which would be the ideal look — but at sample counts reasonable for an example it speckles the whole plane, so VSM stays.

## Note on the history

Commit `7defd40` claimed the light needed rotating because "an unrotated directional light points along -Z" and was grazing the catcher plane. **That was wrong** — a PlayCanvas directional light shines along its entity's local **-Y** ([`forward-renderer.js`](https://github.com/playcanvas/engine/blob/main/src/scene/renderer/forward-renderer.js) negates the world transform's Y axis), so the unrotated light was already casting straight down correctly. The bad diagnosis came from reading `entity.forward`, which is the camera convention. `b9e5078` corrects both the comment and the angle: the original `-60` was a 30°-elevation raking light that also contradicted the overhead studio lighting. The shadow-map sizing from that commit stands, being independent of the light's angle.

## Reviewer notes

- Only the `playcanvas` **devDependency** moves. `peerDependencies` stays `^2.20.1` — the library needs nothing from 2.22, so consumers must not be pushed onto a prerelease. `npm ls` reports no invalid peer; lockfile updated.
- The example's clean shadow depends on a prerelease engine until 2.22.0 is released.
- `examples/animation.html` uses the same unrotated shadow-catcher light. That is *correct* (straight down), so nothing to fix there — noting it since this PR's history briefly claimed otherwise.

## Verification

Browser, against the built bundle on the beta (`deviceType: webgpu`, `pc.version: 2.22.0-beta.10`): binding resolves (`state: 'bound'`, `path: 'Root/Plane'`, plane disabled), text gone, and the shadow renders as a compact soft contact shadow with no artifact, no hard cascade edge, and no visible catcher edge. Light direction measured on the correct axis: `[-0.24, -0.91, 0.35]`, 65° elevation. Holds at full camera zoom-out. `chooseColor` still works (verified by recoloring — it targets only the `coat` material) and paint/reflections are unchanged, confirming the zero-intensity light adds no illumination. Console clean. Full suite green on the beta: 608 tests, lint, both type-check projects, CEM validation (28 elements).

🤖 Generated with [Claude Code](https://claude.com/claude-code)