### PR TITLE
Refresh the examples browser UI

### DIFF
--- a/examples/css/browser.css
+++ b/examples/css/browser.css
@@ -61,7 +61,6 @@ body {
     border-right: 1px solid var(--color-border);
     height: 100dvh;
     padding-left: env(safe-area-inset-left);
-    outline: none;
 }
 
 /* Header styles */
@@ -402,7 +401,6 @@ body {
     flex: 1;
     min-width: 0;
     font-weight: 400;
-    outline: none;
 }
 
 .example-category {

--- a/examples/css/browser.css
+++ b/examples/css/browser.css
@@ -7,15 +7,36 @@
 :root {
     color-scheme: dark;
 
-    --color-bg: #121212;                          /* page base / behind iframe */
-    --color-surface: #1a1a1a;                     /* sidebar */
-    --color-surface-raised: #242424;              /* search input, QR modal, hamburger */
+    /* Sync points (values duplicated by necessity - there is no build step):
+       - index.html <meta name="theme-color">  = --color-surface (#1a1a1a)
+       - manifest.json theme_color             = --color-surface (#1a1a1a)
+       - manifest.json background_color        = --color-bg (#121212)
+       - css/example.css                       = example pages do not load this file; they carry
+         their own copies of the shared literals. Update both files together. */
+
+    --color-bg: #121212;                             /* page base / behind iframe */
+    --color-surface: #1a1a1a;                        /* sidebar, title bar */
+    --color-surface-raised: #242424;                 /* search input, QR modal */
     --color-border: #333;
+    --color-border-strong: #4a4a4a;
+
     --color-text: #e0e0e0;
     --color-text-dim: #999;
-    --color-accent: #f60;                         /* PlayCanvas orange */
-    --color-accent-soft: rgba(255, 102, 0, 0.15);
-    --color-focus: #ff8533;
+
+    --color-accent: #f60;                            /* PlayCanvas orange */
+    --color-accent-bright: #ff8533;                  /* active text, focus rings */
+    --color-focus: var(--color-accent-bright);
+    --color-accent-soft: rgba(255, 102, 0, 0.12);    /* active-row tint */
+
+    --color-hover: rgba(255, 255, 255, 0.07);        /* neutral hover fill */
+    --color-hover-strong: rgba(255, 255, 255, 0.12); /* pressed state */
+
+    --radius-s: 4px;
+    --radius-m: 6px;
+    --radius-l: 8px;
+    --radius-xl: 12px;
+
+    --titlebar-height: 48px;
 }
 
 /* Base layout */
@@ -32,12 +53,6 @@ body {
     outline-offset: -2px;
 }
 
-/* Hide menu toggle by default */
-.menu-toggle {
-    display: none;
-    color: var(--color-text);
-}
-
 /* Sidebar */
 .sidebar {
     display: flex;
@@ -46,42 +61,54 @@ body {
     border-right: 1px solid var(--color-border);
     height: 100dvh;
     padding-left: env(safe-area-inset-left);
+    outline: none;
 }
 
 /* Header styles */
 .header {
     display: flex;
     align-items: center;
-    gap: 12px;
-    padding: 20px 16px 16px;
-    padding-top: max(20px, env(safe-area-inset-top));
+    gap: 10px;
+    padding: 16px;
+    padding-top: max(16px, env(safe-area-inset-top));
 }
 
 .logo {
-    width: 40px;
-    height: 40px;
-    border-radius: 8px;
+    width: 32px;
+    height: 32px;
+    border-radius: var(--radius-m);
 }
 
 .header h2 {
-    font-size: 16px;
-    line-height: 1.25;
+    font-size: 14px;
     font-weight: 600;
+    letter-spacing: 0.01em;
+    line-height: 1.3;
     color: var(--color-text);
+}
+
+.header h2 span {
+    display: block;
+    font-size: 12px;
+    font-weight: 400;
+    color: var(--color-text-dim);
 }
 
 .github-link {
     display: flex;
     align-items: center;
     justify-content: center;
+    flex-shrink: 0;
+    width: 32px;
+    height: 32px;
     margin-left: auto;
-    padding: 6px;
-    border-radius: 6px;
+    border-radius: var(--radius-m);
     color: var(--color-text-dim);
-    transition: color 0.2s;
+    transition: background-color 0.15s, color 0.15s;
 }
 
 .github-link:hover {
+    background: var(--color-hover);
     color: var(--color-text);
 }
 
@@ -102,13 +129,13 @@ body {
 
 #search-input {
     width: 100%;
-    padding: 8px 12px 8px 34px;
+    padding: 8px 60px 8px 34px;
     font-size: 13px;
     font-family: inherit;
     color: var(--color-text);
     background: var(--color-surface-raised);
     border: 1px solid var(--color-border);
-    border-radius: 6px;
+    border-radius: var(--radius-m);
     outline: none;
     transition: border-color 0.2s;
 }
@@ -119,6 +146,76 @@ body {
 
 #search-input:focus {
     border-color: var(--color-accent);
+}
+
+/* The custom clear button replaces the native one */
+#search-input::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+    appearance: none;
+}
+
+.search-kbd {
+    position: absolute;
+    right: 8px;
+    padding: 3px 6px;
+    font-family: inherit;
+    font-size: 11px;
+    line-height: 1;
+    color: var(--color-text-dim);
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-s);
+    pointer-events: none;
+}
+
+.search:focus-within .search-kbd,
+#search-input:not(:placeholder-shown) ~ .search-kbd {
+    display: none;
+}
+
+@media (hover: none) {
+    .search-kbd {
+        display: none;
+    }
+}
+
+.search-count {
+    display: none;
+    position: absolute;
+    right: 32px;
+    font-size: 11px;
+    color: var(--color-text-dim);
+    font-variant-numeric: tabular-nums;
+    pointer-events: none;
+}
+
+#search-input:not(:placeholder-shown) ~ .search-count {
+    display: block;
+}
+
+.search-clear {
+    display: none;
+    position: absolute;
+    right: 6px;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    border: none;
+    border-radius: var(--radius-s);
+    background: none;
+    color: var(--color-text-dim);
+    cursor: pointer;
+    transition: background-color 0.15s, color 0.15s;
+}
+
+#search-input:not(:placeholder-shown) ~ .search-clear {
+    display: flex;
+}
+
+.search-clear:hover {
+    background: var(--color-hover);
+    color: var(--color-text);
 }
 
 /* Example list styles */
@@ -141,11 +238,11 @@ body {
 
 #example-list::-webkit-scrollbar-thumb {
     background: var(--color-border);
-    border-radius: 4px;
+    border-radius: var(--radius-s);
 }
 
 #example-list::-webkit-scrollbar-thumb:hover {
