### PR TITLE
Make 'pc-module' an AsyncElement that loads on connection

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,13 +1,21 @@
 import { basisInitialize, WasmModule } from 'playcanvas';
 
+import { AsyncElement } from './async-element';
+
 /**
  * The ModuleElement interface provides properties and methods for manipulating
- * {@link https://developer.playcanvas.com/user-manual/web-components/tags/pc-module/ | `<pc-module>`} elements.
- * The ModuleElement interface also inherits the properties and methods of the
- * {@link HTMLElement} interface.
+ * {@link https://developer.playcanvas.com/user-manual/web-components/tags/pc-module/ | `<pc-module>`}
+ * elements. The ModuleElement interface also inherits the properties and methods of the
+ * {@link AsyncElement} interface.
  *
- * Note that these attributes are read once when the element is created, so changing them later
- * has no effect.
+ * The attributes are read once, when the module starts loading - on the element's first
+ * connection, or earlier if a containing `<pc-app>` boots first and collects it - so changing
+ * them later has no effect. The element becomes ready once the module has loaded. WebAssembly
+ * modules configure engine-global state that never unloads, so readiness is not re-armed by
+ * removing the element, and a re-inserted element does not load again.
+ *
+ * A `<pc-module>` without a `name` warns and never becomes ready; a containing `<pc-app>` still
+ * boots.
  *
  * @attribute {string} name - The name of the WebAssembly module to configure, e.g. `Basis` or
  * `Ammo`.
@@ -16,21 +24,25 @@ import { basisInitialize, WasmModule } from 'playcanvas';
  * @attribute {string} fallback - The URL of the module's asm.js fallback script, used when
  * WebAssembly is unavailable.
  */
