### PR TITLE
Surface graphics device creation failure on 'pc-app' instead of rejecting

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -88,8 +88,8 @@ const pointerEventTypes = ['pointermove', 'pointerdown', 'pointerup', 'pointeren
  * not bubble.
  *
  * @fires {ErrorEvent} error - Fired when the application cannot boot because no graphics device
- * could be created (for example, a browser with WebGL disabled). `message` names the backends
- * that were attempted and `error` holds the underlying failure. The element never becomes ready
+ * could be created (for example, a browser with WebGL disabled). `message` names the requested
+ * backends and `error` holds the underlying failure. The element never becomes ready
  * and `app` stays `null` — listen for this event to show a fallback UI. Removing the element and
  * re-inserting it retries the boot with its current attributes. Does not bubble.
  */
@@ -283,7 +283,7 @@ class AppElement extends AsyncElement {
 
             const reason = error instanceof Error ? error.message : String(error);
             const message = `pc-app failed to create a graphics device (${requested}) - ${reason}`;
-            console.error(message);
+            console.error(message, error);
             this.dispatchEvent(new ErrorEvent('error', { message, error }));
             return;
         }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import type { CameraComponent, GraphNode, GSplatComponent, Entity } from 'playcanvas';
+import type { CameraComponent, GraphicsDevice, GraphNode, GSplatComponent, Entity } from 'playcanvas';
 import {
     AppBase,
     AppOptions,
@@ -86,6 +86,12 @@ const pointerEventTypes = ['pointermove', 'pointerdown', 'pointerup', 'pointeren
  * `total` are asset counts, not bytes, and an asset that fails to load still counts as loaded.
  * Fired at least once per boot, and the final event always has `loaded` equal to `total`. Does
  * not bubble.
+ *
+ * @fires {ErrorEvent} error - Fired when the application cannot boot because no graphics device
+ * could be created (for example, a browser with WebGL disabled). `message` names the backends
+ * that were attempted and `error` holds the underlying failure. The element never becomes ready
+ * and `app` stays `null` — listen for this event to show a fallback UI. Removing the element and
+ * re-inserting it retries the boot with its current attributes. Does not bubble.
  */
 class AppElement extends AsyncElement {
     /**
@@ -241,14 +247,46 @@ class AppElement extends AsyncElement {
 
         this._optionsLocked = true;
 
-        const device = await createGraphicsDevice(this._canvas, {
-            // @ts-ignore - alpha needs to be documented
-            alpha: this._alpha,
-            antialias: this._antialias,
-            depth: this._depthBuffer,
-            deviceTypes: deviceTypes,
-            stencil: this._stencilBuffer
-        });
+        // createGraphicsDevice appends its final null-device fallback to the array in place, so
+        // the requested list is captured now for the failure message.
+        const requested = deviceTypes.join(', ');
+
+        let device: GraphicsDevice;
+        try {
+            device = await createGraphicsDevice(this._canvas, {
+                // @ts-ignore - alpha needs to be documented
+                alpha: this._alpha,
+                antialias: this._antialias,
+                depth: this._depthBuffer,
+                deviceTypes: deviceTypes,
+                stencil: this._stencilBuffer
+            });
+        } catch (error) {
+            // The element may have been removed while device creation was failing. The teardown
+            // has already cleaned up, and the failure belongs to a boot that no longer owns the
+            // element.
+            if (generation !== this._bootGeneration) {
+                return;
+            }
+
+            // Return the element to its pre-boot state - no dead canvas, no loading bar stuck at
+            // zero - before announcing the failure. Readiness deliberately stays pending: nothing
+            // it would announce (the app, the entity hierarchy) exists, so a device-less element
+            // joins the documented never-ready cases and the failure surfaces through the error
+            // event instead.
+            if (this._canvas && this.contains(this._canvas)) {
+                this.removeChild(this._canvas);
+            }
+            this._canvas = null;
+            this._bar?.destroy();
+            this._bar = null;
+
+            const reason = error instanceof Error ? error.message : String(error);
+            const message = `pc-app failed to create a graphics device (${requested}) - ${reason}`;
+            console.error(message);
+            this.dispatchEvent(new ErrorEvent('error', { message, error }));
+            return;
+        }
 
         // The element may have been removed while the device was created. disconnectedCallback
         // has already cleaned up the canvas; the device was created inside the await, so it is
@@ -495,9 +533,9 @@ class AppElement extends AsyncElement {
         // created from onpointer* attributes when their elements were first upgraded, or
         // listeners carried over from before a re-boot)
         pointerEventTypes.forEach((type) => {
-            const anyListeners = Array.from(
-                this.querySelectorAll<EntityBaseElement>('pc-entity, pc-node')
-            ).some((entity) => entity._hasListeners(type));
+            const anyListeners = Array.from(this.querySelectorAll<EntityBaseElement>('pc-entity, pc-node')).some(
+                (entity) => entity._hasListeners(type)
+            );
             if (anyListeners) {
                 this._onPointerListenerAdded(type);
             }
@@ -718,9 +756,9 @@ class AppElement extends AsyncElement {
     }
 
     private _onPointerListenerRemoved(type: string) {
-        const hasListeners = Array.from(
-            this.querySelectorAll<EntityBaseElement>('pc-entity, pc-node')
-        ).some((entity) => entity._hasListeners(type));
+        const hasListeners = Array.from(this.querySelectorAll<EntityBaseElement>('pc-entity, pc-node')).some((entity) =>
+            entity._hasListeners(type)
+        );
 
         if (!hasListeners && this._canvas) {
             this._hasPointerListeners[type] = false;

--- a/src/async-element.ts
+++ b/src/async-element.ts
@@ -96,7 +96,8 @@ type AsyncElementTagName = {
 /**
  * Waits for the first element matching the given tag name to be fully initialized. Note that the
  * promise never settles if the element cannot finish initializing (for example, a `<pc-script>`
- * that is not a direct child of `<pc-scripts>`). A component element outside a `<pc-entity>` is
+ * that is not a direct child of `<pc-scripts>`, or a `<pc-app>` that could not create a graphics
+ * device — listen for its `error` event instead). A component element outside a `<pc-entity>` is
  * the exception: it still becomes ready, but its `component` is `null`. Either way, a misplaced
  * element logs a warning naming the parent it requires.
  * @param target - The tag name of the element to wait for (e.g. `'pc-app'`).
@@ -120,7 +121,8 @@ function whenReady<T extends AsyncElement>(target: T): Promise<T>;
 /**
  * Waits for the first element matching the given CSS selector to be fully initialized. Note that
  * the promise never settles if the element cannot finish initializing (for example, a `<pc-script>`
- * that is not a direct child of `<pc-scripts>`). A component element outside a `<pc-entity>` is
+ * that is not a direct child of `<pc-scripts>`, or a `<pc-app>` that could not create a graphics
+ * device — listen for its `error` event instead). A component element outside a `<pc-entity>` is
  * the exception: it still becomes ready, but its `component` is `null`. Either way, a misplaced
  * element logs a warning naming the parent it requires.
  * @param target - A CSS selector matching the element to wait for (e.g. `'#my-app'`).

--- a/test/integration/app-device-failure.test.ts
+++ b/test/integration/app-device-failure.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AppElement } from '../../src/app';
+import { mount } from '../helpers/dom';
+import { useGuard } from '../helpers/guard';
+import { expectNeverReady, readyWithin } from '../helpers/ready';
+
+/**
+ * What <pc-app> does when no graphics device can be created. jsdom's getContext() returns null
+ * (pinned in test/setup/dom.ts), which is the same observable condition as a browser with WebGL
+ * disabled or blocklisted - so backend="webgl2" here boots straight into total device failure.
+ */
+describe('<pc-app> graphics device failure', () => {
+    const { errors, uncaught } = useGuard();
+
+    const nextError = (element: AppElement) =>
+        new Promise<ErrorEvent>((resolve) => {
+            element.addEventListener('error', resolve as EventListener, { once: true });
+        });
+
+    it('fires error and never becomes ready when no device can be created', async () => {
+        const handle = mount('<pc-app backend="webgl2"></pc-app>');
+        const appElement = handle.get<AppElement>('pc-app');
+
+        const event = await nextError(appElement);
+
+        expect(event.message).toContain('pc-app failed to create a graphics device (webgl2)');
+        expect(event.error).toBeInstanceOf(Error);
+        expect(appElement.app).toBeNull();
+        await expectNeverReady(appElement);
+
+        // The failure must arrive on the channels above, not as an unhandled rejection escaping
+        // the async connectedCallback (the guard also fails the test on any left unclaimed).
+        expect(uncaught.seen).toEqual([]);
+        errors.expect('pc-app failed to create a graphics device (webgl2)');
+    });
+
+    it('names every requested backend when the default webgpu request fails', async () => {
+        // jsdom has no navigator.gpu, so the engine only ever attempts webgl2 - but the element
+        // requested the webgpu-with-fallback pair, and the message reports what was requested.
+        const handle = mount('<pc-app></pc-app>');
+        const appElement = handle.get<AppElement>('pc-app');
+
+        const event = await nextError(appElement);
+
+        expect(event.message).toContain('(webgpu, webgl2)');
+        errors.expect('pc-app failed to create a graphics device (webgpu, webgl2)');
+    });
+
+    it('leaves the element empty - no dead canvas, no stuck loading bar', async () => {
+        const handle = mount('<pc-app backend="webgl2"></pc-app>');
+        const appElement = handle.get<AppElement>('pc-app');
+
+        await nextError(appElement);
+
+        expect(appElement.querySelector('canvas')).toBeNull();
+        expect(appElement.firstElementChild).toBeNull();
+        errors.expect('pc-app failed to create a graphics device (webgl2)');
+    });
+
+    it('boots normally when re-inserted with a working backend', async () => {
+        const handle = mount('<pc-app backend="webgl2"></pc-app>');
+        const appElement = handle.get<AppElement>('pc-app');
+        await nextError(appElement);
+
+        // Remove-and-reinsert is the documented recovery path: teardown unlocks the boot-time
+        // options, so the new backend is read when the element reconnects.
+        appElement.remove();
+        appElement.setAttribute('backend', 'null');
+        handle.container.appendChild(appElement);
+
+        await readyWithin(appElement);
+        expect(appElement.app).not.toBeNull();
+        errors.expect('pc-app failed to create a graphics device (webgl2)');
+    });
+});

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -245,13 +245,13 @@ if (manifest) {
     // they exercise the analyzer's non-CustomEvent detection - and must not leak onto other tags
     // through the inheritance step
     check(events('pc-app').includes('progress'), "pc-app is missing the 'progress' event");
+    check(events('pc-app').includes('error'), "pc-app is missing the 'error' event");
     for (const name of ['load', 'error']) {
         check(events('pc-asset').includes(name), `pc-asset is missing the '${name}' event`);
     }
     check(!events('pc-entity').includes('progress'), 'pc-entity should not have a progress event');
-    const strayAssetEvents = ['load', 'error'].filter(name => events('pc-app').includes(name));
-    check(strayAssetEvents.length === 0,
-        `pc-app should not declare asset events: ${strayAssetEvents.join(', ')}`);
+    // pc-app declares its own 'error' event, so 'load' is what remains of the leak canary
+    check(!events('pc-app').includes('load'), "pc-app should not declare pc-asset's 'load' event");
 
     // ---- Members: the manifest's public API surface ----
     //


### PR DESCRIPTION
Fixes #308

## What

When no graphics device can be created (a browser with WebGL disabled, a blocklisted GPU, a hardened enterprise profile), `<pc-app>` previously produced an unhandled promise rejection from its async `connectedCallback` and never fired `ready` - a blank page with a loading bar stuck at zero and no signal to the page.

It now:

- catches the failure and returns the element to its pre-boot state (canvas and loading bar removed),
- logs a `console.error` naming the requested backends, e.g. `pc-app failed to create a graphics device (webgpu, webgl2) - WebGL not supported`, and
- dispatches a non-bubbling `ErrorEvent` named `error` on the element, with the message and the underlying failure in `error` - so a page can show a fallback UI.

## The readiness contract (the 1.0.0 lock-in)

Readiness deliberately **stays pending** on failure. A device-less `<pc-app>` has nothing its readiness would announce - no app, no entity hierarchy - and its descendants can never become ready either, so it joins the documented never-settles cases (`whenReady` docs updated). This also preserves the library-wide invariant that no `ready()` promise ever rejects, and keeps `sky.ts`/`particlesystem-component.ts` (which dereference `.app` after awaiting readiness) safe. This intentionally differs from `pc-model`, where a failed *asset load* on a successfully booted element settles readiness - here the element cannot finish initializing at all.

Removing and re-inserting the element retries the boot with its current attributes (teardown already unlocks the boot-time options), which is the documented recovery path.

## Notes

- The requested-backend list is snapshotted before the `createGraphicsDevice` call because the engine appends its `null`-device fallback to the caller''s `deviceTypes` array in place.
- The CEM validator''s inheritance-leak canary (pc-app must not inherit pc-asset''s events) now pins only `load`, since `error` is legitimately pc-app''s own; a positive check for the new event is added.
- The engine-side half of #308 (its device-type fallback is broken by a synchronous throw escaping `Promise.resolve(fn())`) still stands and is worth filing upstream; this change makes `<pc-app>` robust either way.

## Verification

- 4 new integration tests: error event + never-ready, requested-backend naming, element left empty, and recovery by re-insertion with a working backend. The suite''s guard also asserts no unhandled rejection escapes.
- Full suite: 612 tests pass; type-check, lint, prettier and `cem` validation clean.
- Verified end-to-end against the built `dist/pwc.mjs` in a real browser with `getContext` stubbed to return `null` (the same observable condition as WebGL disabled): error event fired, zero unhandled rejections, element left empty, readiness never settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)