### PR TITLE
Give the solar system example explicit 'pc-app' dimensions

### DIFF
--- a/examples/solar-system.html
+++ b/examples/solar-system.html
@@ -121,10 +121,16 @@
                     rgba(255, 110, 40, 0) 79%);
             }
 
+            /* Explicit dimensions, not inset-stretching: the library's base styles give pc-app
+               an intrinsic 300x150 size (like a video element), and explicit width/height beat
+               inset in CSS box resolution. Percentages on a fixed element resolve against the
+               viewport. */
             pc-app {
                 display: block;
                 position: fixed;
                 inset: 0;
+                width: 100%;
+                height: 100%;
                 z-index: 1;
                 pointer-events: none;
             }


### PR DESCRIPTION
## Root cause

Your instinct was right - this was #363 (pc-app element-driven sizing). The library''s injected base styles give pc-app an intrinsic 300x150 size (like a video element), and in CSS box resolution an **explicit width/height beats inset stretching** - so this page''s `position: fixed; inset: 0` rule, which previously stretched to the viewport, collapsed the whole 3D scene into a 300x150 box in the top-left corner.

Solar System was uniquely exposed: it is the **only** example that ships its own page theme instead of loading `css/example.css`, so it missed the `pc-app { width: 100%; height: 100dvh }` rule the other 32 examples inherited there.

## Fix

Add `width: 100%; height: 100%` to the page''s own pc-app rule (percentages on a fixed element resolve against the initial containing block), with a comment explaining why inset-stretching alone is not enough. As a bonus this is more correct than the old fill-window behavior, which sized the canvas to `window.innerWidth` and overlapped the page''s scrollbar by ~10px - the ICB excludes it.

## Verification

Reproduced before the fix (pc-app computed 300x150 against a 1154x538 viewport), then confirmed after:

- pc-app rect exactly matches the initial containing block; drawing buffer at full DPR.
- The scroll-driven camera tour works end to end (manually stepped `app.update()` since the headless pane never ticks rAF): scrolling to 40% drives the camera to Mars (y = -118.8), scrolling back returns it exactly to the hero position (0, 7.6, 63).
- The script-projected sun halo is being driven (it depends on correct canvas dimensions).
- Star layers, sections, and the body ready/scrolled state machine all intact.

Worth a line in the upcoming pc-app Sizing docs: pages should size the element with explicit width/height - `inset` stretching alone is defeated by the intrinsic default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)