-class ModuleElement extends HTMLElement {
-    private loadPromise: Promise<void>;
+class ModuleElement extends AsyncElement {
+    private _loadPromise: Promise<void> | null = null;
 
-    /** @ignore */
-    constructor() {
-        super();
-        this.loadPromise = this.loadModule();
+    connectedCallback() {
+        this._getLoadPromise();
     }
 
-    private async loadModule(): Promise<void> {
-        const name = this.getAttribute('name')!;
-        const glueUrl = this.getAttribute('glue')!;
-        const wasmUrl = this.getAttribute('wasm')!;
-        const fallbackUrl = this.getAttribute('fallback')!;
-        const config = { glueUrl, wasmUrl, fallbackUrl };
+    private async _loadModule(): Promise<void> {
+        const name = this.getAttribute('name');
+        if (!name) {
+            console.warn("pc-module requires a 'name' attribute - no module was configured");
+            return;
+        }
+
+        const config = {
+            glueUrl: this.getAttribute('glue') ?? undefined,
+            wasmUrl: this.getAttribute('wasm') ?? undefined,
+            fallbackUrl: this.getAttribute('fallback') ?? undefined
+        };
 
         if (name === 'Basis') {
             basisInitialize(config);
@@ -41,17 +53,24 @@ class ModuleElement extends HTMLElement {
                 WasmModule.getInstance(name, () => resolve());
             });
         }
+
+        this._onReady();
     }
 
     /**
-     * Returns the promise that settles when the module has loaded. Awaited by the containing
-     * `<pc-app>` element before it creates its graphics device.
+     * Returns the promise that settles when the module has loaded, starting the load if it has
+     * not already started - a containing `<pc-app>` boots in document order, so it may collect
+     * this element before the element's own connectedCallback has run. A missing `name` resolves
+     * the promise without configuring anything, so a misconfigured module never blocks the app.
      *
      * @returns The load promise.
      * @internal
      */
     _getLoadPromise(): Promise<void> {
-        return this.loadPromise;
+        if (!this._loadPromise) {
+            this._loadPromise = this._loadModule();
+        }
+        return this._loadPromise;
     }
 }
 

--- a/test/elements/registration.test.ts
+++ b/test/elements/registration.test.ts
@@ -25,8 +25,8 @@ describe('customElements registration', () => {
         expect(document.createElement(tag)).toBeInstanceOf(AsyncElement);
     });
 
-    it.for(['pc-material', 'pc-module'])('%s extends HTMLElement directly, so it never becomes ready', (tag) => {
-        const element = document.createElement(tag);
+    it('pc-material extends HTMLElement directly, so it never becomes ready', () => {
+        const element = document.createElement('pc-material');
         expect(element).toBeInstanceOf(HTMLElement);
         expect(element).not.toBeInstanceOf(AsyncElement);
     });

--- a/test/integration/module.test.ts
+++ b/test/integration/module.test.ts
@@ -1,0 +1,104 @@
+import { WasmModule } from 'playcanvas';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AppElement } from '../../src/app';
+import { whenReady } from '../../src/index';
+import type { ModuleElement } from '../../src/module';
+import { mount } from '../helpers/dom';
+import { useGuard } from '../helpers/guard';
+import { expectNeverReady, readyWithin } from '../helpers/ready';
+
+/**
+ * Stubs the engine's wasm loader: no real network or script execution can happen in jsdom, and
+ * the element's contract - configure, wait for the instance, announce readiness - is what these
+ * tests pin. The Basis branch is not covered: basisInitialize is a plain module export, and the
+ * setup file has already loaded src/ against the real engine before any per-file vi.mock could
+ * replace it (WasmModule's statics are spyable because the spies mutate the shared class).
+ */
+const stubWasmModule = () => {
+    const setConfig = vi.spyOn(WasmModule, 'setConfig').mockImplementation(() => undefined);
+    const getInstance = vi.spyOn(WasmModule, 'getInstance').mockImplementation((_name, callback) => callback({}));
+    return { setConfig, getInstance };
+};
+
+describe('<pc-module>', () => {
+    const { warnings } = useGuard();
+
+    it('loads the configured module, becomes ready and lets the app boot', async () => {
+        const { setConfig, getInstance } = stubWasmModule();
+
+        const handle = mount(
+            '<pc-app backend="null">' +
+                '<pc-module name="Ammo" glue="ammo.wasm.js" wasm="ammo.wasm.wasm" fallback="ammo.js"></pc-module>' +
+                '</pc-app>'
+        );
+
+        await readyWithin(handle.get<ModuleElement>('pc-module'));
+        expect(setConfig).toHaveBeenCalledWith('Ammo', {
+            glueUrl: 'ammo.wasm.js',
+            wasmUrl: 'ammo.wasm.wasm',
+            fallbackUrl: 'ammo.js'
+        });
+        expect(getInstance).toHaveBeenCalledTimes(1);
+
+        // The app gates its boot on the module and still becomes ready afterwards
+        await readyWithin(handle.get<AppElement>('pc-app'));
+    });
+
+    it("resolves whenReady('pc-module') instead of throwing", async () => {
+        stubWasmModule();
+        mount('<pc-module name="Ammo" glue="g.js" wasm="a.wasm" fallback="f.js"></pc-module>');
+
+        // Threw for the whole pre-AsyncElement life of this element
+        const moduleElement = await whenReady('pc-module');
+        expect(moduleElement.tagName.toLowerCase()).toBe('pc-module');
+    });
+
+    it('reads attributes set after creation, not at construction', async () => {
+        const { setConfig } = stubWasmModule();
+        const handle = mount('<div></div>');
+
+        // The old constructor-time read made exactly this sequence configure the engine with
+        // null for every value before the attributes existed
+        const moduleElement = document.createElement('pc-module');
+        moduleElement.setAttribute('name', 'Ammo');
+        moduleElement.setAttribute('glue', 'glue.js');
+        moduleElement.setAttribute('wasm', 'ammo.wasm');
+        moduleElement.setAttribute('fallback', 'fallback.js');
+        expect(setConfig).not.toHaveBeenCalled();
+
+        handle.container.appendChild(moduleElement);
+
+        await readyWithin(moduleElement);
+        expect(setConfig).toHaveBeenCalledWith('Ammo', {
+            glueUrl: 'glue.js',
+            wasmUrl: 'ammo.wasm',
+            fallbackUrl: 'fallback.js'
+        });
+    });
+
+    it('warns and never becomes ready without a name, but does not block the app', async () => {
+        stubWasmModule();
+        const handle = mount('<pc-app backend="null"><pc-module glue="g.js"></pc-module></pc-app>');
+
+        // The broken module must not brick the whole application
+        await readyWithin(handle.get<AppElement>('pc-app'));
+        await expectNeverReady(handle.get<ModuleElement>('pc-module'));
+        warnings.expect("pc-module requires a 'name' attribute");
+    });
+
+    it('does not reload or re-arm readiness when re-inserted', async () => {
+        const { setConfig, getInstance } = stubWasmModule();
+        const handle = mount('<pc-module name="Ammo" glue="g.js" wasm="a.wasm" fallback="f.js"></pc-module>');
+        const moduleElement = handle.get<ModuleElement>('pc-module');
+        await readyWithin(moduleElement);
+
+        moduleElement.remove();
+        handle.container.appendChild(moduleElement);
+
+        // Wasm modules configure engine-global state that never unloads: still ready, no reload
+        await readyWithin(moduleElement);
+        expect(setConfig).toHaveBeenCalledTimes(1);
+        expect(getInstance).toHaveBeenCalledTimes(1);
+    });
+});

--- a/utils/cem/tags.mjs
+++ b/utils/cem/tags.mjs
@@ -24,5 +24,5 @@ export const COMPONENT_TAGS = [
     'pc-screen', 'pc-scripts', 'pc-scrollbar', 'pc-scrollview', 'pc-sounds'
 ];
 
-/** `pc-material` and `pc-module` extend `HTMLElement`, so they never become ready. */
-export const READY_TAGS = TAGS.filter(tag => tag !== 'pc-material' && tag !== 'pc-module');
+/** `pc-material` extends `HTMLElement`, so it never becomes ready. */
+export const READY_TAGS = TAGS.filter(tag => tag !== 'pc-material');

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -305,7 +305,7 @@ if (manifest) {
         // gloss fields, so no attribute claims them as its backing member
         ['pc-material', ['get', 'material', 'roughness', 'roughnessMap']],
         ['pc-model', ['entity', ...ASYNC_MEMBERS]],
-        ['pc-module', []],
+        ['pc-module', [...ASYNC_MEMBERS]],
         ['pc-node', ['addEventListener', 'entity', 'path', 'removeEventListener', 'state', ...ASYNC_MEMBERS]],
         ['pc-particles', ['component', 'pause', 'play', 'reset', 'stop', ...ASYNC_MEMBERS]],
         ['pc-scene', ['scene', ...ASYNC_MEMBERS]],


### PR DESCRIPTION
The last boot-path element still outside the readiness contract, and a 1.0.0 lock-in.

## Defects fixed

1. **`whenReady('pc-module')` threw** — `pc-module` was the only boot-path element extending plain `HTMLElement`, so the library's own waiting primitive rejected it ("does not initialize asynchronously"), at runtime and at the type level (it was excluded from the `AsyncElementTagName` union).
2. **Constructor-time attribute reads** — loading started in the constructor, which read all four attributes immediately. A parser-created element happened to work (attributes exist at upgrade), but the programmatic path — `createElement` → `setAttribute` → `append` — configured the engine with `null` for every value before the attributes existed. Same defect class as the fixed `createEntity` reads (#317).
3. **Four non-null assertions** on the attribute reads (part of the planned non-null sweep).
4. **A misconfigured module could wedge the app**: `<pc-app>` awaits every child module's load promise before creating its graphics device, with no escape hatch.

## New contract

- `ModuleElement extends AsyncElement`. Loading starts on the element's **first connection** — or earlier if a containing `<pc-app>` boots first and collects it via `_getLoadPromise()`, which now lazily starts the load (`pc-app` connects in document order, ahead of its children, so this path is real).
- The element becomes **ready once the module has loaded**. WebAssembly modules configure engine-global state that never unloads, so readiness is deliberately *not* re-armed on removal, and a re-inserted element does not reload — documented in the class JSDoc.
- A `pc-module` without a `name` **warns and never becomes ready, while its load promise still resolves** — the containing app boots regardless. Previously this path handed `null` to `WasmModule.setConfig`/`getInstance`.
- `pc-module` joins `READY_TAGS` (manifest + runtime registration checks both pin the `ready` event and the `AsyncElement` surface).

## Tests

Five integration tests: declarative load gating the app boot; `whenReady('pc-module')` resolving; the programmatic-creation regression (attributes read after creation, not at construction); the missing-`name` warn-but-don't-block-the-app path; and sticky readiness with no reload on re-insertion. The engine's `WasmModule` statics are stubbed (no wasm can execute in jsdom). The `Basis` branch is uncovered — `basisInitialize` is a plain module export that the setup file has already bound before any per-file mock could replace it; the branch is two lines and noted in the test header.

## Verification

- Full suite 622 green, type-check, lint, prettier, CEM validation clean.
- Live against the built `dist/` with the **real Ammo wasm**: `whenReady('pc-module')` resolves on `physics.html`, the app boots behind it, and the simulation demonstrably works (a dynamic body re-dropped from y=6 falls and settles at exactly y=0.5 on the ground plane).

One note for the User Manual: the `pc-module` page says the attributes are "read once when the element is created" — that becomes "when the module starts loading (the element's first connection)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
