### PR TITLE
Pick with the camera whose viewport contains the pointer

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -723,8 +723,11 @@ class AppElement extends AsyncElement {
     /**
      * Whether a camera's viewport contains the point. A camera renders into its normalized
      * `rect`, whose origin is the bottom-left of the canvas while buffer coordinates run from
-     * the top-left - the same flipped containment test the engine's ElementInput applies to
-     * UI input.
+     * the top-left - so the vertical test flips, as the engine's ElementInput flips it for UI
+     * input. The right and bottom edges are exclusive: a viewport rasterizes the half-open
+     * pixel range [left, right) x [top, bottom), so a coordinate on a shared edge belongs to
+     * the viewport whose first pixel it is - never to the one it just left, whose pick buffer
+     * holds nothing there.
      *
      * @param camera - The camera to test.
      * @param x - The x coordinate, in buffer space.
@@ -737,7 +740,7 @@ class AppElement extends AsyncElement {
         const left = rect.x * canvas.width;
         const bottom = (1 - rect.y) * canvas.height;
         const top = bottom - rect.w * canvas.height;
-        return x >= left && x <= left + rect.z * canvas.width && y >= top && y <= bottom;
+        return x >= left && x < left + rect.z * canvas.width && y >= top && y < bottom;
     }
 
     /**

--- a/src/app.ts
+++ b/src/app.ts
@@ -692,21 +692,64 @@ class AppElement extends AsyncElement {
         return null;
     }
 
-    // New helper to convert CSS coordinates to canvas (picker) coordinates
-    private _getPickerCoordinates(event: PointerEvent): { x: number; y: number } {
-        // Get the canvas' bounding rectangle in CSS pixels.
-        const canvasRect = this._canvas!.getBoundingClientRect();
-        // Compute scale factors based on canvas actual resolution vs. its CSS display size.
-        const scaleX = this._canvas!.width / canvasRect.width;
-        const scaleY = this._canvas!.height / canvasRect.height;
-        // Convert the client coordinates accordingly.
-        const x = (event.clientX - canvasRect.left) * scaleX;
-        const y = (event.clientY - canvasRect.top) * scaleY;
-        return { x, y };
+    /**
+     * Converts a pointer event's client coordinates into drawing-buffer coordinates - the space
+     * the pick buffer and the camera viewports are laid out in. When the canvas has no CSS box
+     * to map through (jsdom; a hidden canvas receives no pointer events in a browser), the
+     * client coordinates are passed through unmapped and `mapped` is false, so callers know the
+     * coordinates correspond to no real geometry.
+     *
+     * @param event - The pointer event to convert.
+     * @param canvas - The canvas the event was dispatched on.
+     * @returns The buffer-space coordinates, and whether they were actually mapped.
+     */
+    private _getPickerCoordinates(
+        event: PointerEvent,
+        canvas: HTMLCanvasElement
+    ): { x: number; y: number; mapped: boolean } {
+        const canvasRect = canvas.getBoundingClientRect();
+        if (canvasRect.width === 0 || canvasRect.height === 0) {
+            return { x: event.clientX, y: event.clientY, mapped: false };
+        }
+        const scaleX = canvas.width / canvasRect.width;
+        const scaleY = canvas.height / canvasRect.height;
+        return {
+            x: (event.clientX - canvasRect.left) * scaleX,
+            y: (event.clientY - canvasRect.top) * scaleY,
+            mapped: true
+        };
+    }
+
+    /**
+     * Whether a camera's viewport contains the point. A camera renders into its normalized
+     * `rect`, whose origin is the bottom-left of the canvas while buffer coordinates run from
+     * the top-left - the same flipped containment test the engine's ElementInput applies to
+     * UI input.
+     *
+     * @param camera - The camera to test.
+     * @param x - The x coordinate, in buffer space.
+     * @param y - The y coordinate, in buffer space.
+     * @param canvas - The canvas the coordinates are relative to.
+     * @returns Whether the camera's viewport contains the point.
+     */
+    private _cameraContains(camera: CameraComponent, x: number, y: number, canvas: HTMLCanvasElement): boolean {
+        const rect = camera.rect;
+        const left = rect.x * canvas.width;
+        const bottom = (1 - rect.y) * canvas.height;
+        const top = bottom - rect.w * canvas.height;
+        return x >= left && x <= left + rect.z * canvas.width && y >= top && y <= bottom;
     }
 
     /**
      * Picks the scene under the pointer and returns the graph node that was hit, or `null`.
+     *
+     * The camera is resolved the way the engine's ElementInput resolves it for UI input:
+     * enabled cameras are tried topmost-first (they render in ascending `priority` order),
+     * skipping cameras that render to a texture and cameras whose viewport `rect` does not
+     * contain the pointer. A camera that picks nothing ends the search if it clears the color
+     * buffer - its background visually owns the pixel - and otherwise cedes to the cameras
+     * beneath it, so an overlay camera only intercepts picks where it actually drew something.
+     * The pick buffer is prepared per camera, so each camera picks from its own layers.
      *
      * The read back is asynchronous because the synchronous {@link Picker.getSelection} is not
      * supported on WebGPU, where it returns an empty selection rather than failing - which
@@ -717,17 +760,44 @@ class AppElement extends AsyncElement {
      * @returns The graph node under the pointer, or `null` if nothing was hit.
      */
     private async _pickNode(event: PointerEvent): Promise<GraphNode | null> {
-        const camera = this.app!.root.findComponent('camera') as CameraComponent;
-        if (!camera) return null;
+        const app = this.app;
+        const picker = this._picker;
+        const canvas = this._canvas;
+        if (!app || !picker || !canvas) return null;
 
-        const { x, y } = this._getPickerCoordinates(event);
+        const { x, y, mapped } = this._getPickerCoordinates(event, canvas);
 
-        this._picker!.prepare(camera, this.app!.scene);
-        const selection = await this._picker!.getSelectionAsync(x, y);
-        if (selection.length === 0) return null;
+        // Walked from the end: the array is sorted by ascending priority, so the last camera
+        // renders last and sits on top. Read through .at() because a pick handler may remove
+        // cameras while an earlier iteration's read back is in flight.
+        const cameras = app.systems.camera?.cameras ?? [];
+        for (let i = cameras.length - 1; i >= 0; i--) {
+            const camera = cameras.at(i);
 
-        const item = selection[0];
-        return item instanceof MeshInstance ? item.node : (item as GSplatComponent).entity;
+            // A camera rendering to a texture is not on the canvas.
+            if (!camera || camera.renderTarget) continue;
+
+            // Coordinates that could not be mapped cannot be tested for containment.
+            if (mapped && !this._cameraContains(camera, x, y, canvas)) continue;
+
+            picker.prepare(camera, app.scene);
+            const selection = await picker.getSelectionAsync(x, y);
+
+            // The element may have disconnected while the read back was in flight.
+            if (!this._picker || !this.app) return null;
+
+            if (selection.length > 0) {
+                const item = selection[0];
+                return item instanceof MeshInstance ? item.node : (item as GSplatComponent).entity;
+            }
+
+            // Nothing hit. A camera that clears the color buffer paints its background over
+            // everything beneath it, so the miss is final; one that does not is an overlay
+            // that the cameras beneath show through, so they get their turn.
+            if (camera.clearColorBuffer) return null;
+        }
+
+        return null;
     }
 
     private async _onPointerMove(event: PointerEvent) {

--- a/test/integration/pointer.test.ts
+++ b/test/integration/pointer.test.ts
@@ -1,7 +1,8 @@
-import type { Entity } from 'playcanvas';
+import type { Entity, RenderTarget } from 'playcanvas';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { AppElement } from '../../src/app';
+import type { CameraComponentElement } from '../../src/components/camera-component';
 import type { EntityElement } from '../../src/entity';
 import { bootApp } from '../helpers/app';
 import { useGuard } from '../helpers/guard';
@@ -39,24 +40,26 @@ const deferred = <T>() => {
 
 /**
  * Swaps in a picker whose read back this test controls, and records which of the two read-back
- * APIs the element reached for.
+ * APIs the element reached for - and which camera each pick was prepared with.
  *
  * The null device renders nothing, so a real Picker can only ever return an empty selection. The
- * substitution keeps the assertions on the element's own logic - the element resolution, the
- * enter/leave bookkeeping and the ordering guard - rather than on the GPU.
+ * substitution keeps the assertions on the element's own logic - the camera resolution, the
+ * element resolution, the enter/leave bookkeeping and the ordering guard - rather than on the GPU.
  *
  * @param appElement - The booted pc-app.
  * @param queue - Selections to hand out, one per call. A deferred entry is resolved by the test.
- * @returns The per-API call counts.
+ * @returns The per-API call counts and the cameras passed to prepare, in call order.
  */
 const stubPicker = (
     appElement: AppElement,
     queue: (ReturnType<typeof hit>[] | Promise<ReturnType<typeof hit>[]>)[]
 ) => {
-    const calls = { sync: 0, async: 0 };
+    const calls = { sync: 0, async: 0, cameras: [] as unknown[] };
 
     (appElement as unknown as { _picker: unknown })._picker = {
-        prepare: () => undefined,
+        prepare: (camera: unknown) => {
+            calls.cameras.push(camera);
+        },
         getSelection: () => {
             calls.sync++;
             return [];
@@ -316,5 +319,161 @@ describe('pc-app pointer picking', () => {
         await flush();
 
         expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    describe('multi-camera', () => {
+        /**
+         * Boots two cameras and a listening target. jsdom gives the canvas no CSS box, so unless
+         * a test installs geometry via {@link giveCanvasBox}, viewport containment is bypassed
+         * and camera resolution is driven purely by priority order and fall-through.
+         *
+         * @param a - Attributes for the first camera, in document order.
+         * @param b - Attributes for the second camera.
+         * @returns The booted handle plus both camera components, the target's spy and the canvas.
+         */
+        const bootCameraPair = async (a: string, b: string) => {
+            const handle = await bootApp(`
+                <pc-entity name="camA"><pc-camera ${a}></pc-camera></pc-entity>
+                <pc-entity name="camB"><pc-camera ${b}></pc-camera></pc-entity>
+                <pc-entity name="target"></pc-entity>
+            `);
+            const cameraA = handle.get<CameraComponentElement>('pc-entity[name="camA"] pc-camera').component;
+            const cameraB = handle.get<CameraComponentElement>('pc-entity[name="camB"] pc-camera').component;
+            const target = handle.get<EntityElement>('pc-entity[name="target"]');
+            const enter = vi.fn();
+            target.addEventListener('pointerenter', enter);
+
+            const canvas = handle.appElement.querySelector('canvas');
+            if (!canvas) throw new Error('bootCameraPair: pc-app created no canvas');
+
+            return { ...handle, cameraA, cameraB, target, enter, canvas };
+        };
+
+        /**
+         * Gives the canvas the CSS box and drawing-buffer size jsdom never lays out, so
+         * client coordinates map 1:1 into an 800x600 buffer and viewport containment applies.
+         *
+         * @param canvas - The canvas to size.
+         */
+        const giveCanvasBox = (canvas: HTMLCanvasElement) => {
+            canvas.width = 800;
+            canvas.height = 600;
+            vi.spyOn(canvas, 'getBoundingClientRect').mockReturnValue({
+                left: 0,
+                top: 0,
+                right: 800,
+                bottom: 600,
+                width: 800,
+                height: 600,
+                x: 0,
+                y: 0,
+                toJSON: () => ({})
+            } as DOMRect);
+        };
+
+        it('picks with the highest-priority camera, not the first in the document', async () => {
+            // The old resolution was findComponent('camera') - whichever camera a depth-first
+            // walk of the scene found first, regardless of what renders on top.
+            const { appElement, cameraB, target, enter, canvas } = await bootCameraPair('priority="0"', 'priority="1"');
+            const calls = stubPicker(appElement, [[hit(target.entity!)]]);
+
+            canvas.dispatchEvent(move(400, 300));
+            await flush();
+
+            expect(calls.cameras).toEqual([cameraB]);
+            expect(enter).toHaveBeenCalledTimes(1);
+        });
+
+        it('orders cameras by priority, not by how recently they enabled', async () => {
+            const { appElement, cameraA, target, enter, canvas } = await bootCameraPair('priority="1"', 'priority="0"');
+            const calls = stubPicker(appElement, [[hit(target.entity!)]]);
+
+            canvas.dispatchEvent(move(400, 300));
+            await flush();
+
+            expect(calls.cameras).toEqual([cameraA]);
+            expect(enter).toHaveBeenCalledTimes(1);
+        });
+
+        it('falls through an overlay camera that picked nothing', async () => {
+            // An overlay camera leaves the color buffer alone, so wherever it drew nothing the
+            // cameras beneath show through - and should receive the pick.
+            const { appElement, cameraA, cameraB, target, enter, canvas } = await bootCameraPair(
+                'priority="0"',
+                'priority="1" clear-color-buffer="false"'
+            );
+            const calls = stubPicker(appElement, [[], [hit(target.entity!)]]);
+
+            canvas.dispatchEvent(move(400, 300));
+            await flush();
+
+            expect(calls.cameras).toEqual([cameraB, cameraA]);
+            expect(enter).toHaveBeenCalledTimes(1);
+        });
+
+        it('ends the search at an opaque camera that picked nothing', async () => {
+            // A camera that clears the color buffer paints its background over everything
+            // beneath it, so entities under an opaque viewport are not visible - and must not
+            // receive events.
+            const { appElement, cameraB, target, enter, canvas } = await bootCameraPair('priority="0"', 'priority="1"');
+            const calls = stubPicker(appElement, [[], [hit(target.entity!)]]);
+
+            canvas.dispatchEvent(move(400, 300));
+            await flush();
+
+            expect(calls.cameras).toEqual([cameraB]);
+            expect(enter).not.toHaveBeenCalled();
+        });
+
+        it('routes the pick to the camera whose viewport contains the pointer', async () => {
+            // Split screen: two same-priority cameras side by side. The pointer's position, not
+            // camera order, decides which viewport owns the pick.
+            const { appElement, cameraA, cameraB, target, canvas } = await bootCameraPair(
+                'rect="0 0 0.5 1"',
+                'rect="0.5 0 0.5 1"'
+            );
+            giveCanvasBox(canvas);
+            const calls = stubPicker(appElement, [[hit(target.entity!)], [hit(target.entity!)]]);
+
+            canvas.dispatchEvent(move(600, 300)); // right half
+            await flush();
+            canvas.dispatchEvent(move(200, 300)); // left half
+            await flush();
+
+            expect(calls.cameras).toEqual([cameraB, cameraA]);
+        });
+
+        it("flips the viewport test to match rect's bottom-left origin", async () => {
+            // rect="0 0.5 1 0.5" starts halfway up from the BOTTOM of the canvas, so it is the
+            // top half of the screen - the y axis of client coordinates runs the other way.
+            const { appElement, cameraA, cameraB, target, canvas } = await bootCameraPair(
+                'priority="0"',
+                'priority="1" rect="0 0.5 1 0.5"'
+            );
+            giveCanvasBox(canvas);
+            const calls = stubPicker(appElement, [[hit(target.entity!)], [hit(target.entity!)]]);
+
+            canvas.dispatchEvent(move(400, 150)); // top half: inside camB's viewport
+            await flush();
+            canvas.dispatchEvent(move(400, 450)); // bottom half: outside it
+            await flush();
+
+            expect(calls.cameras).toEqual([cameraB, cameraA]);
+        });
+
+        it('skips a camera that renders to a texture', async () => {
+            const { appElement, cameraA, cameraB, target, enter, canvas } = await bootCameraPair(
+                'priority="0"',
+                'priority="1"'
+            );
+            cameraB.renderTarget = {} as RenderTarget;
+            const calls = stubPicker(appElement, [[hit(target.entity!)]]);
+
+            canvas.dispatchEvent(move(400, 300));
+            await flush();
+
+            expect(calls.cameras).toEqual([cameraA]);
+            expect(enter).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/test/integration/pointer.test.ts
+++ b/test/integration/pointer.test.ts
@@ -461,6 +461,30 @@ describe('pc-app pointer picking', () => {
             expect(calls.cameras).toEqual([cameraB, cameraA]);
         });
 
+        it('resolves a shared viewport edge to the viewport whose first pixel it is', async () => {
+            // Viewports rasterize half-open pixel ranges: on an 800-wide canvas split at 400,
+            // buffer column 400 is the right viewport's first pixel and holds nothing in the
+            // left camera's pick buffer. The right camera is declared first so the left camera
+            // is walked first - an inclusive bound would let it claim the edge, miss, and end
+            // the search at its opaque background.
+            const { appElement, cameraA, target, canvas } = await bootCameraPair(
+                'rect="0.5 0 0.5 1"',
+                'rect="0 0 0.5 1"'
+            );
+            giveCanvasBox(canvas);
+            const calls = stubPicker(appElement, [[hit(target.entity!)]]);
+
+            canvas.dispatchEvent(move(400, 300)); // exactly on the split
+            await flush();
+
+            expect(calls.cameras).toEqual([cameraA]);
+
+            canvas.dispatchEvent(move(800, 300)); // on the canvas's outer edge: pixel 800 does not exist
+            await flush();
+
+            expect(calls.cameras, 'no viewport owns a coordinate at the canvas edge').toEqual([cameraA]);
+        });
+
         it('skips a camera that renders to a texture', async () => {
             const { appElement, cameraA, cameraB, target, enter, canvas } = await bootCameraPair(
                 'priority="0"',


### PR DESCRIPTION
## Summary

Pointer picking resolved its camera with `findComponent('camera')` - the first camera a depth-first scene walk happened to find - so on any page with more than one camera (split screen, picture-in-picture, overlay cameras), picks were evaluated against a camera unrelated to the viewport under the pointer.

`_pickNode` now resolves the camera the way the engine's `ElementInput` resolves it for UI input:

- Enabled cameras are tried **topmost-first** (the camera system's list is sorted by ascending `priority`, so the walk runs back-to-front).
- Cameras that **render to a texture** are skipped - they are not on the canvas.
- Cameras whose **viewport `rect` does not contain the pointer** are skipped, using the same bottom-left-origin flip `ElementInput` applies.
- A camera that picks nothing **ends the search if it clears the color buffer** - its background visually owns the pixel. A camera that does not clear (an overlay) **cedes to the cameras beneath it**, so overlays only intercept picks where they actually drew something.
- The pick buffer is prepared **per camera**, so each camera picks only from its own layers - an overlay camera rendering a gizmo layer cannot steal picks intended for the scene camera beneath, and vice versa.

The single-camera path is unchanged in cost: one prepare + one read back per pointer event.

## Testing

- 7 new integration tests covering priority order, insertion-order independence, overlay fall-through, opaque-miss finality, viewport containment (split screen), the bottom-left-origin y-flip, and render-target skipping - alongside the 12 existing pointer tests (629 total green).
- Verified end-to-end on WebGPU: a split-screen page (two cameras, `rect="0 0 0.5 1"` / `rect="0.5 0 0.5 1"`, one box per viewport) routes `pointerdown` to `left-box` when clicking the left viewport, `right-box` when clicking the right, and nothing on empty space. Under the old resolution the right-viewport click was evaluated against the left camera.

The name-based entity lookup half of the issue was fixed earlier by #341 (identity map). With the camera half addressed, this closes it out.

The manual's `pc-entity` Events section (developer-site) documents the old first-camera constraint and can be updated once this lands.

Fixes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)
