### PR TITLE
Fix the npm package metadata ahead of 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,9 @@
         "typescript": "6.0.3",
         "vitest": "4.1.10"
       },
+      "engines": {
+        "node": ">=18.3.0"
+      },
       "peerDependencies": {
         "playcanvas": "^2.20.1"
       }

--- a/package.json
+++ b/package.json
@@ -32,14 +32,23 @@
   "web-types": "dist/web-types.json",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/pwc.mjs",
-      "require": "./dist/pwc.cjs"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/pwc.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/pwc.cjs"
+      }
     },
     "./dist/*": "./dist/*",
     "./package.json": "./package.json"
   },
   "type": "module",
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18.3.0"
+  },
   "files": [
     "dist",
     "src"
@@ -47,7 +56,7 @@
   "scripts": {
     "prebuild": "node -e \"fs.rmSync('dist', { recursive: true, force: true })\"",
     "build": "rollup -c",
-    "postbuild": "npm run cem",
+    "postbuild": "node utils/fix-declarations.mjs && npm run cem",
     "cem": "cem analyze && node utils/cem/validate.mjs",
     "dev": "concurrently \"npm run watch\" \"npm run serve\"",
     "docs": "typedoc",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -24,14 +24,14 @@ export default {
         },
         {
             file: 'dist/pwc.js',
-            name: 'pd',
+            name: 'pwc',
             format: 'umd',
             sourcemap: true,
             globals: { playcanvas: 'pc' }
         },
         {
             file: 'dist/pwc.min.js',
-            name: 'pd',
+            name: 'pwc',
             format: 'umd',
             sourcemap: true,
             plugins: [terser()],

--- a/utils/fix-declarations.mjs
+++ b/utils/fix-declarations.mjs
@@ -1,0 +1,36 @@
+/**
+ * Makes the emitted declarations resolvable under Node16 module resolution, in both flavors.
+ *
+ * The TypeScript emit preserves the source's extensionless relative imports, which Node16
+ * resolution rejects - so every relative specifier in the .d.ts tree gains a .js extension.
+ * The package also ships a CJS build, and a lone .d.ts inside a `"type": "module"` package is
+ * interpreted as an ES module declaration - so resolving types through the `require` condition
+ * would claim the CJS build is ESM. Each .d.ts is therefore also copied to a .d.cts sibling
+ * whose relative specifiers use .cjs, keeping resolution inside the CJS-flavored tree.
+ */
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Matches the specifier of a relative import/export in TS-emitted declaration files, which only
+// ever reference other modules via `from '...'`
+const RELATIVE_SPECIFIER = /(from\s+)(['"])(\.\.?\/[^'"]+)\2/g;
+
+const withExtension = (source, extension) =>
+    source.replace(RELATIVE_SPECIFIER, (match, lead, quote, specifier) =>
+        (/\.[cm]?js$/.test(specifier) ? match : `${lead}${quote}${specifier}${extension}${quote}`)
+    );
+
+const fixTree = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const path = join(dir, entry.name);
+        if (entry.isDirectory()) {
+            fixTree(path);
+        } else if (entry.name.endsWith('.d.ts')) {
+            const source = readFileSync(path, 'utf8');
+            writeFileSync(path, withExtension(source, '.js'));
+            writeFileSync(path.replace(/\.d\.ts$/, '.d.cts'), withExtension(source, '.cjs'));
+        }
+    }
+};
+
+fixTree('dist');


### PR DESCRIPTION
Four packaging lock-ins from the 1.0.0 review, each free now and breaking later. No runtime code changes.

## UMD global: `pd` -> `pwc`

The UMD builds still registered the stale global `pd`. Renamed to `pwc`, matching the bundle filename. Nothing in the repo, examples or docs referenced `pd` (verified by grep - the only hits were minified vendored wasm glue). Verified live: `spinning-cube-umd.html` boots with `window.pwc` exposing the API and `window.pd` undefined.

## CJS-flavored type declarations

Two related defects, confirmed by `publint` and `@arethetypeswrong/cli`:

1. A lone `index.d.ts` inside a `"type": "module"` package is interpreted as an ES module declaration, so resolving types through the `require` condition claimed the CJS build was ESM ("masquerading as ESM").
2. The emitted `.d.ts` tree kept the source's extensionless relative imports (`from './app'`), which Node16 resolution rejects in **both** flavors - so `node16` consumers hit internal resolution errors even from ESM. This half was pre-existing and invisible until checked.

A new `utils/fix-declarations.mjs` postbuild step rewrites the `.d.ts` specifiers to `.js` and emits a parallel `.d.cts` tree using `.cjs` specifiers (so each tree resolves within its own flavor), and the exports map now declares per-condition `types`:

```json
".": {
  "import":  { "types": "./dist/index.d.ts",  "default": "./dist/pwc.mjs" },
  "require": { "types": "./dist/index.d.cts", "default": "./dist/pwc.cjs" }
}
```

**Before:** `attw` reported `node16 (from CJS): Internal resolution error` and `node16 (from ESM): Internal resolution error`.
**After:** `publint`: All good. `attw`: No problems found - green across node10, node16-CJS, node16-ESM and bundler.

## `"sideEffects": true`, explicitly

publint suggests `false`, which would be actively wrong: importing this package exists to run 28 `customElements.define` calls, and `false` licenses bundlers to tree-shake them all away. `true` is the current implicit behavior - declaring it makes the intent auditable and pins it against future "optimization".

## `engines.node: ">=18.3.0"`

Matches the `playcanvas` peer's own floor - this package cannot support less than its peer.

## Verification

- `publint` clean, `attw --pack` green in all four resolution modes
- Full suite (612 tests), type-check, CEM validation all pass
- UMD example verified in a browser against the rebuilt `dist/`
- `npm pack --dry-run` shows `dist/index.d.cts` shipping alongside `index.d.ts`

One note for the User Manual: if any docs mention the UMD global, they should say `pwc` from the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
