### PR TITLE
Add an 'Edit on StackBlitz' button to every example

### DIFF
--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -68,6 +68,7 @@ canvas {
 .example-button.icon.icon-fs-enter { background-image: url("../img/fullscreen-enter.svg"); }
 .example-button.icon.icon-fs-exit { background-image: url("../img/fullscreen-exit.svg"); }
 .example-button.icon.icon-source { background-image: url("../img/code.svg"); }
+.example-button.icon.icon-stackblitz { background-image: url("../img/stackblitz.svg"); }
 
 .example-button:hover {
     background-color: rgba(255, 255, 255, 1);

--- a/examples/img/stackblitz.svg
+++ b/examples/img/stackblitz.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#1f1f1f"><path d="M10.797 14.182H3.635L16.728 0l-3.525 9.818h7.162L7.272 24l3.525-9.818Z"/></svg>

--- a/examples/js/example.mjs
+++ b/examples/js/example.mjs
@@ -2,6 +2,8 @@ import { MiniStats, XRTYPE_AR, XRTYPE_VR } from 'playcanvas';
 
 import { whenReady } from '@playcanvas/web-components';
 
+import { openInStackBlitz } from './stackblitz.mjs';
+
 const { app } = await whenReady('pc-app');
 
 // Add MiniStats if the query parameter is present
@@ -71,6 +73,15 @@ if (document.documentElement.requestFullscreen && document.exitFullscreen) {
 
     container.appendChild(fullscreenButton);
 }
+
+// Add a button that opens the example as an editable npm-based StackBlitz project
+container.appendChild(
+    createButton({
+        iconClass: 'icon-stackblitz',
+        title: 'Edit on StackBlitz',
+        onClick: () => openInStackBlitz()
+    })
+);
 
 // Add view-source button linking to this page's source on GitHub
 const filename = window.location.pathname.split('/').pop();

--- a/examples/js/stackblitz.mjs
+++ b/examples/js/stackblitz.mjs
@@ -1,0 +1,168 @@
+const EXAMPLES_BASE = 'https://playcanvas.github.io/web-components/examples/';
+
+// Matches the package name in a /node_modules/ URL, e.g. 'playcanvas' or '@mediapipe/tasks-vision'
+const PACKAGE_REGEX = /\/node_modules\/((?:@[\w.-]+\/)?[\w.-]+)/g;
+
+/**
+ * Rewrites an example's HTML so it runs as a standalone npm-based project: the local library
+ * build and repo-relative node_modules paths become project-root node_modules paths (installed
+ * from npm), while example-relative resources (assets, scripts, styles) load from the deployed
+ * examples site.
+ * @param {string} html - The example's HTML source.
+ * @returns {string} The transformed HTML.
+ */
+export function transformHtml(html) {
+    return html
+        .replace(/(\.\.\/)+dist\//g, '/node_modules/@playcanvas/web-components/dist/')
+        .replace(/(\.\.\/)+node_modules\//g, '/node_modules/')
+        .replace(/(["'(])((?:assets|css|img|js|modules)\/)/g, `$1${EXAMPLES_BASE}$2`);
+}
+
+/**
+ * Collects the names of all npm packages referenced via /node_modules/ URLs in the given HTML.
+ * @param {string} html - The transformed example HTML.
+ * @returns {Set<string>} The referenced package names.
+ */
+export function collectPackages(html) {
+    const packages = new Set();
+    for (const [, name] of html.matchAll(PACKAGE_REGEX)) {
+        packages.add(name);
+    }
+    return packages;
+}
+
+/**
+ * Builds the package.json for the generated project. Referenced packages are pinned to the
+ * versions used by this repo (read from the repo's own package.json) so the project matches
+ * the deployed examples.
+ * @param {object} rootPkg - The repo's package.json (may be empty if it could not be fetched).
+ * @param {Set<string>} packages - Package names referenced by the example.
+ * @param {string} name - The npm-style name for the generated project.
+ * @returns {object} The package.json contents for the StackBlitz project.
+ */
+function buildPackageJson(rootPkg, packages, name) {
+    // devDependencies take precedence over peerDependencies: the repo pins the exact package
+    // versions it is developed (and deployed) against in devDependencies, while
+    // peerDependencies express a looser supported range
+    const versions = {
+        ...rootPkg.peerDependencies,
+        ...rootPkg.dependencies,
+        ...rootPkg.devDependencies
+    };
+
+    const dependencies = {
+        '@playcanvas/web-components': rootPkg.version ? `^${rootPkg.version}` : 'latest'
+    };
+    for (const pkg of [...packages].sort()) {
+        if (pkg !== '@playcanvas/web-components') {
+            dependencies[pkg] = versions[pkg] ?? 'latest';
+        }
+    }
+
+    return {
+        name,
+        private: true,
+        scripts: {
+            start: 'serve .'
+        },
+        dependencies,
+        devDependencies: {
+            serve: versions.serve ?? 'latest'
+        },
+        stackblitz: {
+            startCommand: 'npm start'
+        }
+    };
+}
+
+/**
+ * Submits a project to StackBlitz via its POST API, opening it in the given window.
+ * @param {object} project - The project definition.
+ * @param {string} project.title - The project title.
+ * @param {string} project.description - The project description.
+ * @param {Record<string, string>} project.files - Map of file paths to file contents.
+ * @param {string} target - The name of the window to open the project in.
+ */
+function postToStackBlitz({ title, description, files }, target) {
+    const form = document.createElement('form');
+    form.method = 'POST';
+    form.action = 'https://stackblitz.com/run?file=index.html';
+    form.target = target;
+    form.style.display = 'none';
+
+    const addField = (fieldName, value) => {
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = fieldName;
+        input.value = value;
+        form.appendChild(input);
+    };
+
+    addField('project[title]', title);
+    addField('project[description]', description);
+    addField('project[template]', 'node');
+    for (const [path, contents] of Object.entries(files)) {
+        addField(`project[files][${path}]`, contents);
+    }
+
+    document.body.appendChild(form);
+    form.submit();
+    form.remove();
+}
+
+/**
+ * Opens the current example as an editable StackBlitz project. The project installs `playcanvas`
+ * and `@playcanvas/web-components` (plus any other packages the example imports) from npm and
+ * serves the example HTML, while assets continue to load from the deployed examples site.
+ */
+export async function openInStackBlitz() {
+    // Open the tab synchronously so the browser attributes it to the user's click; the form
+    // submission below then navigates it once the project has been assembled
+    const target = `stackblitz-${Date.now()}`;
+    const projectWindow = window.open('about:blank', target);
+
+    try {
+        const [html, rootPkg] = await Promise.all([
+            fetch(window.location.href).then((r) => r.text()),
+            fetch('../package.json').then((r) => (r.ok ? r.json() : {}))
+        ]);
+
+        const transformed = transformHtml(html);
+        const slug = window.location.pathname
+            .split('/')
+            .pop()
+            .replace(/\.html$/, '');
+        const title = document.title;
+        const packageJson = buildPackageJson(rootPkg, collectPackages(transformed), `pwc-example-${slug}`);
+
+        const readme = [
+            `# ${title}`,
+            '',
+            'A [PlayCanvas Web Components](https://www.npmjs.com/package/@playcanvas/web-components)',
+            'example - a 3D scene declared entirely in HTML.',
+            '',
+            'Edit `index.html` and refresh the preview to see your changes.',
+            '',
+            '- [User Manual](https://developer.playcanvas.com/user-manual/web-components/)',
+            '- [API Reference](https://api.playcanvas.com/web-components)',
+            '- [GitHub](https://github.com/playcanvas/web-components)',
+            ''
+        ].join('\n');
+
+        postToStackBlitz(
+            {
+                title,
+                description: 'A PlayCanvas Web Components example - a 3D scene declared entirely in HTML',
+                files: {
+                    'index.html': transformed,
+                    'package.json': JSON.stringify(packageJson, null, 4),
+                    'README.md': readme
+                }
+            },
+            target
+        );
+    } catch (error) {
+        projectWindow?.close();
+        console.error('Failed to open example on StackBlitz:', error);
+    }
+}


### PR DESCRIPTION
## What

Adds an **Edit on StackBlitz** button to the example chrome (between Fullscreen and View Source). Clicking it opens the current example as an editable StackBlitz project, with the example open in the editor and running in the preview pane.

## Why

Every example shared in Discord, the forum, or on social media becomes a one-click, forkable workspace. Because the generated project uses StackBlitz''s `node` template, opening it boots a WebContainer and runs a **real `npm install` of `playcanvas` and `@playcanvas/web-components`** - driving actual npm registry traffic and landing users in a project where the packages are already dependencies they can carry into their own apps. (A CDN-based CodePen/JSFiddle export would not touch npm at all.)

## How it works

On click, `examples/js/stackblitz.mjs`:

1. Fetches the current page''s raw HTML.
2. Rewrites `../dist/` to the npm package and `../node_modules/` to project-root `/node_modules/` (installed from npm), and points example-relative resources (`assets/`, `css/`, `js/`, `modules/`) at the deployed examples site, which serves CORS `*`.
3. Scans the result for every referenced package, so e.g. 3D Text picks up `earcut` + `opentype.js`, Tweening picks up `@tweenjs/tween.js`, and the AR examples pick up `@mediapipe/tasks-vision`. Versions are pinned from this repo''s own `package.json` (devDependencies take precedence, so the project gets the exact engine build the deployed examples run against).
4. POSTs `index.html`, `package.json` and a `README.md` (with User Manual / API Reference / GitHub links) to StackBlitz''s [POST API](https://developer.stackblitz.com/platform/api/post-api), targeting a tab opened synchronously on click so popup blockers attribute it to the user gesture.

No dependencies added - the POST is a plain HTML form submission.

## Notes for reviewers

- An offline check ran the transform over all 33 example pages: no repo-relative paths survive and every referenced package resolves to a known version.
- Verified live: the generated project boots on StackBlitz, `npm install` runs (a `package-lock.json` appears), `serve` comes up on port 3000 and the preview attaches. Cross-origin asset fetches and ESM imports from the GitHub Pages site were confirmed working.
- Examples that need camera/XR permissions won''t get them inside StackBlitz''s embedded preview iframe; the preview can be popped out into its own tab instead.
- Projects generated from a local checkout reference the *deployed* assets and the *published* npm packages, so unreleased local changes won''t be reflected in the StackBlitz project until deploy/publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)