### PR TITLE
Size 'pc-app' like a replaced element instead of filling the window

### DIFF
--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -16,9 +16,11 @@ canvas {
 }
 
 /* pc-app is sized like a video element - a block box the page's CSS controls. The examples are
-   all full-viewport experiences, so size it to the visible viewport. */
+   all full-viewport experiences, so size it to the visible viewport (100vh is the fallback for
+   browsers without dynamic viewport units). */
 pc-app {
     width: 100%;
+    height: 100vh;
     height: 100dvh;
 }
 

--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -15,6 +15,13 @@ canvas {
     touch-action: none;
 }
 
+/* pc-app is sized like a video element - a block box the page's CSS controls. The examples are
+   all full-viewport experiences, so size it to the visible viewport. */
+pc-app {
+    width: 100%;
+    height: 100dvh;
+}
+
 .example-button-container {
     position: absolute;
     right: max(16px, env(safe-area-inset-right));

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,7 +4,7 @@ import {
     AppOptions,
     createGraphicsDevice,
     ElementInput,
-    FILLMODE_FILL_WINDOW,
+    FILLMODE_NONE,
     Keyboard,
     Mouse,
     Picker,
@@ -77,10 +77,33 @@ import { parseBool, parseEnum, parseNumber } from './parse';
 const pointerEventTypes = ['pointermove', 'pointerdown', 'pointerup', 'pointerenter', 'pointerleave'] as const;
 
 /**
+ * Gives `pc-app` the sizing contract of a replaced element (`<video>`, `<img>`): a block-level
+ * box that the page's CSS sizes, defaulting to the canvas's own 300x150 intrinsic size, with the
+ * canvas and loading bar anchored to it. `:where()` keeps every declaration at zero specificity,
+ * so any page rule - however plain - overrides these defaults.
+ */
+const ensureBaseStyles = () => {
+    const id = 'pc-app-styles';
+    if (document.getElementById(id)) {
+        return;
+    }
+    const style = document.createElement('style');
+    style.id = id;
+    style.textContent = ':where(pc-app) { display: block; position: relative; width: 300px; height: 150px; }';
+    document.head.appendChild(style);
+};
+
+/**
  * The AppElement interface provides properties and methods for manipulating
  * {@link https://developer.playcanvas.com/user-manual/web-components/tags/pc-app/ | `<pc-app>`} elements.
  * The AppElement interface also inherits the properties and methods of the
  * {@link HTMLElement} interface.
+ *
+ * The element is sized like a replaced element such as `<video>`: a block-level box that the
+ * page's CSS controls, 300x150 by default. The application's canvas always fills the element,
+ * and the drawing buffer resolution follows the element's size (capped by `max-pixel-ratio`),
+ * tracked live via a ResizeObserver — so the element can be embedded at any size, resized by
+ * its container, or made fullscreen with ordinary CSS such as `width: 100vw; height: 100dvh`.
  *
  * @fires {ProgressEvent} progress - Fired while the application preloads its assets. `loaded` and
  * `total` are asset counts, not bytes, and an asset that fails to load still counts as loaded.
@@ -172,6 +195,13 @@ class AppElement extends AsyncElement {
     private _loadProgress = 0;
 
     /**
+     * Tracks the element's box so the drawing buffer and picker follow it. Created per boot once
+     * the application exists, and disconnected on teardown. `null` where ResizeObserver is
+     * unavailable (jsdom), where the boot-time resolution set is the only sizing that happens.
+     */
+    private _resizeObserver: ResizeObserver | null = null;
+
+    /**
      * The PlayCanvas application instance. `null` until the element is ready, and again once it
      * has been removed from the document — await {@link whenReady} or the element's `ready()`
      * promise before accessing it.
@@ -200,9 +230,6 @@ class AppElement extends AsyncElement {
     constructor() {
         super();
 
-        // Bind methods to maintain 'this' context
-        this._onWindowResize = this._onWindowResize.bind(this);
-
         // Track pointer listeners being added to and removed from descendant entities.
         // Registered once here rather than on every boot - the handlers no-op while there is no
         // canvas, and a re-booted element must not stack a second set.
@@ -214,6 +241,10 @@ class AppElement extends AsyncElement {
 
     async connectedCallback() {
         const generation = ++this._bootGeneration;
+
+        // Installed before the loading bar is created: the bar anchors to this element, which
+        // these styles make a positioned block box
+        ensureBaseStyles();
 
         // Created before the first await, so the bar is visible while modules and the graphics
         // device are created, and exists before any disconnect could need to clean it up
@@ -233,8 +264,11 @@ class AppElement extends AsyncElement {
             return;
         }
 
-        // Create and append the canvas to the element
+        // Create and append the canvas, filling the element's content box - the page sizes the
+        // element, and everything else follows. touch-action: none keeps touch drags driving the
+        // engine's input handlers instead of scrolling the page.
         this._canvas = document.createElement('canvas');
+        this._canvas.style.cssText = 'display: block; width: 100%; height: 100%; touch-action: none;';
         this.appendChild(this._canvas);
 
         // Configure device types based on backend selection
@@ -370,10 +404,21 @@ class AppElement extends AsyncElement {
         this._app = app;
         app.init(createOptions);
 
-        app.setCanvasFillMode(FILLMODE_FILL_WINDOW);
+        // FILLMODE_NONE leaves the canvas's CSS sizing alone (the engine's other fill modes
+        // stamp window-derived pixel sizes onto it); RESOLUTION_AUTO sizes the drawing buffer
+        // from the canvas's client size
+        app.setCanvasFillMode(FILLMODE_NONE);
         app.setCanvasResolution(RESOLUTION_AUTO);
 
         this._pickerCreate();
+
+        // Track the element's box rather than the window: containers resize without any window
+        // event (splitter drags, flex reflow, animations). Guarded because jsdom has no
+        // ResizeObserver - there, the resolution set above is the only sizing that happens.
+        if (typeof ResizeObserver !== 'undefined') {
+            this._resizeObserver = new ResizeObserver(() => this._syncCanvasSize());
+            this._resizeObserver.observe(this);
+        }
 
         // Get all pc-asset elements that are direct children of the pc-app element
         const assetElements = this.querySelectorAll<AssetElement>(':scope > pc-asset');
@@ -464,9 +509,6 @@ class AppElement extends AsyncElement {
             // first rAF tick
             app.once('frameend', () => this._bar?.complete());
 
-            // Handle window resize to keep the canvas responsive
-            window.addEventListener('resize', this._onWindowResize);
-
             this._onReady();
         });
     }
@@ -496,8 +538,9 @@ class AppElement extends AsyncElement {
         this._hierarchyReady = false;
         this._resetReady();
 
-        // Remove event listeners
-        window.removeEventListener('resize', this._onWindowResize);
+        // Stop tracking the element's size
+        this._resizeObserver?.disconnect();
+        this._resizeObserver = null;
 
         // Remove the canvas
         if (this._canvas && this.contains(this._canvas)) {
@@ -506,10 +549,18 @@ class AppElement extends AsyncElement {
         }
     }
 
-    private _onWindowResize() {
-        if (this.app) {
-            this.app.resizeCanvas();
+    /**
+     * Syncs the drawing buffer and the picker to the canvas's current CSS size. The picker must
+     * track the buffer, or picks would land at stale coordinates after a resize. Skipped while
+     * an XR session presents - the session owns the buffer size.
+     */
+    private _syncCanvasSize() {
+        if (!this.app || this.app.xr?.active) {
+            return;
         }
+        this.app.updateCanvasSize();
+        const { width, height } = this.app.graphicsDevice;
+        this._picker?.resize(width, height);
     }
 
     private _pickerCreate() {
@@ -900,7 +951,7 @@ class AppElement extends AsyncElement {
         this._maxPixelRatio = value;
         if (this.app) {
             this.app.graphicsDevice.maxPixelRatio = value;
-            this.app.resizeCanvas();
+            this._syncCanvasSize();
         }
     }
 

--- a/src/loading-bar.ts
+++ b/src/loading-bar.ts
@@ -28,9 +28,9 @@ class LoadingBar {
         this._track.setAttribute('aria-label', 'Loading');
         this._track.setAttribute('aria-valuemin', '0');
         this._track.setAttribute('aria-valuemax', '100');
-        // Fixed positioning matches the canvas, which always fills the window (FILLMODE_FILL_WINDOW)
+        // Anchored to the pc-app element, which the library's base styles make a positioned box
         this._track.style.cssText = [
-            'position: fixed',
+            'position: absolute',
             'top: 0',
             'left: 0',
             'width: 100%',

--- a/test/integration/app-sizing.test.ts
+++ b/test/integration/app-sizing.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AppElement } from '../../src/app';
+import { bootApp, settle } from '../helpers/app';
+import { mount } from '../helpers/dom';
+import { useGuard } from '../helpers/guard';
+
+/**
+ * The element's sizing contract: pc-app is a replaced-element-style block box that the page's
+ * CSS controls, with the canvas filling it and the drawing buffer following the canvas's client
+ * size. jsdom has no layout engine, so the client size is pinned at 800x600 by test/setup/dom.ts.
+ */
+describe('<pc-app> sizing', () => {
+    useGuard();
+
+    it('installs the zero-specificity base styles exactly once', async () => {
+        const handle = mount('<pc-app backend="null"></pc-app><pc-app backend="null"></pc-app>');
+        await settle(handle.container);
+
+        const sheets = document.querySelectorAll('#pc-app-styles');
+        expect(sheets).toHaveLength(1);
+
+        // :where() is what keeps any page rule able to override these defaults
+        const css = sheets[0].textContent!;
+        expect(css).toContain(':where(pc-app)');
+        expect(css).toContain('display: block');
+        expect(css).toContain('position: relative');
+    });
+
+    it('fills the element with a block canvas that keeps touch input', async () => {
+        const { appElement } = await bootApp();
+        const canvas = appElement.querySelector('canvas')!;
+
+        expect(canvas.style.display).toBe('block');
+        expect(canvas.style.width).toBe('100%');
+        expect(canvas.style.height).toBe('100%');
+        expect(canvas.style.touchAction).toBe('none');
+    });
+
+    it('sizes the drawing buffer from the canvas client size, not the window', async () => {
+        const { app } = await bootApp();
+
+        // 800x600 is the stubbed client size; jsdom's window is 1024x768, which must not leak in
+        expect(app.graphicsDevice.width).toBe(800);
+        expect(app.graphicsDevice.height).toBe(600);
+    });
+
+    it('keeps the picker aligned with the drawing buffer when the resolution changes', async () => {
+        vi.stubGlobal('devicePixelRatio', 2);
+
+        const { appElement } = await bootApp('', { appAttributes: 'max-pixel-ratio="1"' });
+        const picker = (appElement as unknown as { _picker: { width: number; height: number } })._picker;
+        expect(picker.width).toBe(800);
+        expect(picker.height).toBe(600);
+
+        appElement.setAttribute('max-pixel-ratio', '2');
+
+        // The buffer doubled, and the picker must double with it or picks land at stale
+        // coordinates
+        expect(picker.width).toBe(1600);
+        expect(picker.height).toBe(1200);
+    });
+
+    it('anchors the loading bar to the element, not the window', () => {
+        const handle = mount('<pc-app backend="null"></pc-app>');
+        const bar = handle.get<AppElement>('pc-app').querySelector<HTMLElement>('[role="progressbar"]');
+
+        expect(bar).not.toBeNull();
+        expect(bar!.style.position).toBe('absolute');
+    });
+});

--- a/test/setup/dom.ts
+++ b/test/setup/dom.ts
@@ -38,9 +38,9 @@ import '../../src/index';
  * inside connectedCallback, so no test can get a handle on it before the read happens. Hence the
  * prototype.
  *
- * Note that canvas.style.width IS set correctly by FILLMODE_FILL_WINDOW (jsdom's window is
- * 1024x768) - it is only the layout read-back that is dead, so the stubs go on the layout
- * accessors and not on style.
+ * Note that the canvas's style.width IS set (AppElement styles it to fill the element) - it is
+ * only the layout read-back that is dead, so the stubs go on the layout accessors and not on
+ * style.
  */
 type Viewport = {
     width: number;
@@ -102,8 +102,11 @@ Object.defineProperty(window, 'devicePixelRatio', {
 
 // Deliberately NOT polyfilled:
 //
-// - ResizeObserver: zero occurrences in the engine source and zero in src/. @playcanvas/react
-//   mocks it because its own Application component uses it; nothing here does.
+// - ResizeObserver: absent in jsdom, and AppElement guards its use - without it, the boot-time
+//   setCanvasResolution(RESOLUTION_AUTO) call (which reads the stubbed accessors above) is the
+//   only sizing that happens. That is exactly what these tests need: deterministic dimensions
+//   with no observer callbacks firing between assertions. Resize-driven syncing is exercised
+//   through the max-pixel-ratio setter, which shares the same code path.
 // - navigator.xr: absent means XrManager reports supported === false, which is the correct
 //   headless answer. A truthy stub would push it down paths jsdom cannot honour.
 // - AudioContext: absent means SoundManager's lazy context getter returns null. Verified that


### PR DESCRIPTION
The largest remaining "free now, breaking later" item before 1.0.0: `<pc-app>` ignored its own CSS box.

## Before

The element hardcoded `FILLMODE_FILL_WINDOW`, so the engine stamped window-derived pixel sizes onto the canvas on every resize - the element's own box was never consulted. The element shipped no host styles, so it laid out as `display: inline` (the custom-element default): measured live, a `<pc-app>` in a 400x300 container was a 17px-tall line box while its canvas painted at full window size, bursting out of the container. Consequences:

- Embedding in a card, split pane or blog post was effectively unsupported - only full-viewport pages worked, which is why nobody noticed.
- One app per page, implicitly (two apps would both fill the window).
- The loading bar had already inherited the coupling (`position: fixed`).
- Only `window.resize` was observed, so a container resize could never be tracked.
- None of this was documented.

## After

`<pc-app>` behaves like a replaced element (`<video>`, `<img>`), the model proven by `<model-viewer>` and already used by `@playcanvas/react`:

- An injected zero-specificity rule - `:where(pc-app) { display: block; position: relative; width: 300px; height: 150px; }` - gives it the canvas's intrinsic default size while letting any page rule override it. One `<style>` element, injected once, shared by all apps.
- The canvas fills the element's content box (`display: block; width: 100%; height: 100%` inline), with `FILLMODE_NONE` + `RESOLUTION_AUTO` so the drawing buffer follows the canvas's client size, capped by `max-pixel-ratio` as before.
- A `ResizeObserver` on the element replaces the window resize listener, so splitter drags, flex reflow and container animations all track - not just window resizes. The engine already skips buffer updates while an XR session presents.
- The loading bar anchors to the element (`position: absolute`).
- Fullscreen becomes ordinary CSS: the shared example stylesheet now sizes `pc-app { width: 100%; height: 100dvh }` and every example works as before. Fill modes disappear from the mental model entirely - CSS is the sizing API (`aspect-ratio` even subsumes `FILLMODE_KEEP_ASPECT`).

### Bonus fixes

- **Picker miscalibration on resize**: the picker was created at boot size and never resized, so picking after any window resize sampled at stale coordinates. The resize path now keeps it aligned with the drawing buffer (same as @playcanvas/react's `usePicker`).
- **`touch-action: none`** is now set on the canvas by the library, so touch drags drive camera/input scripts instead of scrolling the page - previously every consumer had to know to add this in page CSS.

## Verification

- 5 new integration tests (base styles injected once across multiple apps, canvas fill styles, buffer-from-client-size, picker/buffer alignment through the `max-pixel-ratio` path, loading bar anchoring); full suite 617 green; type-check, lint, CEM validation clean.
- Verified live against the built `dist/`:
  - a `<pc-app>` in a 400x300 container renders exactly 400x300 with a 600x450 buffer (dpr 1.5), inside the container;
  - growing the container to 600x450 (no window resize) retracks canvas and buffer via the ResizeObserver;
  - an unstyled `<pc-app>` measures the replaced-element default 300x150, and two apps coexist on one page;
  - the physics and annotations examples still fill the viewport at full DPR with hotspot overlays intact.

## Breaking change

Pages that relied on the implicit fill-window behavior must now size the element (e.g. `pc-app { width: 100%; height: 100dvh }`). This is exactly why it needs to land before 1.0.0 - afterwards it is semver-major. The `pc-app` User Manual page needs a short "Sizing" section; I can prepare that developer-site PR next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