-    background: #4a4a4a;
+    background: var(--color-border-strong);
 }
 
 .category-title {
@@ -161,6 +258,10 @@ body {
     margin-top: 4px;
 }
 
+.category-list {
+    list-style: none;
+}
+
 .hidden {
     display: none !important;
 }
@@ -171,73 +272,256 @@ body {
     color: var(--color-text-dim);
 }
 
-.example-link {
+.example-row {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    position: relative;
     gap: 8px;
     padding: 7px 8px 7px 12px;
     margin: 1px 0;
-    border-radius: 6px;
-    color: var(--color-text);
-    font-size: 14px;
-    text-decoration: none;
+    border-radius: var(--radius-m);
     transition: background-color 0.15s;
 }
 
-.example-link:hover {
+.example-row:hover {
+    background-color: var(--color-hover);
+}
+
+.example-row.active {
     background-color: var(--color-accent-soft);
 }
 
-.example-link.active {
-    background-color: var(--color-accent);
-    color: white;
+.example-row.active::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 6px;
+    bottom: 6px;
+    width: 3px;
+    border-radius: 2px;
+    background: var(--color-accent);
 }
 
-.link-buttons {
+.example-link {
+    color: var(--color-text);
+    font-size: 14px;
+    text-decoration: none;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Stretched link: the whole row activates the example */
+.example-link::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+}
+
+.example-row.active .example-link {
+    color: var(--color-accent-bright);
+    font-weight: 500;
+}
+
+.row-actions {
     display: flex;
-    gap: 4px;
+    gap: 2px;
     flex-shrink: 0;
+    position: relative;
+    z-index: 1;
+    opacity: 0.5;
 }
 
-.qr-button,
-.open-in-new {
+/* Reveal on demand where a pointer can hover; touch keeps the always-visible fallback above.
+   opacity (not visibility/display) so the buttons stay in the tab order and :focus-within can
+   reach them; pointer-events blocks clicks on the invisible targets. */
+@media (hover: hover) {
+    .row-actions {
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.12s ease;
+    }
+
+    .example-row:hover .row-actions,
+    .example-row:focus-within .row-actions {
+        opacity: 1;
+        pointer-events: auto;
+    }
+}
+
+.row-action {
     display: flex;
     align-items: center;
     justify-content: center;
-    opacity: 0.5;
-    padding: 4px;
-    border-radius: 4px;
-    border: none;
-    background: none;
-    cursor: pointer;
-    color: currentColor;
     width: 24px;
     height: 24px;
+    padding: 0;
+    border: none;
+    border-radius: var(--radius-s);
+    background: none;
+    cursor: pointer;
+    color: var(--color-text-dim);
+    transition: background-color 0.15s, color 0.15s;
 }
 
-.qr-button:hover,
-.open-in-new:hover {
-    opacity: 1;
-    background: rgba(255, 255, 255, 0.1);
+.row-action:hover {
+    background: var(--color-hover-strong);
+    color: var(--color-text);
 }
 
-.qr-button svg,
-.open-in-new svg {
-    stroke-width: 2;
+.example-row.active .row-action {
+    color: var(--color-accent-bright);
 }
 
 /* Main content */
 .main {
+    display: flex;
+    flex-direction: column;
+    position: relative;
     height: 100dvh;
     overflow: hidden;
 }
 
+/* Title bar */
+.title-bar {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex: none;
+    height: var(--titlebar-height);
+    padding: 0 max(12px, env(safe-area-inset-right)) 0 12px;
+    background: var(--color-surface);
+    border-bottom: 1px solid var(--color-border);
+}
+
+.example-title {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    flex: 1;
+    min-width: 0;
+    font-weight: 400;
+    outline: none;
+}
+
+.example-category {
+    font-size: 13px;
+    color: var(--color-text-dim);
+    white-space: nowrap;
+}
+
+.example-separator {
+    font-size: 13px;
+    color: var(--color-text-dim);
+    opacity: 0.5;
+}
+
+.example-name {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--color-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.title-bar-nav,
+.title-bar-actions {
+    display: flex;
+    gap: 4px;
+    flex: none;
+}
+
+.title-bar-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border: none;
+    border-radius: var(--radius-m);
+    background: transparent;
+    color: var(--color-text-dim);
+    cursor: pointer;
+    transition: background-color 0.15s, color 0.15s;
+}
+
+.title-bar-button:hover {
+    background: var(--color-hover);
+    color: var(--color-text);
+}
+
+.title-bar-button:active {
+    background: var(--color-hover-strong);
+}
+
+.title-bar-button:disabled {
+    opacity: 0.35;
+    cursor: default;
+}
+
+.title-bar-button:disabled:hover {
+    background: transparent;
+    color: var(--color-text-dim);
+}
+
+.title-bar-divider {
+    width: 1px;
+    height: 16px;
+    background: var(--color-border);
+    margin: 0 6px;
+    flex: none;
+}
+
+/* Hide menu toggle on desktop - it lives in the title bar on mobile */
+.menu-toggle {
+    display: none;
+}
+
+/* Iframe and loading treatment */
 #example-frame {
+    flex: 1;
+    min-height: 0;
     width: 100%;
-    height: 100%;
     border: none;
     background: var(--color-bg);
+    opacity: 1;
+    transition: opacity 0.25s ease;
+}
+
+.main.loading #example-frame {
+    opacity: 0;
+    transition-duration: 0.1s;
+}
+
+/* Spinner: the transition delay means fast loads never flash it */
+.main::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    top: calc(50% + var(--titlebar-height) / 2);
+    width: 28px;
+    height: 28px;
+    margin: -14px 0 0 -14px;
+    border: 2px solid rgba(255, 255, 255, 0.15);
+    border-top-color: var(--color-accent);
+    border-radius: 50%;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.main.loading::after {
+    opacity: 1;
+    animation: spin 0.8s linear infinite;
+    transition: opacity 0.15s ease 0.25s;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 /* Sidebar overlay (mobile) */
@@ -255,20 +539,8 @@ body {
 
     .menu-toggle {
         display: flex;
-        position: fixed;
-        top: max(16px, env(safe-area-inset-top));
-        left: max(16px, env(safe-area-inset-left));
-        width: 40px;
-        height: 40px;
-        background: rgba(26, 26, 26, 0.9);
-        border: 1px solid var(--color-border);
-        border-radius: 8px;
-        z-index: 999;
-        cursor: pointer;
-        align-items: center;
-        justify-content: center;
-        backdrop-filter: blur(8px);
-        -webkit-backdrop-filter: blur(8px);
+        width: 36px;
+        height: 36px;
     }
 
     .sidebar {
@@ -301,6 +573,20 @@ body {
         width: 100%;
         height: 100%;
     }
+
+    /* The bar owns the notch region; its surface matches the theme-color meta */
+    .title-bar {
+        height: calc(var(--titlebar-height) + env(safe-area-inset-top));
+        padding-top: env(safe-area-inset-top);
+        padding-left: max(12px, env(safe-area-inset-left));
+    }
+}
+
+@media (max-width: 420px) {
+    .example-category,
+    .example-separator {
+        display: none;
+    }
 }
 
 /* QR Code Modal styles */
@@ -311,34 +597,97 @@ body {
     transform: translate(-50%, -50%);
     padding: 0;
     border: 1px solid var(--color-border);
-    border-radius: 12px;
+    border-radius: var(--radius-xl);
     background: var(--color-surface-raised);
     color: var(--color-text);
     margin: 0;
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+}
+
+#qr-modal[open] {
+    animation: modal-in 0.18s ease;
+}
+
+@keyframes modal-in {
+    from {
+        opacity: 0;
+        transform: translate(-50%, -50%) scale(0.96);
+    }
 }
 
 #qr-modal::backdrop {
-    background: rgba(0, 0, 0, 0.7);
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
 }
 
 .qr-modal-content {
-    padding: 24px;
+    position: relative;
+    padding: 20px 24px 24px;
     text-align: center;
 }
 
-.qr-modal-content p {
-    margin-top: 16px;
-    font-size: 14px;
+.qr-modal-close {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    border: none;
+    border-radius: var(--radius-m);
+    background: transparent;
     color: var(--color-text-dim);
+    cursor: pointer;
+    transition: background-color 0.15s, color 0.15s;
+}
+
+.qr-modal-close:hover {
+    background: var(--color-hover);
+    color: var(--color-text);
+}
+
+#qr-modal-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--color-text);
+    margin: 0 20px 14px;
 }
 
 #qr-code {
-    background: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 164px;
+    min-height: 164px;
+    background: #fff; /* the QR quiet zone is functional - deliberately light */
     padding: 12px;
-    border-radius: 8px;
+    border-radius: var(--radius-l);
+    color: #333;
+    font-size: 13px;
 }
 
 #qr-code img {
     display: block;
     margin: 0 auto;
+}
+
+.qr-modal-caption {
+    margin-top: 14px;
+    font-size: 13px;
+    color: var(--color-text-dim);
+}
+
+/* Placed last so the override ordering is explicit */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
 }

--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -1,6 +1,14 @@
+/* Shared literals kept in sync with css/browser.css :root (example pages do not load that
+   file): page base #121212, accent #f60, bright accent #ff8533. Update both files together. */
+
+:root {
+    color-scheme: dark;
+}
+
 body {
-    margin: 0; 
-    overflow: hidden; 
+    margin: 0;
+    overflow: hidden;
+    background-color: #121212; /* pre-scene paint matches the shell, so example swaps never flash */
     touch-action: none;
     -webkit-touch-callout: none;
     -webkit-user-select: none;
@@ -45,40 +53,98 @@ pc-app {
     top: max(16px, env(safe-area-inset-top));
 }
 
+/* Dark glass, matching the shell's chrome: translucent #121212 over the scene, hairline light
+   border to carry the edge on dark scenes */
 .example-button {
     display: flex;
     position: relative;
     height: 40px;
-    background-color: rgba(255, 255, 255, 0.9);
-    border: 1px solid #ddd;
+    background-color: rgba(18, 18, 18, 0.66);
+    border: 1px solid rgba(255, 255, 255, 0.12);
     border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
     cursor: pointer;
     align-items: center;
     justify-content: center;
     padding: 0 16px;
     margin: 0;
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
-    transition: background-color 0.2s;
-    color: #2c3e50;
-    font-weight: bold;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    transition: background-color 0.2s, border-color 0.2s, color 0.2s;
+    color: rgba(255, 255, 255, 0.92);
+    font-weight: 600;
+}
+
+@supports not (backdrop-filter: blur(12px)) {
+    .example-button {
+        background-color: rgba(18, 18, 18, 0.88);
+    }
+}
+
+.example-button:hover {
+    background-color: rgba(18, 18, 18, 0.82);
+    border-color: rgba(255, 255, 255, 0.22);
+    color: #fff;
+}
+
+.example-button:focus-visible {
+    outline: 2px solid #ff8533;
+    outline-offset: 2px;
 }
 
 .example-button.icon {
     width: 40px;
     padding: 0;
-    background-position: center center;
-    background-repeat: no-repeat;
-    background-size: 24px 24px;
 }
 
-.example-button.icon.icon-ar { background-image: url("../img/ar.svg"); }
-.example-button.icon.icon-vr { background-image: url("../img/vr.svg"); }
-.example-button.icon.icon-fs-enter { background-image: url("../img/fullscreen-enter.svg"); }
-.example-button.icon.icon-fs-exit { background-image: url("../img/fullscreen-exit.svg"); }
-.example-button.icon.icon-source { background-image: url("../img/code.svg"); }
-.example-button.icon.icon-stackblitz { background-image: url("../img/stackblitz.svg"); }
+/* Icons are masks rather than background images, so they tint via currentColor - the mixed
+   source fills and viewBoxes are irrelevant because only the SVG's alpha channel is used */
+.example-button.icon::before {
+    content: "";
+    width: 24px;
+    height: 24px;
+    background-color: currentColor;
+    -webkit-mask: center / 24px 24px no-repeat;
+    mask: center / 24px 24px no-repeat;
+}
 
-.example-button:hover {
-    background-color: rgba(255, 255, 255, 1);
+.example-button.icon.icon-ar::before {
+    -webkit-mask-image: url("../img/ar.svg");
+    mask-image: url("../img/ar.svg");
+}
+
+.example-button.icon.icon-vr::before {
+    -webkit-mask-image: url("../img/vr.svg");
+    mask-image: url("../img/vr.svg");
+}
+
+.example-button.icon.icon-fs-enter::before {
+    -webkit-mask-image: url("../img/fullscreen-enter.svg");
+    mask-image: url("../img/fullscreen-enter.svg");
+}
+
+.example-button.icon.icon-fs-exit::before {
+    -webkit-mask-image: url("../img/fullscreen-exit.svg");
+    mask-image: url("../img/fullscreen-exit.svg");
+}
+
+.example-button.icon.icon-source::before {
+    -webkit-mask-image: url("../img/code.svg");
+    mask-image: url("../img/code.svg");
+}
+
+.example-button.icon.icon-stackblitz::before {
+    -webkit-mask-image: url("../img/stackblitz.svg");
+    mask-image: url("../img/stackblitz.svg");
+}
+
+/* Placed last so the override ordering is explicit */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
 }

--- a/examples/index.html
+++ b/examples/index.html
@@ -6,8 +6,8 @@
         <title>PlayCanvas Web Components Examples</title>
 
         <!-- Favicon -->
-        <link rel="icon" type="image/png" href="img/playcanvas.png">
-        <link rel="apple-touch-icon" href="img/playcanvas.png">
+        <link rel="icon" type="image/png" href="img/playcanvas-192.png">
+        <link rel="apple-touch-icon" href="img/playcanvas-192.png">
 
         <!-- SEO -->
         <meta name="description" content="Examples showcasing PlayCanvas Web Components capabilities and features">
@@ -31,15 +31,14 @@
         <link rel="manifest" href="manifest.json">
 
         <link rel="stylesheet" href="css/browser.css">
-        <script src="https://cdn.jsdelivr.net/npm/qrcode-generator@1.4.4/qrcode.min.js"></script>
     </head>
     <body>
-        <aside class="sidebar">
+        <aside class="sidebar" id="sidebar" tabindex="-1">
             <header class="header">
-                <img src="img/playcanvas.png" alt="PlayCanvas Logo" class="logo">
-                <h2>PlayCanvas<br>Web Components</h2>
+                <img src="img/playcanvas-192.png" alt="PlayCanvas Logo" class="logo" width="32" height="32">
+                <h2>PlayCanvas <span>Web Components</span></h2>
                 <a class="github-link" href="https://github.com/playcanvas/web-components" target="_blank" rel="noopener" aria-label="View on GitHub">
-                    <svg width="20" height="20" viewBox="0 0 16 16" aria-hidden="true">
+                    <svg width="18" height="18" viewBox="0 0 16 16" aria-hidden="true">
                         <path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
                     </svg>
                 </a>
@@ -50,24 +49,74 @@
                     <line x1="21" y1="21" x2="16.65" y2="16.65"/>
                 </svg>
                 <input type="search" id="search-input" placeholder="Search examples" autocomplete="off" spellcheck="false" aria-label="Search examples">
+                <kbd class="search-kbd" aria-hidden="true">/</kbd>
+                <span class="search-count" aria-hidden="true"></span>
+                <button type="button" class="search-clear" aria-label="Clear search">
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
+                        <line x1="18" y1="6" x2="6" y2="18"/>
+                        <line x1="6" y1="6" x2="18" y2="18"/>
+                    </svg>
+                </button>
             </div>
             <nav id="example-list" aria-label="Examples"></nav>
         </aside>
         <main class="main">
-            <iframe id="example-frame" allow="fullscreen; xr-spatial-tracking;"></iframe>
+            <header class="title-bar">
+                <button type="button" class="menu-toggle title-bar-button" aria-label="Menu" aria-expanded="false" aria-controls="sidebar">
+                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" fill="currentColor"/>
+                    </svg>
+                </button>
+                <h1 id="example-title" class="example-title" aria-live="polite" tabindex="-1">
+                    <span class="example-category" id="example-category"></span><span class="example-separator" aria-hidden="true">/</span><span class="example-name" id="example-name"></span>
+                </h1>
+                <div class="title-bar-nav">
+                    <button type="button" id="prev-example" class="title-bar-button" aria-label="Previous example" aria-keyshortcuts="[" title="Previous example">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
+                            <polyline points="15 18 9 12 15 6"/>
+                        </svg>
+                    </button>
+                    <button type="button" id="next-example" class="title-bar-button" aria-label="Next example" aria-keyshortcuts="]" title="Next example">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
+                            <polyline points="9 18 15 12 9 6"/>
+                        </svg>
+                    </button>
+                </div>
+                <div class="title-bar-divider" role="presentation"></div>
+                <div class="title-bar-actions">
+                    <button type="button" id="title-qr-button" class="title-bar-button" aria-label="Show QR code for this example" title="View QR code for mobile">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
+                            <rect x="3" y="3" width="7" height="7"/>
+                            <rect x="14" y="3" width="7" height="7"/>
+                            <rect x="14" y="14" width="7" height="7"/>
+                            <rect x="3" y="14" width="7" height="7"/>
+                        </svg>
+                    </button>
+                    <a id="standalone-link" class="title-bar-button" target="_blank" rel="noopener" aria-label="Open example in a new tab" title="Open in new tab">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
+                            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+                            <polyline points="15 3 21 3 21 9"/>
+                            <line x1="10" y1="14" x2="21" y2="3"/>
+                        </svg>
+                    </a>
+                </div>
+            </header>
+            <iframe id="example-frame" title="Example" allow="fullscreen; xr-spatial-tracking;"></iframe>
         </main>
 
-        <button class="menu-toggle" aria-label="Toggle Menu">
-            <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" fill="currentColor"/>
-            </svg>
-        </button>
         <div class="sidebar-overlay" role="presentation"></div>
 
-        <dialog id="qr-modal">
+        <dialog id="qr-modal" aria-labelledby="qr-modal-title">
             <div class="qr-modal-content">
+                <button type="button" class="qr-modal-close" aria-label="Close" autofocus>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
+                        <line x1="18" y1="6" x2="6" y2="18"/>
+                        <line x1="6" y1="6" x2="18" y2="18"/>
+                    </svg>
+                </button>
+                <h2 id="qr-modal-title"></h2>
                 <div id="qr-code"></div>
-                <p>Scan to view on mobile</p>
+                <p class="qr-modal-caption">Scan to view on mobile</p>
             </div>
         </dialog>
 

--- a/examples/js/browser.mjs
+++ b/examples/js/browser.mjs
@@ -2,34 +2,84 @@ import { examples } from './example-list.mjs';
 import { setupNavigation } from './navigation.mjs';
 import { showQRCode } from './qr-code.mjs';
 
+const QR_ICON = `
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
+        <rect x="3" y="3" width="7" height="7"/>
+        <rect x="14" y="3" width="7" height="7"/>
+        <rect x="14" y="14" width="7" height="7"/>
+        <rect x="3" y="14" width="7" height="7"/>
+    </svg>`;
+
+const OPEN_ICON = `
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
+        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+        <polyline points="15 3 21 3 21 9"/>
+        <line x1="10" y1="14" x2="21" y2="3"/>
+    </svg>`;
+
+/** How long a hung example may keep the shell in its loading state. */
+const LOAD_TIMEOUT_MS = 10000;
+
 class ExampleBrowser {
     constructor() {
+        this.main = document.querySelector('.main');
         this.frame = document.getElementById('example-frame');
         this.exampleList = document.getElementById('example-list');
         this.searchInput = document.getElementById('search-input');
+        this.searchCount = document.querySelector('.search-count');
+        this.searchClear = document.querySelector('.search-clear');
         this.menuToggle = document.querySelector('.menu-toggle');
-        this.sidebar = document.querySelector('.sidebar');
+        this.sidebar = document.getElementById('sidebar');
         this.overlay = document.querySelector('.sidebar-overlay');
+        this.exampleTitle = document.getElementById('example-title');
+        this.exampleCategory = document.getElementById('example-category');
+        this.exampleName = document.getElementById('example-name');
+        this.prevButton = document.getElementById('prev-example');
+        this.nextButton = document.getElementById('next-example');
+        this.qrButton = document.getElementById('title-qr-button');
+        this.standaloneLink = document.getElementById('standalone-link');
 
-        // Per-example render state used by the search filter
+        this.activePath = null;
+        this.loadTimeout = null;
+
+        // Per-example render state used by the search filter and prev/next navigation
         this.entries = [];
 
-        this.setupNavigation();
+        // Fires for every cross-document navigation in the frame, including those driven by
+        // contentWindow.location.replace()
+        this.frame.addEventListener('load', () => this.endLoading());
+
+        this.updateURL = setupNavigation((path) => {
+            this.loadExample(path);
+            this.setActiveExample(path);
+        }).updateURL;
+
         this.createExampleList();
         this.setupSearch();
-        this.loadInitialExample();
+        this.setupTitleBar();
+        this.setupKeyboard();
         this.setupMobileMenu();
-    }
-
-    setupNavigation() {
-        this.updateURL = setupNavigation((path) => this.loadExample(path)).updateURL;
+        this.loadInitialExample();
     }
 
     loadExample(path) {
-        // Use location.replace() rather than setting the iframe's src: it
-        // swaps the iframe's history entry instead of pushing a new one, so
-        // browser back/forward only steps through the hash entries
+        this.beginLoading();
+        // Use location.replace() rather than setting the iframe's src: it swaps the iframe's
+        // history entry instead of pushing a new one, so browser back/forward only steps through
+        // the hash entries
         this.frame.contentWindow.location.replace(new URL(path, window.location.href));
+    }
+
+    beginLoading() {
+        clearTimeout(this.loadTimeout);
+        this.main.classList.add('loading');
+        // A hung example must never leave the shell dimmed; a later 'load' is harmless
+        this.loadTimeout = setTimeout(() => this.endLoading(), LOAD_TIMEOUT_MS);
+    }
+
+    endLoading() {
+        clearTimeout(this.loadTimeout);
+        this.main.classList.remove('loading');
     }
 
     createExampleList() {
@@ -51,97 +101,168 @@ class ExampleBrowser {
             title.textContent = category;
             section.appendChild(title);
 
+            const list = document.createElement('ul');
+            list.className = 'category-list';
+
             categoryExamples.forEach((example) => {
-                const link = this.createExampleLink(example);
-                section.appendChild(link);
+                const { row, link } = this.createExampleRow(example);
+                list.appendChild(row);
                 this.entries.push({
+                    example,
+                    row,
                     link,
                     searchText: `${example.name} ${example.category}`.toLowerCase()
                 });
             });
 
+            section.appendChild(list);
             this.exampleList.appendChild(section);
         });
 
         this.noResults = document.createElement('p');
         this.noResults.className = 'no-results';
+        this.noResults.setAttribute('role', 'status');
         this.noResults.textContent = 'No examples found';
         this.noResults.hidden = true;
         this.exampleList.appendChild(this.noResults);
     }
 
-    createExampleLink(example) {
+    createExampleRow(example) {
+        const row = document.createElement('li');
+        row.className = 'example-row';
+
+        // The row's actions are siblings of the anchor, never children - interactive elements
+        // must not nest. The anchor stretches over the whole row via CSS.
         const link = document.createElement('a');
-        link.href = `#${example.path}`;
         link.className = 'example-link';
-
-        const nameSpan = document.createElement('span');
-        nameSpan.textContent = example.name;
-        link.appendChild(nameSpan);
-
-        const buttonContainer = this.createButtonContainer(example);
-        link.appendChild(buttonContainer);
-
-        link.onclick = (e) => this.handleExampleClick(e, example, link);
-
-        return link;
-    }
-
-    createButtonContainer(example) {
-        const container = document.createElement('div');
-        container.className = 'link-buttons';
-
-        container.appendChild(this.createQRButton(example));
-        container.appendChild(this.createOpenInNewButton(example));
-
-        return container;
-    }
-
-    createQRButton(example) {
-        const button = document.createElement('button');
-        button.className = 'qr-button';
-        button.innerHTML = `
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
-                <rect x="3" y="3" width="7" height="7"/>
-                <rect x="14" y="3" width="7" height="7"/>
-                <rect x="14" y="14" width="7" height="7"/>
-                <rect x="3" y="14" width="7" height="7"/>
-            </svg>`;
-        button.title = 'View QR code for mobile';
-        button.onclick = (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            showQRCode(example.path);
-        };
-        return button;
-    }
-
-    createOpenInNewButton(example) {
-        const button = document.createElement('button');
-        button.className = 'open-in-new';
-        button.innerHTML = `
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
-                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
-                <polyline points="15 3 21 3 21 9"/>
-                <line x1="10" y1="14" x2="21" y2="3"/>
-            </svg>`;
-        button.title = 'Open in new tab';
-        button.onclick = (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            window.open(example.path, '_blank');
-        };
-        return button;
-    }
-
-    handleExampleClick(e, example, link) {
-        if (e.target.className !== 'open-in-new') {
+        link.href = `#${example.path}`;
+        link.textContent = example.name;
+        link.addEventListener('click', (e) => {
             e.preventDefault();
             this.loadExample(example.path);
             this.updateURL(example.path);
-            document.querySelectorAll('.example-link').forEach((l) => l.classList.remove('active'));
-            link.classList.add('active');
+            this.setActiveExample(example.path);
+            this.setMobileMenu(false);
+        });
+        row.appendChild(link);
+
+        const actions = document.createElement('div');
+        actions.className = 'row-actions';
+
+        const qrButton = document.createElement('button');
+        qrButton.type = 'button';
+        qrButton.className = 'row-action';
+        qrButton.setAttribute('aria-label', `Show QR code for ${example.name}`);
+        qrButton.title = 'View QR code for mobile';
+        qrButton.innerHTML = QR_ICON;
+        qrButton.addEventListener('click', () => showQRCode(example.path, example.name));
+        actions.appendChild(qrButton);
+
+        const openLink = document.createElement('a');
+        openLink.className = 'row-action';
+        openLink.href = example.path;
+        openLink.target = '_blank';
+        openLink.rel = 'noopener';
+        openLink.setAttribute('aria-label', `Open ${example.name} in a new tab`);
+        openLink.title = 'Open in new tab';
+        openLink.innerHTML = OPEN_ICON;
+        actions.appendChild(openLink);
+
+        row.appendChild(actions);
+
+        return { row, link };
+    }
+
+    /**
+     * The single place all active-example UI syncs: sidebar row, title bar, document title,
+     * iframe title and the standalone link. Called from row clicks, prev/next, popstate and the
+     * initial load.
+     * @param {string} path - The path of the example to mark active.
+     */
+    setActiveExample(path) {
+        this.activePath = path;
+        const example = examples.find((ex) => ex.path === path);
+
+        this.entries.forEach(({ example: ex, row, link }) => {
+            const active = ex.path === path;
+            row.classList.toggle('active', active);
+            if (active) {
+                link.setAttribute('aria-current', 'page');
+                link.scrollIntoView({ block: 'nearest' });
+            } else {
+                link.removeAttribute('aria-current');
+            }
+        });
+
+        this.exampleCategory.textContent = example?.category ?? '';
+        this.exampleName.textContent = example?.name ?? '';
+        this.frame.title = example ? `Example: ${example.name}` : 'Example';
+        this.standaloneLink.href = example?.path ?? '#';
+        if (example) {
+            document.title = `${example.name} - PlayCanvas Web Components Examples`;
         }
+
+        this.updatePrevNextState();
+    }
+
+    /** @returns {Array<object>} The entries not hidden by the search filter, in list order. */
+    visibleEntries() {
+        return this.entries.filter(({ row }) => !row.classList.contains('hidden'));
+    }
+
+    /**
+     * Navigates to the previous or next visible example. No wrap-around. When the active example
+     * is itself filtered out, forward enters the visible list at its start and backward at its
+     * end.
+     * @param {number} step - `-1` for previous, `1` for next.
+     */
+    navigateExample(step) {
+        const visible = this.visibleEntries();
+        if (visible.length === 0) {
+            return;
+        }
+
+        const index = visible.findIndex(({ example }) => example.path === this.activePath);
+        let target;
+        if (index === -1) {
+            target = step > 0 ? 0 : visible.length - 1;
+        } else {
+            target = index + step;
+            if (target < 0 || target >= visible.length) {
+                return;
+            }
+        }
+
+        const { example } = visible[target];
+        this.loadExample(example.path);
+        this.updateURL(example.path);
+        this.setActiveExample(example.path);
+    }
+
+    updatePrevNextState() {
+        const visible = this.visibleEntries();
+        const index = visible.findIndex(({ example }) => example.path === this.activePath);
+
+        this.prevButton.disabled = visible.length === 0 || index === 0;
+        this.nextButton.disabled = visible.length === 0 || index === visible.length - 1;
+
+        // Never strand keyboard focus on a control that just disabled itself
+        if (this.prevButton.disabled && document.activeElement === this.prevButton) {
+            (this.nextButton.disabled ? this.exampleTitle : this.nextButton).focus();
+        } else if (this.nextButton.disabled && document.activeElement === this.nextButton) {
+            (this.prevButton.disabled ? this.exampleTitle : this.prevButton).focus();
+        }
+    }
+
+    setupTitleBar() {
+        this.prevButton.addEventListener('click', () => this.navigateExample(-1));
+        this.nextButton.addEventListener('click', () => this.navigateExample(1));
+        this.qrButton.addEventListener('click', () => {
+            const example = examples.find((ex) => ex.path === this.activePath);
+            if (example) {
+                showQRCode(example.path, example.name);
+            }
+        });
     }
 
     setupSearch() {
@@ -151,6 +272,8 @@ class ExampleBrowser {
 
         this.searchInput.addEventListener('keydown', (e) => {
             if (e.key === 'Escape') {
+                // preventDefault marks the key as handled, so the document-level handler does
+                // not also close the mobile drawer - dismissal is layered, innermost first
                 e.preventDefault();
                 if (this.searchInput.value) {
                     this.searchInput.value = '';
@@ -159,17 +282,14 @@ class ExampleBrowser {
                     this.searchInput.blur();
                 }
             } else if (e.key === 'Enter') {
-                this.exampleList.querySelector('.example-link:not(.hidden)')?.click();
+                this.exampleList.querySelector('.example-row:not(.hidden) .example-link')?.click();
             }
         });
 
-        // Press / anywhere to focus the search box
-        document.addEventListener('keydown', (e) => {
-            if (e.key === '/' && document.activeElement !== this.searchInput) {
-                e.preventDefault();
-                this.searchInput.focus();
-                this.searchInput.select();
-            }
+        this.searchClear.addEventListener('click', () => {
+            this.searchInput.value = '';
+            this.filterExamples('');
+            this.searchInput.focus();
         });
     }
 
@@ -177,49 +297,102 @@ class ExampleBrowser {
         const q = query.trim().toLowerCase();
         let visible = 0;
 
-        this.entries.forEach(({ link, searchText }) => {
+        this.entries.forEach(({ row, searchText }) => {
             const match = q === '' || searchText.includes(q);
-            link.classList.toggle('hidden', !match);
+            row.classList.toggle('hidden', !match);
             if (match) visible++;
         });
 
         this.exampleList.querySelectorAll('.category').forEach((section) => {
-            section.classList.toggle('hidden', !section.querySelector('.example-link:not(.hidden)'));
+            section.classList.toggle('hidden', !section.querySelector('.example-row:not(.hidden)'));
         });
 
         this.noResults.hidden = visible > 0;
+        this.searchCount.textContent = q === '' ? '' : `${visible}/${this.entries.length}`;
+        this.updatePrevNextState();
+    }
+
+    setupKeyboard() {
+        // These shortcuts live on the shell document: once focus is inside the iframe, keys go
+        // to the example (which may legitimately consume them) until focus returns to the shell.
+        document.addEventListener('keydown', (e) => {
+            if (e.defaultPrevented || e.altKey || e.ctrlKey || e.metaKey) {
+                return;
+            }
+
+            if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+                // Deliberately active while the search input is focused: filter-then-arrow is
+                // the established affordance
+                e.preventDefault();
+                this.navigateExample(e.key === 'ArrowUp' ? -1 : 1);
+            } else if (e.key === '[' || e.key === ']') {
+                if (e.target instanceof Element && e.target.closest('input, textarea, select')) {
+                    return;
+                }
+                e.preventDefault();
+                this.navigateExample(e.key === '[' ? -1 : 1);
+            } else if (e.key === '/' && document.activeElement !== this.searchInput) {
+                e.preventDefault();
+                this.searchInput.focus();
+                this.searchInput.select();
+            } else if (e.key === 'Escape' && this.sidebar.classList.contains('open')) {
+                this.setMobileMenu(false);
+                this.menuToggle.focus();
+            }
+        });
     }
 
     loadInitialExample() {
-        if (examples.length > 0) {
-            const hash = window.location.hash.slice(1);
-            if (hash && examples.some((ex) => ex.path === hash)) {
-                this.loadExample(hash);
-                document.querySelector(`a[href="#${hash}"]`)?.classList.add('active');
-            } else {
-                this.loadExample(examples[0].path);
-                this.updateURL(examples[0].path, true);
-                this.exampleList.querySelector('.example-link')?.classList.add('active');
-            }
+        if (examples.length === 0) {
+            return;
+        }
+        const hash = window.location.hash.slice(1);
+        const initial = examples.find((ex) => ex.path === hash) ?? examples[0];
+        if (initial.path !== hash) {
+            this.updateURL(initial.path, true);
+        }
+        this.loadExample(initial.path);
+        this.setActiveExample(initial.path);
+    }
+
+    setMobileMenu(open) {
+        this.sidebar.classList.toggle('open', open);
+        this.overlay.classList.toggle('open', open);
+        this.menuToggle.setAttribute('aria-expanded', String(open));
+        this.syncSidebarInert();
+        if (open) {
+            // Focus the drawer itself rather than the search input, which would pop the soft
+            // keyboard
+            this.sidebar.focus();
         }
     }
 
+    /**
+     * The closed drawer is only translated offscreen, so without `inert` it would still be
+     * tabbable - keyboard and AT users would traverse an invisible sidebar.
+     */
+    syncSidebarInert() {
+        this.sidebar.inert = this.mobileQuery.matches && !this.sidebar.classList.contains('open');
+    }
+
     setupMobileMenu() {
-        const toggleMenu = () => {
-            this.sidebar.classList.toggle('open');
-            this.overlay.classList.toggle('open');
-        };
+        this.mobileQuery = window.matchMedia('(max-width: 768px)');
 
-        this.menuToggle.addEventListener('click', toggleMenu);
-        this.overlay.addEventListener('click', toggleMenu);
-
-        document.querySelectorAll('.example-link').forEach((link) => {
-            link.addEventListener('click', () => {
-                if (window.innerWidth <= 768) {
-                    toggleMenu();
-                }
-            });
+        this.menuToggle.addEventListener('click', () => {
+            this.setMobileMenu(!this.sidebar.classList.contains('open'));
         });
+        this.overlay.addEventListener('click', () => this.setMobileMenu(false));
+
+        this.mobileQuery.addEventListener('change', () => {
+            if (this.mobileQuery.matches) {
+                this.syncSidebarInert();
+            } else {
+                this.setMobileMenu(false);
+            }
+        });
+
+        // Initial sync of aria-expanded and inert
+        this.setMobileMenu(false);
     }
 }
 

--- a/examples/js/navigation.mjs
+++ b/examples/js/navigation.mjs
@@ -1,6 +1,12 @@
 import { examples } from './example-list.mjs';
 
-export function setupNavigation(loadExample) {
+/**
+ * Owns the URL and history: hash updates on navigation, and back/forward (popstate) validation.
+ * All UI syncing is delegated to the callback, which is the single active-state codepath.
+ * @param {(path: string) => void} onNavigate - Called with a valid example path to activate.
+ * @returns {{ updateURL: (path: string, replace?: boolean) => void }} The URL updater.
+ */
+export function setupNavigation(onNavigate) {
     function updateURL(path, replace = false) {
         if (replace) {
             history.replaceState(null, '', `#${path}`);
@@ -12,23 +18,7 @@ export function setupNavigation(loadExample) {
     window.addEventListener('popstate', () => {
         const hash = window.location.hash.slice(1);
         if (hash && examples.some((ex) => ex.path === hash)) {
-            loadExample(hash);
-            document.querySelectorAll('.example-link').forEach((link) => {
-                link.classList.toggle('active', link.getAttribute('href') === `#${hash}`);
-            });
-        }
-    });
-
-    document.addEventListener('keydown', (e) => {
-        if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
-            e.preventDefault();
-            const links = Array.from(document.querySelectorAll('.example-link:not(.hidden)'));
-            if (links.length === 0) return;
-            const currentIndex = links.findIndex((link) => link.classList.contains('active'));
-            const nextIndex =
-                e.key === 'ArrowUp' ? Math.max(0, currentIndex - 1) : Math.min(links.length - 1, currentIndex + 1);
-
-            links[nextIndex].click();
+            onNavigate(hash);
         }
     });
 

--- a/examples/js/qr-code.mjs
+++ b/examples/js/qr-code.mjs
@@ -68,7 +68,9 @@ export async function showQRCode(path, name) {
         if (!modal.open) {
             return; // closed while the library was loading
         }
-        const url = `${window.location.origin}${window.location.pathname}${path}`;
+        // Resolved against the page URL rather than concatenated: the shell is also reachable
+        // as .../index.html (the PWA's start_url), where concatenation would corrupt the URL
+        const url = new URL(path, window.location.href).href;
         const qr = qrcode(0, 'L');
         qr.addData(url);
         qr.make();

--- a/examples/js/qr-code.mjs
+++ b/examples/js/qr-code.mjs
@@ -1,30 +1,81 @@
-let backdropHandlerAttached = false;
+/**
+ * The QR generator is loaded on first use rather than with the page: the modal is a rarely-used
+ * feature and the library was previously a render-blocking classic script. The pinned /+esm
+ * bundle's default export is the same factory the classic build exposed as a global. (SRI is not
+ * possible on jsdelivr's /+esm bundles; if it ever becomes a requirement, switch to injecting
+ * the static qrcode.min.js with an integrity attribute.)
+ */
+const QR_LIB_URL = 'https://cdn.jsdelivr.net/npm/qrcode-generator@1.4.4/+esm';
 
-export function showQRCode(path) {
-    const qr = window.qrcode(0, 'L');
-    const url = `${window.location.origin}${window.location.pathname}${path}`;
-    qr.addData(url);
-    qr.make();
+let qrcodePromise = null;
+let modalWired = false;
 
-    const modal = document.getElementById('qr-modal');
-    const qrDiv = document.getElementById('qr-code');
-    qrDiv.innerHTML = qr.createImgTag(4);
-
-    // Add click handler (once) to close on backdrop click
-    if (!backdropHandlerAttached) {
-        modal.addEventListener('click', (e) => {
-            const rect = modal.getBoundingClientRect();
-            const isInDialog =
-                rect.top <= e.clientY &&
-                e.clientY <= rect.top + rect.height &&
-                rect.left <= e.clientX &&
-                e.clientX <= rect.left + rect.width;
-            if (!isInDialog) {
-                modal.close();
+function loadLibrary() {
+    if (!qrcodePromise) {
+        qrcodePromise = import(QR_LIB_URL).then(
+            (module) => module.default,
+            (error) => {
+                // Drop the failed attempt so the next click retries
+                qrcodePromise = null;
+                throw error;
             }
-        });
-        backdropHandlerAttached = true;
+        );
     }
+    return qrcodePromise;
+}
 
+function wireModal(modal) {
+    if (modalWired) {
+        return;
+    }
+    modalWired = true;
+
+    modal.querySelector('.qr-modal-close').addEventListener('click', () => modal.close());
+
+    // Close on backdrop click: a click outside the dialog's own rectangle can only be the
+    // backdrop, which browsers report with the dialog itself as the target
+    modal.addEventListener('click', (e) => {
+        const rect = modal.getBoundingClientRect();
+        const isInDialog =
+            rect.top <= e.clientY &&
+            e.clientY <= rect.top + rect.height &&
+            rect.left <= e.clientX &&
+            e.clientX <= rect.left + rect.width;
+        if (!isInDialog) {
+            modal.close();
+        }
+    });
+}
+
+/**
+ * Shows the QR modal for an example. The modal opens immediately with a pending state; the
+ * generator library loads on first use.
+ * @param {string} path - The example's path, resolved against the current page's URL.
+ * @param {string} name - The example's display name, shown as the dialog heading.
+ */
+export async function showQRCode(path, name) {
+    const modal = document.getElementById('qr-modal');
+    const title = document.getElementById('qr-modal-title');
+    const qrDiv = document.getElementById('qr-code');
+    wireModal(modal);
+
+    title.textContent = name;
+    qrDiv.textContent = 'Generating…';
     modal.showModal();
+
+    try {
+        const qrcode = await loadLibrary();
+        if (!modal.open) {
+            return; // closed while the library was loading
+        }
+        const url = `${window.location.origin}${window.location.pathname}${path}`;
+        const qr = qrcode(0, 'L');
+        qr.addData(url);
+        qr.make();
+        qrDiv.innerHTML = qr.createImgTag(4, undefined, `QR code linking to ${url}`);
+    } catch {
+        if (modal.open) {
+            qrDiv.textContent = 'Could not load the QR code generator. Check your connection and try again.';
+        }
+    }
 }


### PR DESCRIPTION
A holistic design pass over the examples browser — the shell's last real design iteration was #257. The goal: one coherent dark chrome system across the sidebar, a new title bar, the QR modal, and the in-iframe example buttons, plus the structural/a11y fixes uncovered along the way. No frameworks, no build step, no new dependencies.

## Title bar (new)

A slim 48px bar above the iframe: category/name breadcrumb, prev/next buttons (keyboard: `[` and `]`), QR code, and open-standalone (a real link — middle-click works). Prev/next walk the *visible* list when a search filter is active, stop at the ends, and never strand keyboard focus on a just-disabled button. `document.title` and the iframe's (previously missing) `title` attribute track the active example. On mobile the menu toggle moves in-flow into the bar — the floating glass hamburger is gone, and the bar owns the notch region via `env(safe-area-inset-top)` (the iOS-landscape sizing from the v3/v4/v5 era is inherited, not modified).

## Sidebar

- **Structural fix**: rows were `<a>` elements with `<button>`s nested inside — invalid HTML and an a11y defect. Rows are now list items with the actions as *siblings* of a stretched link. Whole-row click preserved; QR/open actions get per-example `aria-label`s; open-in-new is a real link.
- Row actions reveal on hover/`:focus-within` where a pointer can hover (via `opacity` + `pointer-events` only, so they stay in the tab order); touch keeps them always visible.
- Active row: solid orange fill replaced by a 3px accent bar + soft tint + orange text (~7:1 contrast). Hierarchy rule: **neutral tint = hover, orange = active only.**
- `aria-current="page"` on the active link; sidebar auto-scrolls it into view.
- Header lockup: two-tier wordmark instead of a wrapped heading, 32px logo, ghost-button GitHub link.
- Search: `/` shortcut chip (hides while typing/on touch), live result count (`4/30`), clear button.

## Loading treatment

Example documents now paint `#121212` before their scene initializes (`example.css`), killing the white flash on every entry route. The shell crossfades the iframe between examples, with a spinner that only appears when a load is actually slow (250ms delay) and a 10s guard so a hung example never leaves the shell dimmed.

## QR modal

The generator library was a render-blocking classic script loaded on every page view for a rarely-used feature. It now lazy-loads (pinned `/+esm` build, single-flight, retry on failure) on first click; the modal opens instantly with a pending state, shows the example name as its heading, and gains a visible close button (previously the dialog had *zero* focusable descendants), a failure message, and alt text on the QR image. SRI isn't possible on `/+esm` bundles — documented in-code with the static-file alternative.

## In-iframe chrome unified

The floating example buttons (AR/VR/fullscreen/StackBlitz/source) retheme from light glass (`rgba(255,255,255,0.9)`, slate text) to the shell's dark glass (`rgba(18,18,18,0.66)` + blur + hairline light border, `@supports` fallback). Icons switch from `background-image` to **CSS masks**, so the mixed-fill/mixed-viewBox SVGs tint via `currentColor` — no icon file edits, hover states free. Verified legible over the bright Text scene and dark splat scenes; the shoe configurator's variant buttons inherit the same treatment.

## System-wide

Design-token cleanup with documented sync points (manifest/meta/example.css carry duplicated literals by necessity — no build step), radius scale, `prefers-reduced-motion` support in both stylesheets, Escape layering (search clears → blurs → drawer closes, focus returned to the toggle), `aria-expanded` on the menu toggle, an `inert` closed drawer (it was tabbable while translated offscreen), and the favicon now uses the 25 KB 192px logo instead of the 193 KB 512px one.

## Verification

- Full DOM-level assertion battery against the running shell: zero nested interactives; exactly one `aria-current`; breadcrumb/`document.title`/standalone-href/iframe-title sync across click, `[`/`]`, and `history.back()`; loading class toggles and clears; filter count + clear button + filter-aware prev/next (active-filtered-out edge case included); QR pending → generated img with alt → close; mobile (375×812): toggle in bar, `aria-expanded`/`inert` sync, Escape-to-close with focus return, drawer closes on selection; dark-glass computed styles + mask icons + idle-fade intact on example pages.
- `eslint` + `prettier` clean on `examples/js`; full test suite (617) green.
- **Not testable in this environment**: real-device iOS landscape/safe-area behavior — worth a quick device pass before merging, since the title bar now owns the notch region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
