### PR TITLE
Polish the car configurator: UI, paint palette and tone mapping

### DIFF
--- a/examples/assets/scripts/baked-ao.mjs
+++ b/examples/assets/scripts/baked-ao.mjs
@@ -32,7 +32,7 @@ export class BakedAo extends Script {
      * The brightness of the baked occlusion. Negative values deepen the shadow.
      * @attribute
      */
-    brightness = -0.65;
+    brightness = -0.9;
 
     /**
      * How much of the sphere the ambient light is taken from. 0.4 is roughly an upper hemisphere,

--- a/examples/assets/scripts/choose-color.mjs
+++ b/examples/assets/scripts/choose-color.mjs
@@ -1,31 +1,128 @@
 import { math, Script, Color } from 'playcanvas';
 
+/**
+ * Exterior paint options, drawn from the 991-generation 911's own palette. `finish` is Porsche's
+ * own grouping and drives both the label and the shading: only Metallic paints get metalness,
+ * while Solid and Special colors are pigment over a clear coat.
+ */
+const PAINTS = [
+    { name: 'Carrara White', hex: '#e6e7e4', finish: 'Metallic' },
+    { name: 'GT Silver', hex: '#b4b7b8', finish: 'Metallic' },
+    { name: 'Agate Grey', hex: '#585c5e', finish: 'Metallic' },
+    { name: 'Jet Black', hex: '#0e0f10', finish: 'Metallic' },
+    { name: 'Sapphire Blue', hex: '#1b3868', finish: 'Metallic' },
+    { name: 'Guards Red', hex: '#cc0000', finish: 'Solid' },
+    { name: 'Racing Yellow', hex: '#ffcc00', finish: 'Solid' },
+    { name: 'Miami Blue', hex: '#00a2d8', finish: 'Special' },
+    { name: 'Lava Orange', hex: '#f4550c', finish: 'Special' },
+    { name: 'Carmine Red', hex: '#9d0b25', finish: 'Special' }
+];
+
+/** The paint applied on load, so the panel's name always matches what is on the car. */
+const DEFAULT_PAINT = 'GT Silver';
+
+const STYLES = `
+.cfg-panel {
+    position: fixed;
+    bottom: max(16px, env(safe-area-inset-bottom));
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 14px 18px 16px;
+    border-radius: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(14, 15, 16, 0.72);
+    backdrop-filter: blur(20px) saturate(1.3);
+    -webkit-backdrop-filter: blur(20px) saturate(1.3);
+    box-shadow: 0 10px 36px rgba(0, 0, 0, 0.4);
+    font-family: system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+    transition: opacity 0.5s ease;
+}
+
+.cfg-caption {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    min-height: 18px;
+}
+
+.cfg-name {
+    color: #fff;
+    font-size: 14px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+}
+
+.cfg-finish {
+    color: rgba(255, 255, 255, 0.5);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+
+.cfg-swatches {
+    display: flex;
+    gap: 10px;
+}
+
+.cfg-swatch {
+    width: 34px;
+    height: 34px;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    cursor: pointer;
+    /* A soft highlight reads as paint under a studio light rather than a flat chip */
+    background-image: radial-gradient(circle at 34% 26%, rgba(255, 255, 255, 0.5), transparent 46%);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.28), 0 2px 6px rgba(0, 0, 0, 0.35);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+/* Metallic flake catches the light more sharply than solid pigment */
+.cfg-swatch[data-finish="Metallic"] {
+    background-image: radial-gradient(circle at 34% 24%, rgba(255, 255, 255, 0.72), transparent 40%);
+}
+
+.cfg-swatch:hover {
+    transform: translateY(-2px);
+}
+
+.cfg-swatch:focus-visible {
+    outline: 2px solid #fff;
+    outline-offset: 3px;
+}
+
+.cfg-swatch[aria-pressed="true"] {
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.28), 0 0 0 2px #fff, 0 2px 8px rgba(0, 0, 0, 0.45);
+}
+
+/* Keep clear of the example harness's own buttons in the bottom-right corner */
+@media (max-width: 700px) {
+    .cfg-panel {
+        bottom: max(72px, env(safe-area-inset-bottom));
+    }
+}
+`;
+
 export class ChooseColor extends Script {
     static scriptName = 'chooseColor';
 
-    // Define available colors as a static property
-    static PAINT_OPTIONS = [
-        { name: 'Guards Red', color: new Color(0.902, 0.004, 0.086), metallic: false },
-        { name: 'Racing Yellow', color: new Color(1, 0.831, 0), metallic: false },
-        { name: 'GT Silver', color: new Color(0.82, 0.82, 0.82), metallic: true },
-        { name: 'Jet Black', color: new Color(0.05, 0.05, 0.05), metallic: true },
-        { name: 'Carrara White', color: new Color(0.95, 0.95, 0.95), metallic: false },
-        { name: 'Gentian Blue', color: new Color(0.15, 0.24, 0.41), metallic: true },
-        { name: 'Agate Grey', color: new Color(0.47, 0.47, 0.47), metallic: true },
-        { name: 'Shark Blue', color: new Color(0.16, 0.33, 0.47), metallic: true },
-        { name: 'Python Green', color: new Color(0.38, 0.45, 0.23), metallic: true },
-        { name: 'Miami Blue', color: new Color(0, 0.67, 0.87), metallic: false }
-    ];
+    /** Seconds are the reciprocal of this: 2 gives a half-second cross-fade. */
+    static TRANSITION_SPEED = 2;
 
-    // Constants
-    static TRANSITION_SPEED = 2; // 0.5 seconds transition
-
+    /**
+     * Metallic paint is a pigmented base coat with aluminium flake, so it wants some metalness -
+     * but not a mirror. Solid and Special colors get their shine from the clear coat alone.
+     */
     static METALNESS = {
-        METALLIC: 0.9,
-        NON_METALLIC: 0
+        Metallic: 0.8,
+        Solid: 0,
+        Special: 0
     };
 
-    // Initialize properties
     /**
      * @type {import('playcanvas').StandardMaterial}
      */
@@ -43,9 +140,26 @@ export class ChooseColor extends Script {
 
     isTransitioning = false;
 
+    /** @type {HTMLElement} */
+    panel = null;
+
+    /** @type {HTMLElement} */
+    nameEl = null;
+
+    /** @type {HTMLElement} */
+    finishEl = null;
+
+    /** @type {HTMLButtonElement[]} */
+    swatches = [];
+
     initialize() {
         this.findMaterial();
         this.createUI();
+
+        const initial = PAINTS.find((paint) => paint.name === DEFAULT_PAINT) ?? PAINTS[0];
+        this.select(initial, false);
+
+        this.on('destroy', () => this.panel?.remove());
     }
 
     findMaterial() {
@@ -57,6 +171,14 @@ export class ChooseColor extends Script {
                     this.toColor.copy(this.material.diffuse);
                     this.fromMetalness = this.material.metalness;
                     this.toMetalness = this.material.metalness;
+
+                    // Automotive paint is pigment under lacquer: the clear coat supplies the
+                    // sharp reflection, so it is set once rather than per frame.
+                    this.material.useMetalness = true;
+                    this.material.clearCoat = 0.25;
+                    this.material.clearCoatGloss = 0.9;
+                    this.material.gloss = 0.85;
+                    this.material.update();
                     return;
                 }
             }
@@ -64,47 +186,71 @@ export class ChooseColor extends Script {
     }
 
     createUI() {
-        const container = this.createContainer();
-        ChooseColor.PAINT_OPTIONS.forEach((color) => {
-            container.appendChild(this.createColorButton(color));
+        if (!document.getElementById('cfg-styles')) {
+            const style = document.createElement('style');
+            style.id = 'cfg-styles';
+            style.textContent = STYLES;
+            document.head.appendChild(style);
+        }
+
+        this.panel = document.createElement('div');
+        this.panel.classList.add('cfg-panel');
+
+        const caption = document.createElement('div');
+        caption.classList.add('cfg-caption');
+        this.nameEl = document.createElement('span');
+        this.nameEl.classList.add('cfg-name');
+        this.finishEl = document.createElement('span');
+        this.finishEl.classList.add('cfg-finish');
+        caption.append(this.nameEl, this.finishEl);
+
+        const swatches = document.createElement('div');
+        swatches.classList.add('cfg-swatches');
+        swatches.setAttribute('role', 'group');
+        swatches.setAttribute('aria-label', 'Exterior color');
+        this.swatches = PAINTS.map((paint) => {
+            const button = document.createElement('button');
+            button.classList.add('cfg-swatch');
+            button.style.backgroundColor = paint.hex;
+            button.dataset.finish = paint.finish;
+            button.title = `${paint.name} - ${paint.finish}`;
+            button.setAttribute('aria-label', `${paint.name}, ${paint.finish}`);
+            button.setAttribute('aria-pressed', 'false');
+            button.onclick = () => this.select(paint, true);
+            swatches.appendChild(button);
+            return button;
         });
-        document.body.appendChild(container);
+
+        this.panel.append(caption, swatches);
+        document.body.appendChild(this.panel);
     }
 
-    createContainer() {
-        const container = document.createElement('div');
-        container.classList.add('example-button-container', 'top-right');
-        container.style.display = 'grid';
-        container.style.gridTemplateColumns = 'repeat(5, 1fr)';
-        container.style.gap = '8px';
-        return container;
-    }
-
-    createColorButton(color) {
-        const button = document.createElement('button');
-        button.title = color.name;
-        Object.assign(button.style, {
-            width: '40px',
-            height: '40px',
-            border: '2px solid black',
-            backgroundColor: color.color.toString(),
-            cursor: 'pointer',
-            padding: '0',
-            borderRadius: '4px'
+    /**
+     * Applies a paint, cross-fading from whatever is on the car unless `animate` is false.
+     *
+     * @param {object} paint - The entry from PAINTS to apply.
+     * @param {boolean} animate - Whether to cross-fade rather than snap.
+     */
+    select(paint, animate) {
+        this.nameEl.textContent = paint.name;
+        this.finishEl.textContent = paint.finish;
+        this.swatches.forEach((button, i) => {
+            button.setAttribute('aria-pressed', String(PAINTS[i] === paint));
         });
-        button.onclick = () => this.startColorTransition(color);
-        return button;
-    }
 
-    startColorTransition(color) {
         if (!this.material) return;
 
         this.fromColor.copy(this.material.diffuse);
-        this.toColor.copy(color.color);
+        this.toColor.fromString(paint.hex);
         this.fromMetalness = this.material.metalness;
-        this.toMetalness = color.metallic ? ChooseColor.METALNESS.METALLIC : ChooseColor.METALNESS.NON_METALLIC;
+        this.toMetalness = ChooseColor.METALNESS[paint.finish];
         this.lerpTime = 0;
         this.isTransitioning = true;
+
+        if (!animate) {
+            this.updateMaterial(1);
+            this.isTransitioning = false;
+        }
     }
 
     update(dt) {
@@ -123,8 +269,6 @@ export class ChooseColor extends Script {
     updateMaterial(t) {
         this.material.diffuse.lerp(this.fromColor, this.toColor, t);
         this.material.metalness = math.lerp(this.fromMetalness, this.toMetalness, t);
-        this.material.clearCoat = 0.25;
-        this.material.clearCoatGloss = 0.9;
         this.material.update();
     }
 }

--- a/examples/assets/scripts/choose-color.mjs
+++ b/examples/assets/scripts/choose-color.mjs
@@ -77,7 +77,13 @@ const STYLES = `
     cursor: pointer;
     /* A soft highlight reads as paint under a studio light rather than a flat chip */
     background-image: radial-gradient(circle at 34% 26%, rgba(255, 255, 255, 0.5), transparent 46%);
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.28), 0 2px 6px rgba(0, 0, 0, 0.35);
+    /* The middle layer is the selection ring, transparent until selected. Both states must carry
+       the same layers in the same order: box-shadow lists interpolate positionally, so a state
+       with fewer layers makes the drop shadow morph into the ring instead of the ring fading in. */
+    box-shadow:
+        inset 0 0 0 1px rgba(255, 255, 255, 0.28),
+        0 0 0 2px transparent,
+        0 2px 6px rgba(0, 0, 0, 0.35);
     transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
@@ -96,7 +102,10 @@ const STYLES = `
 }
 
 .cfg-swatch[aria-pressed="true"] {
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.28), 0 0 0 2px #fff, 0 2px 8px rgba(0, 0, 0, 0.45);
+    box-shadow:
+        inset 0 0 0 1px rgba(255, 255, 255, 0.28),
+        0 0 0 2px #fff,
+        0 2px 8px rgba(0, 0, 0, 0.45);
 }
 
 /* Keep clear of the example harness's own buttons in the bottom-right corner */

--- a/examples/car-configurator.html
+++ b/examples/car-configurator.html
@@ -21,7 +21,6 @@
             <pc-module name="DracoDecoderModule" glue="modules/draco/draco.wasm.js" wasm="modules/draco/draco.wasm.wasm" fallback="modules/draco/draco.js"></pc-module>
             <!-- Assets -->
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-frame.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-controllers.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-menu.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-navigation.mjs"></pc-asset>
@@ -32,7 +31,7 @@
             <pc-asset src="assets/skies/octagon-lamps-photo-studio-2k.hdr" id="studio"></pc-asset>
             <pc-asset src="assets/models/porsche-911-carrera-4s.glb" id="car"></pc-asset>
             <!-- Materials (the ground's diffuse is tuned so its lit value matches the backdrop) -->
-            <pc-material id="ground" diffuse="0.81 0.81 0.81" metalness="0" gloss="0.1"></pc-material>
+            <pc-material id="ground" diffuse="0.84 0.84 0.84" metalness="0" gloss="0.1"></pc-material>
             <!-- Scene -->
             <pc-scene>
                 <!-- Sky -->
@@ -40,7 +39,7 @@
                 <!-- Camera (with XR support) -->
                 <pc-entity name="camera root">
                     <pc-entity name="camera" position="0 1.75 5">
-                        <pc-camera fov="35"></pc-camera>
+                        <pc-camera fov="35" tonemap="neutral"></pc-camera>
                         <pc-scripts>
                             <pc-script name="cameraControls"
                                        enable-fly="false"


### PR DESCRIPTION
## UI

The color picker was ten flat squares with black borders and no indication of what was selected. It is now a panel: the paint's **name and finish** above a row of circular swatches.

- A radial highlight makes each swatch read as paint under a studio light rather than a flat chip, and metallic swatches get a sharper highlight than solid ones.
- The selected swatch carries a ring; hover lifts; `:focus-visible` gives a visible outline.
- `role="group"`, `aria-label` and `aria-pressed` expose the selection to assistive tech — the old buttons conveyed selection not at all.
- Styles are injected under a `cfg-` prefix instead of going into the shared `example.css`, so no other example is touched. A media query lifts the panel clear of the harness's own buttons on narrow viewports.

## Paint palette

Now drawn from the 991-generation 911's own range, with Porsche's finish groupings — **Metallic / Solid / Special** — shown in the panel and driving the shading, so only metallics get metalness.

That corrects entries previously flagged metallic where the real paint is solid: **Shark Blue** and **Python Green** (both replaced here). Metallic paint gets metalness 0.8 rather than 0.9 — pigmented base coat with aluminium flake, not a mirror — and the clear coat is set once in `findMaterial` instead of being reassigned every frame.

A paint is applied on load, so the panel's label always matches what is on the car rather than naming a color the model isn't wearing.

## Rendering

The camera had **no tone mapping**, so the studio HDRI's highlights clipped. It now uses **Khronos PBR Neutral**, which is built for product visualization and preserves hue and saturation — the right trade for a configurator whose entire purpose is judging paint color.

`aces2` was tried and rejected: it darkens and shifts the saturated paints, and it broke the ground plane's match with the backdrop.

Tone mapping compresses the baked contact shadow (measured: the shadow core went from 44 luminance levels below the open ground to 15), so two values are re-tuned to restore it — the ground's albedo is re-matched to the backdrop at `0.84`, and the bake's occlusion brightness deepened to `-0.9`. Verified: backdrop, above-horizon, below-horizon and open ground all read 191, with the shadow core back down to ~150.

Also drops `camera-frame.mjs`, which was preloaded on every run and never used. I did wire it up — SSAO and MSAA genuinely add definition — but it renders through its own pipeline, which breaks the ground's match with the backdrop, and it brings a large set of knobs into an example that is about the markup. Worth revisiting as a deliberate change rather than smuggling it in here.

## Verification

Browser, default WebGPU backend against the built bundle: default paint applies on load with a matching label; switching to Guards Red cross-fades and updates name, finish and the selected ring; ground stays seamless with the backdrop; panel repositions correctly at 620px wide. Console clean. `npm run lint` and Prettier pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)