### PR TITLE
Load lazy assets on first use, from any element that references them

### DIFF
--- a/src/asset.ts
+++ b/src/asset.ts
@@ -389,12 +389,12 @@ class AssetElement extends AsyncElement {
             data = data ?? {};
 
             // Resolve the referenced texture atlas to its (numeric) asset id. The atlas must be
-            // declared before the sprite so its asset already exists in the registry. Resolved
-            // without triggering a load - this wiring happens at creation time, not at a use,
-            // and the engine's sprite handler loads the atlas when the sprite itself loads.
+            // declared before the sprite so its asset already exists in the registry. The
+            // passive lookup is deliberate: creation-time wiring is not a use, and the engine's
+            // sprite handler loads the atlas when the sprite itself loads.
             const atlas = this.getAttribute('atlas') ?? data.textureAtlasAsset;
             if (typeof atlas === 'string') {
-                const atlasAsset = AssetElement._find(atlas);
+                const atlasAsset = AssetElement.get(atlas);
                 if (atlasAsset) {
                     data.textureAtlasAsset = atlasAsset.id;
                 } else {
@@ -676,33 +676,34 @@ class AssetElement extends AsyncElement {
     }
 
     /**
-     * Returns the asset created by the `<pc-asset>` element with the given `id`, without
-     * starting a load. This is the lookup half of {@link get}, for wiring references while
-     * assets are still being created - before anything can be said to be using them.
-     *
-     * @param id - The `id` of the `<pc-asset>` element.
-     * @returns The asset, or `undefined`.
-     */
-    private static _find(id: string) {
-        const assetElement = document.querySelector<AssetElement>(`pc-asset[id="${id}"]`);
-        return assetElement?.asset;
-    }
-
-    /**
      * Returns the {@link Asset} created by the `<pc-asset>` element with the given `id`, or
      * `undefined` if there is no such element or its asset has not been created yet.
      *
-     * Resolving an asset counts as using it: a registered asset that has not started to load -
-     * a `lazy` one - starts loading here, which is what makes `lazy` mean load on first use,
-     * uniformly for every element that references assets. The load is asynchronous - listen for
-     * the `<pc-asset>` element's `load` event (or the asset's own) to observe the resource
-     * arriving.
+     * The lookup is passive - it never starts a load. A `lazy` asset loads when an element that
+     * references it uses it, or when its `lazy` attribute is removed; to load one imperatively,
+     * pass it to the registry's own `app.assets.load()`.
      *
      * @param id - The `id` of the `<pc-asset>` element.
      * @returns The asset, or `undefined`.
      */
     static get(id: string) {
-        const asset = AssetElement._find(id);
+        const assetElement = document.querySelector<AssetElement>(`pc-asset[id="${id}"]`);
+        return assetElement?.asset;
+    }
+
+    /**
+     * Resolves an asset reference for use: {@link get}, plus starting the load of a registered
+     * asset that has not begun one - a `lazy` asset. Every element that consumes assets
+     * resolves its references here rather than through the passive {@link get}, which is what
+     * makes `lazy` mean load on first use without any consumer having to remember the load.
+     * The load is asynchronous - callers observe the asset's `load` event for the resource.
+     *
+     * @param id - The `id` of the `<pc-asset>` element.
+     * @returns The asset, or `undefined`.
+     * @internal
+     */
+    static _use(id: string) {
+        const asset = AssetElement.get(id);
         // load() ignores an asset that is already loaded or loading, so repeated resolution
         // costs nothing.
         if (asset) {

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -389,8 +389,8 @@ class AssetElement extends AsyncElement {
             data = data ?? {};
 
             // Resolve the referenced texture atlas to its (numeric) asset id. The atlas must be
-            // declared before the sprite so its asset already exists in the registry. The
-            // passive lookup is deliberate: creation-time wiring is not a use, and the engine's
+            // declared before the sprite so its asset already exists in the registry. Resolved
+            // with get, not useAsset: creation-time wiring is not a use, and the engine's
             // sprite handler loads the atlas when the sprite itself loads.
             const atlas = this.getAttribute('atlas') ?? data.textureAtlasAsset;
             if (typeof atlas === 'string') {
@@ -579,7 +579,6 @@ class AssetElement extends AsyncElement {
         this._lazy = value;
         if (this.asset) {
             this.asset.preload = !value;
-            // Clearing lazy on a registered asset is the declarative way to start its load
             if (!value) {
                 this.asset.registry?.load(this.asset);
             }
@@ -679,10 +678,6 @@ class AssetElement extends AsyncElement {
      * Returns the {@link Asset} created by the `<pc-asset>` element with the given `id`, or
      * `undefined` if there is no such element or its asset has not been created yet.
      *
-     * The lookup is passive - it never starts a load. A `lazy` asset loads when an element that
-     * references it uses it, or when its `lazy` attribute is removed; to load one imperatively,
-     * pass it to the registry's own `app.assets.load()`.
-     *
      * @param id - The `id` of the `<pc-asset>` element.
      * @returns The asset, or `undefined`.
      */
@@ -779,9 +774,9 @@ customElements.define('pc-asset', AssetElement);
 /**
  * Resolves an asset reference for use: {@link AssetElement.get}, plus starting the load of a
  * registered asset that has not begun one - a `lazy` asset. Every element that consumes assets
- * resolves its references here rather than through the passive `get`, which is what makes
- * `lazy` mean load on first use without any consumer having to remember the load. The load is
- * asynchronous - callers observe the asset's `load` event for the resource.
+ * resolves its references here, which is what makes `lazy` mean load on first use without any
+ * consumer having to remember the load. The load is asynchronous - callers observe the asset's
+ * `load` event for the resource.
  *
  * Exported for the element implementations, not from the package entry point - internal API,
  * like the parse helpers.

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -778,13 +778,11 @@ customElements.define('pc-asset', AssetElement);
  * consumer having to remember the load. The load is asynchronous - callers observe the asset's
  * `load` event for the resource.
  *
- * Exported for the element implementations, not from the package entry point - internal API,
- * like the parse helpers.
- *
  * @param id - The `id` of the `<pc-asset>` element.
  * @returns The asset, or `undefined`.
+ * @internal
  */
-const useAsset = (id: string) => {
+export const useAsset = (id: string) => {
     const asset = AssetElement.get(id);
     // load() ignores an asset that is already loaded or loading, so repeated resolution
     // costs nothing.
@@ -794,4 +792,4 @@ const useAsset = (id: string) => {
     return asset;
 };
 
-export { AssetElement, useAsset };
+export { AssetElement };

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -153,6 +153,10 @@ const processBufferView = (
  * immediately unless `lazy`. A `pc-asset` must be a direct child of `pc-app` — elements placed
  * elsewhere, or with an unsupported asset type, never become ready.
  *
+ * A `lazy` asset loads on first use: the first time any element resolves it by `id` — a model,
+ * a material map, a sky, a script `asset:` reference — or when the `lazy` attribute is removed,
+ * whichever comes first. Until then it stays registered and unloaded.
+ *
  * For `texture` and `textureatlas` assets, the texture options (`address-u`, `address-v`,
  * `min-filter`, `mag-filter`, `anisotropy`, `mipmaps`, `srgb`, `flip-y`) apply when the texture is
  * created and — like `lazy` — are observed: changing one updates a texture that has already
@@ -385,10 +389,12 @@ class AssetElement extends AsyncElement {
             data = data ?? {};
 
             // Resolve the referenced texture atlas to its (numeric) asset id. The atlas must be
-            // declared before the sprite so its asset already exists in the registry.
+            // declared before the sprite so its asset already exists in the registry. Resolved
+            // without triggering a load - this wiring happens at creation time, not at a use,
+            // and the engine's sprite handler loads the atlas when the sprite itself loads.
             const atlas = this.getAttribute('atlas') ?? data.textureAtlasAsset;
             if (typeof atlas === 'string') {
-                const atlasAsset = AssetElement.get(atlas);
+                const atlasAsset = AssetElement._find(atlas);
                 if (atlasAsset) {
                     data.textureAtlasAsset = atlasAsset.id;
                 } else {
@@ -564,13 +570,19 @@ class AssetElement extends AsyncElement {
     }
 
     /**
-     * Sets whether the asset should be loaded lazily.
+     * Sets whether the asset should be loaded lazily. A lazy asset is registered without being
+     * loaded; it loads on first use - the first time any element resolves it by `id` - or when
+     * this flag is cleared on a registered asset, whichever comes first.
      * @param value - The lazy loading flag.
      */
     set lazy(value: boolean) {
         this._lazy = value;
         if (this.asset) {
             this.asset.preload = !value;
+            // Clearing lazy on a registered asset is the declarative way to start its load
+            if (!value) {
+                this.asset.registry?.load(this.asset);
+            }
         }
     }
 
@@ -664,15 +676,39 @@ class AssetElement extends AsyncElement {
     }
 
     /**
+     * Returns the asset created by the `<pc-asset>` element with the given `id`, without
+     * starting a load. This is the lookup half of {@link get}, for wiring references while
+     * assets are still being created - before anything can be said to be using them.
+     *
+     * @param id - The `id` of the `<pc-asset>` element.
+     * @returns The asset, or `undefined`.
+     */
+    private static _find(id: string) {
+        const assetElement = document.querySelector<AssetElement>(`pc-asset[id="${id}"]`);
+        return assetElement?.asset;
+    }
+
+    /**
      * Returns the {@link Asset} created by the `<pc-asset>` element with the given `id`, or
      * `undefined` if there is no such element or its asset has not been created yet.
+     *
+     * Resolving an asset counts as using it: a registered asset that has not started to load -
+     * a `lazy` one - starts loading here, which is what makes `lazy` mean load on first use,
+     * uniformly for every element that references assets. The load is asynchronous - listen for
+     * the `<pc-asset>` element's `load` event (or the asset's own) to observe the resource
+     * arriving.
      *
      * @param id - The `id` of the `<pc-asset>` element.
      * @returns The asset, or `undefined`.
      */
     static get(id: string) {
-        const assetElement = document.querySelector<AssetElement>(`pc-asset[id="${id}"]`);
-        return assetElement?.asset;
+        const asset = AssetElement._find(id);
+        // load() ignores an asset that is already loaded or loading, so repeated resolution
+        // costs nothing.
+        if (asset) {
+            asset.registry?.load(asset);
+        }
+        return asset;
     }
 
     static get observedAttributes() {

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -691,27 +691,6 @@ class AssetElement extends AsyncElement {
         return assetElement?.asset;
     }
 
-    /**
-     * Resolves an asset reference for use: {@link get}, plus starting the load of a registered
-     * asset that has not begun one - a `lazy` asset. Every element that consumes assets
-     * resolves its references here rather than through the passive {@link get}, which is what
-     * makes `lazy` mean load on first use without any consumer having to remember the load.
-     * The load is asynchronous - callers observe the asset's `load` event for the resource.
-     *
-     * @param id - The `id` of the `<pc-asset>` element.
-     * @returns The asset, or `undefined`.
-     * @internal
-     */
-    static _use(id: string) {
-        const asset = AssetElement.get(id);
-        // load() ignores an asset that is already loaded or loading, so repeated resolution
-        // costs nothing.
-        if (asset) {
-            asset.registry?.load(asset);
-        }
-        return asset;
-    }
-
     static get observedAttributes() {
         return [
             'address-u',
@@ -797,4 +776,27 @@ class AssetElement extends AsyncElement {
 
 customElements.define('pc-asset', AssetElement);
 
-export { AssetElement };
+/**
+ * Resolves an asset reference for use: {@link AssetElement.get}, plus starting the load of a
+ * registered asset that has not begun one - a `lazy` asset. Every element that consumes assets
+ * resolves its references here rather than through the passive `get`, which is what makes
+ * `lazy` mean load on first use without any consumer having to remember the load. The load is
+ * asynchronous - callers observe the asset's `load` event for the resource.
+ *
+ * Exported for the element implementations, not from the package entry point - internal API,
+ * like the parse helpers.
+ *
+ * @param id - The `id` of the `<pc-asset>` element.
+ * @returns The asset, or `undefined`.
+ */
+const useAsset = (id: string) => {
+    const asset = AssetElement.get(id);
+    // load() ignores an asset that is already loaded or loading, so repeated resolution
+    // costs nothing.
+    if (asset) {
+        asset.registry?.load(asset);
+    }
+    return asset;
+};
+
+export { AssetElement, useAsset };

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -74,17 +74,17 @@ class ButtonComponentElement extends ComponentElement {
             data.imageEntity = imageEntity;
         }
 
-        const hoverSpriteAsset = AssetElement.get(this._hoverSpriteAsset);
+        const hoverSpriteAsset = AssetElement._use(this._hoverSpriteAsset);
         if (hoverSpriteAsset) {
             data.hoverSpriteAsset = hoverSpriteAsset.id;
         }
 
-        const pressedSpriteAsset = AssetElement.get(this._pressedSpriteAsset);
+        const pressedSpriteAsset = AssetElement._use(this._pressedSpriteAsset);
         if (pressedSpriteAsset) {
             data.pressedSpriteAsset = pressedSpriteAsset.id;
         }
 
-        const inactiveSpriteAsset = AssetElement.get(this._inactiveSpriteAsset);
+        const inactiveSpriteAsset = AssetElement._use(this._inactiveSpriteAsset);
         if (inactiveSpriteAsset) {
             data.inactiveSpriteAsset = inactiveSpriteAsset.id;
         }
@@ -265,7 +265,7 @@ class ButtonComponentElement extends ComponentElement {
      */
     set hoverSpriteAsset(value: string) {
         this._hoverSpriteAsset = value;
-        const asset = AssetElement.get(value);
+        const asset = AssetElement._use(value);
         if (this.component && asset) {
             this.component.hoverSpriteAsset = asset.id as any;
         }
@@ -305,7 +305,7 @@ class ButtonComponentElement extends ComponentElement {
      */
     set pressedSpriteAsset(value: string) {
         this._pressedSpriteAsset = value;
-        const asset = AssetElement.get(value);
+        const asset = AssetElement._use(value);
         if (this.component && asset) {
             this.component.pressedSpriteAsset = asset.id as any;
         }
@@ -345,7 +345,7 @@ class ButtonComponentElement extends ComponentElement {
      */
     set inactiveSpriteAsset(value: string) {
         this._inactiveSpriteAsset = value;
-        const asset = AssetElement.get(value);
+        const asset = AssetElement._use(value);
         if (this.component && asset) {
             this.component.inactiveSpriteAsset = asset.id as any;
         }

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -1,7 +1,7 @@
 import type { ButtonComponent } from 'playcanvas';
 import { BUTTON_TRANSITION_MODE_SPRITE_CHANGE, BUTTON_TRANSITION_MODE_TINT, Color, Vec4 } from 'playcanvas';
 
-import { AssetElement } from '../asset';
+import { useAsset } from '../asset';
 import { getEntity, parseBool, parseColor, parseEnum, parseNumber, parseVec4 } from '../parse';
 
 import { ComponentElement } from './component';
@@ -74,17 +74,17 @@ class ButtonComponentElement extends ComponentElement {
             data.imageEntity = imageEntity;
         }
 
-        const hoverSpriteAsset = AssetElement._use(this._hoverSpriteAsset);
+        const hoverSpriteAsset = useAsset(this._hoverSpriteAsset);
         if (hoverSpriteAsset) {
             data.hoverSpriteAsset = hoverSpriteAsset.id;
         }
 
-        const pressedSpriteAsset = AssetElement._use(this._pressedSpriteAsset);
+        const pressedSpriteAsset = useAsset(this._pressedSpriteAsset);
         if (pressedSpriteAsset) {
             data.pressedSpriteAsset = pressedSpriteAsset.id;
         }
 
-        const inactiveSpriteAsset = AssetElement._use(this._inactiveSpriteAsset);
+        const inactiveSpriteAsset = useAsset(this._inactiveSpriteAsset);
         if (inactiveSpriteAsset) {
             data.inactiveSpriteAsset = inactiveSpriteAsset.id;
         }
@@ -265,7 +265,7 @@ class ButtonComponentElement extends ComponentElement {
      */
     set hoverSpriteAsset(value: string) {
         this._hoverSpriteAsset = value;
-        const asset = AssetElement._use(value);
+        const asset = useAsset(value);
         if (this.component && asset) {
             this.component.hoverSpriteAsset = asset.id as any;
         }
@@ -305,7 +305,7 @@ class ButtonComponentElement extends ComponentElement {
      */
     set pressedSpriteAsset(value: string) {
         this._pressedSpriteAsset = value;
-        const asset = AssetElement._use(value);
+        const asset = useAsset(value);
         if (this.component && asset) {
             this.component.pressedSpriteAsset = asset.id as any;
         }
@@ -345,7 +345,7 @@ class ButtonComponentElement extends ComponentElement {
      */
     set inactiveSpriteAsset(value: string) {
         this._inactiveSpriteAsset = value;
-        const asset = AssetElement._use(value);
+        const asset = useAsset(value);
         if (this.component && asset) {
             this.component.inactiveSpriteAsset = asset.id as any;
         }

--- a/src/components/element-component.ts
+++ b/src/components/element-component.ts
@@ -118,17 +118,17 @@ class ElementComponentElement extends ComponentElement {
 
         // Asset references are resolved from `<pc-asset>` element ids to engine asset ids. They are
         // only included when they resolve, so image/group elements (with no font) don't error.
-        const fontAsset = AssetElement.get(this._fontAsset);
+        const fontAsset = AssetElement._use(this._fontAsset);
         if (fontAsset) {
             data.fontAsset = fontAsset.id;
         }
 
-        const spriteAsset = AssetElement.get(this._spriteAsset);
+        const spriteAsset = AssetElement._use(this._spriteAsset);
         if (spriteAsset) {
             data.spriteAsset = spriteAsset.id;
         }
 
-        const textureAsset = AssetElement.get(this._textureAsset);
+        const textureAsset = AssetElement._use(this._textureAsset);
         if (textureAsset) {
             data.textureAsset = textureAsset.id;
         }
@@ -257,7 +257,7 @@ class ElementComponentElement extends ComponentElement {
      */
     set fontAsset(value: string) {
         this._fontAsset = value;
-        const asset = AssetElement.get(value);
+        const asset = AssetElement._use(value);
         if (this.component && asset) {
             this.component.fontAsset = asset.id;
         }
@@ -430,7 +430,7 @@ class ElementComponentElement extends ComponentElement {
      */
     set spriteAsset(value: string) {
         this._spriteAsset = value;
-        const asset = AssetElement.get(value);
+        const asset = AssetElement._use(value);
         if (this.component && asset) {
             this.component.spriteAsset = asset.id;
         }
@@ -488,7 +488,7 @@ class ElementComponentElement extends ComponentElement {
      */
     set textureAsset(value: string) {
         this._textureAsset = value;
-        const asset = AssetElement.get(value);
+        const asset = AssetElement._use(value);
         if (this.component && asset) {
             this.component.textureAsset = asset.id;
         }

--- a/src/components/element-component.ts
+++ b/src/components/element-component.ts
@@ -1,7 +1,7 @@
 import type { ElementComponent } from 'playcanvas';
 import { Color, Vec2, Vec4 } from 'playcanvas';
 
-import { AssetElement } from '../asset';
+import { useAsset } from '../asset';
 import { parseBool, parseColor, parseEnum, parseNumber, parseVec2, parseVec4 } from '../parse';
 
 import { ComponentElement } from './component';
@@ -118,17 +118,17 @@ class ElementComponentElement extends ComponentElement {
 
         // Asset references are resolved from `<pc-asset>` element ids to engine asset ids. They are
         // only included when they resolve, so image/group elements (with no font) don't error.
-        const fontAsset = AssetElement._use(this._fontAsset);
+        const fontAsset = useAsset(this._fontAsset);
         if (fontAsset) {
             data.fontAsset = fontAsset.id;
         }
 
-        const spriteAsset = AssetElement._use(this._spriteAsset);
+        const spriteAsset = useAsset(this._spriteAsset);
         if (spriteAsset) {
             data.spriteAsset = spriteAsset.id;
         }
 
-        const textureAsset = AssetElement._use(this._textureAsset);
+        const textureAsset = useAsset(this._textureAsset);
         if (textureAsset) {
             data.textureAsset = textureAsset.id;
         }
@@ -257,7 +257,7 @@ class ElementComponentElement extends ComponentElement {
      */
     set fontAsset(value: string) {
         this._fontAsset = value;
-        const asset = AssetElement._use(value);
+        const asset = useAsset(value);
         if (this.component && asset) {
             this.component.fontAsset = asset.id;
         }
@@ -430,7 +430,7 @@ class ElementComponentElement extends ComponentElement {
      */
     set spriteAsset(value: string) {
         this._spriteAsset = value;
-        const asset = AssetElement._use(value);
+        const asset = useAsset(value);
         if (this.component && asset) {
             this.component.spriteAsset = asset.id;
         }
@@ -488,7 +488,7 @@ class ElementComponentElement extends ComponentElement {
      */
     set textureAsset(value: string) {
         this._textureAsset = value;
-        const asset = AssetElement._use(value);
+        const asset = useAsset(value);
         if (this.component && asset) {
             this.component.textureAsset = asset.id;
         }

--- a/src/components/gsplat-component.ts
+++ b/src/components/gsplat-component.ts
@@ -33,7 +33,7 @@ class GSplatComponentElement extends ComponentElement {
 
     protected getInitialComponentData() {
         return {
-            asset: AssetElement.get(this._asset),
+            asset: AssetElement._use(this._asset),
             castShadows: this._castShadows,
             lodBaseDistance: this._lodBaseDistance,
             lodMultiplier: this._lodMultiplier,
@@ -56,7 +56,7 @@ class GSplatComponentElement extends ComponentElement {
      */
     set asset(value: string) {
         this._asset = value;
-        const asset = AssetElement.get(value);
+        const asset = AssetElement._use(value);
         if (this.component && asset) {
             this.component.asset = asset;
         }

--- a/src/components/gsplat-component.ts
+++ b/src/components/gsplat-component.ts
@@ -1,6 +1,6 @@
 import type { GSplatComponent } from 'playcanvas';
 
-import { AssetElement } from '../asset';
+import { useAsset } from '../asset';
 import { parseBool, parseNumber } from '../parse';
 
 import { ComponentElement } from './component';
@@ -33,7 +33,7 @@ class GSplatComponentElement extends ComponentElement {
 
     protected getInitialComponentData() {
         return {
-            asset: AssetElement._use(this._asset),
+            asset: useAsset(this._asset),
             castShadows: this._castShadows,
             lodBaseDistance: this._lodBaseDistance,
             lodMultiplier: this._lodMultiplier,
@@ -56,7 +56,7 @@ class GSplatComponentElement extends ComponentElement {
      */
     set asset(value: string) {
         this._asset = value;
-        const asset = AssetElement._use(value);
+        const asset = useAsset(value);
         if (this.component && asset) {
             this.component.asset = asset;
         }

--- a/src/components/particlesystem-component.ts
+++ b/src/components/particlesystem-component.ts
@@ -59,9 +59,9 @@ class ParticleSystemComponentElement extends ComponentElement {
     }
 
     private async _loadAsset() {
-        const appElement = await this.closestApp?.ready();
-        const app = appElement?.app;
+        await this.closestApp?.ready();
 
+        // Resolving the asset also starts its load when it is lazy and not yet loading
         const asset = AssetElement.get(this._asset);
         if (!asset) {
             return;
@@ -73,7 +73,6 @@ class ParticleSystemComponentElement extends ComponentElement {
             asset.once('load', () => {
                 this.applyConfig(asset.resource);
             });
-            app!.assets.load(asset);
         }
     }
 

--- a/src/components/particlesystem-component.ts
+++ b/src/components/particlesystem-component.ts
@@ -62,7 +62,6 @@ class ParticleSystemComponentElement extends ComponentElement {
     private async _loadAsset() {
         await this.closestApp?.ready();
 
-        // Resolving the asset also starts its load when it is lazy and not yet loading
         const asset = useAsset(this._asset);
         if (!asset) {
             return;

--- a/src/components/particlesystem-component.ts
+++ b/src/components/particlesystem-component.ts
@@ -1,6 +1,6 @@
 import type { ParticleSystemComponent } from 'playcanvas';
 
-import { AssetElement } from '../asset';
+import { useAsset } from '../asset';
 
 import { ComponentElement } from './component';
 
@@ -21,7 +21,7 @@ class ParticleSystemComponentElement extends ComponentElement {
     }
 
     protected getInitialComponentData() {
-        const asset = AssetElement._use(this._asset);
+        const asset = useAsset(this._asset);
         // A lazy config has no resource yet - _loadAsset applies it once the load completes
         if (!asset || !asset.resource) {
             return {};
@@ -29,7 +29,7 @@ class ParticleSystemComponentElement extends ComponentElement {
 
         if ((asset.resource as any).colorMapAsset) {
             const id = (asset.resource as any).colorMapAsset;
-            const colorMapAsset = AssetElement._use(id)?.id;
+            const colorMapAsset = useAsset(id)?.id;
             if (colorMapAsset) {
                 (asset.resource as any).colorMapAsset = colorMapAsset;
             }
@@ -63,7 +63,7 @@ class ParticleSystemComponentElement extends ComponentElement {
         await this.closestApp?.ready();
 
         // Resolving the asset also starts its load when it is lazy and not yet loading
-        const asset = AssetElement._use(this._asset);
+        const asset = useAsset(this._asset);
         if (!asset) {
             return;
         }

--- a/src/components/particlesystem-component.ts
+++ b/src/components/particlesystem-component.ts
@@ -21,14 +21,15 @@ class ParticleSystemComponentElement extends ComponentElement {
     }
 
     protected getInitialComponentData() {
-        const asset = AssetElement.get(this._asset);
-        if (!asset) {
+        const asset = AssetElement._use(this._asset);
+        // A lazy config has no resource yet - _loadAsset applies it once the load completes
+        if (!asset || !asset.resource) {
             return {};
         }
 
         if ((asset.resource as any).colorMapAsset) {
             const id = (asset.resource as any).colorMapAsset;
-            const colorMapAsset = AssetElement.get(id)?.id;
+            const colorMapAsset = AssetElement._use(id)?.id;
             if (colorMapAsset) {
                 (asset.resource as any).colorMapAsset = colorMapAsset;
             }
@@ -62,7 +63,7 @@ class ParticleSystemComponentElement extends ComponentElement {
         await this.closestApp?.ready();
 
         // Resolving the asset also starts its load when it is lazy and not yet loading
-        const asset = AssetElement.get(this._asset);
+        const asset = AssetElement._use(this._asset);
         if (!asset) {
             return;
         }

--- a/src/components/script-component.ts
+++ b/src/components/script-component.ts
@@ -119,7 +119,7 @@ type Conversion = (rest: string, raw: string) => any;
  * @returns The asset, or `raw`.
  */
 const assetConversion: Conversion = (rest, raw) => {
-    const asset = AssetElement.get(rest);
+    const asset = AssetElement._use(rest);
     if (asset) {
         return asset;
     }

--- a/src/components/script-component.ts
+++ b/src/components/script-component.ts
@@ -1,7 +1,7 @@
 import type { ScriptComponent, Script } from 'playcanvas';
 import { Color, Quat, Vec2, Vec3, Vec4 } from 'playcanvas';
 
-import { AssetElement } from '../asset';
+import { useAsset } from '../asset';
 import {
     getEntity,
     parseBool,
@@ -119,7 +119,7 @@ type Conversion = (rest: string, raw: string) => any;
  * @returns The asset, or `raw`.
  */
 const assetConversion: Conversion = (rest, raw) => {
-    const asset = AssetElement._use(rest);
+    const asset = useAsset(rest);
     if (asset) {
         return asset;
     }

--- a/src/components/sound-slot.ts
+++ b/src/components/sound-slot.ts
@@ -120,7 +120,7 @@ class SoundSlotElement extends AsyncElement {
     set asset(value: string) {
         this._asset = value;
         if (this.soundSlot) {
-            const id = AssetElement.get(value)?.id;
+            const id = AssetElement._use(value)?.id;
             if (id) {
                 this.soundSlot.asset = id;
             }

--- a/src/components/sound-slot.ts
+++ b/src/components/sound-slot.ts
@@ -1,6 +1,6 @@
 import type { SoundSlot } from 'playcanvas';
 
-import { AssetElement } from '../asset';
+import { useAsset } from '../asset';
 import { AsyncElement } from '../async-element';
 import { parseBool, parseNumber } from '../parse';
 
@@ -120,7 +120,7 @@ class SoundSlotElement extends AsyncElement {
     set asset(value: string) {
         this._asset = value;
         if (this.soundSlot) {
-            const id = AssetElement._use(value)?.id;
+            const id = useAsset(value)?.id;
             if (id) {
                 this.soundSlot.asset = id;
             }

--- a/src/material.ts
+++ b/src/material.ts
@@ -523,7 +523,7 @@ class MaterialElement extends HTMLElement {
             return;
         }
 
-        const asset = AssetElement.get(id);
+        const asset = AssetElement._use(id);
         if (!asset) return;
 
         if (asset.loaded) {

--- a/src/material.ts
+++ b/src/material.ts
@@ -26,7 +26,7 @@ import {
 import type { EventHandle, Texture } from 'playcanvas';
 
 import type { AppElement } from './app';
-import { AssetElement } from './asset';
+import { useAsset } from './asset';
 import { parseBool, parseColor, parseEnum, parseNumber, parseVec2 } from './parse';
 
 type BlendType =
@@ -523,7 +523,7 @@ class MaterialElement extends HTMLElement {
             return;
         }
 
-        const asset = AssetElement._use(id);
+        const asset = useAsset(id);
         if (!asset) return;
 
         if (asset.loaded) {

--- a/src/model.ts
+++ b/src/model.ts
@@ -154,7 +154,6 @@ class ModelElement extends AsyncElement {
             return;
         }
 
-        // Resolving the asset also starts its load when it is lazy and not yet loading
         const asset = useAsset(this._asset);
         if (!asset) {
             // An empty id is a legitimate transient (the asset may be assigned later); a

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,6 +1,6 @@
 import type { ContainerResource, Entity, EventHandle } from 'playcanvas';
 
-import { AssetElement } from './asset';
+import { useAsset } from './asset';
 import { AsyncElement } from './async-element';
 
 /**
@@ -155,7 +155,7 @@ class ModelElement extends AsyncElement {
         }
 
         // Resolving the asset also starts its load when it is lazy and not yet loading
-        const asset = AssetElement._use(this._asset);
+        const asset = useAsset(this._asset);
         if (!asset) {
             // An empty id is a legitimate transient (the asset may be assigned later); a
             // non-empty one that resolves to nothing is a dead end - say so rather than staying

--- a/src/model.ts
+++ b/src/model.ts
@@ -155,7 +155,7 @@ class ModelElement extends AsyncElement {
         }
 
         // Resolving the asset also starts its load when it is lazy and not yet loading
-        const asset = AssetElement.get(this._asset);
+        const asset = AssetElement._use(this._asset);
         if (!asset) {
             // An empty id is a legitimate transient (the asset may be assigned later); a
             // non-empty one that resolves to nothing is a dead end - say so rather than staying

--- a/src/model.ts
+++ b/src/model.ts
@@ -154,8 +154,7 @@ class ModelElement extends AsyncElement {
             return;
         }
 
-        const app = appElement.app;
-
+        // Resolving the asset also starts its load when it is lazy and not yet loading
         const asset = AssetElement.get(this._asset);
         if (!asset) {
             // An empty id is a legitimate transient (the asset may be assigned later); a
@@ -194,7 +193,6 @@ class ModelElement extends AsyncElement {
                 );
                 this._onReady();
             });
-            app!.assets.load(asset);
         }
     }
 

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -117,7 +117,7 @@ class SkyElement extends AsyncElement {
         this._appElement = appElement;
 
         // Resolving the asset also starts its load when it is lazy and not yet loading
-        const asset = AssetElement.get(this._asset);
+        const asset = AssetElement._use(this._asset);
         if (!asset) {
             return;
         }

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -116,7 +116,6 @@ class SkyElement extends AsyncElement {
 
         this._appElement = appElement;
 
-        // Resolving the asset also starts its load when it is lazy and not yet loading
         const asset = useAsset(this._asset);
         if (!asset) {
             return;

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -2,7 +2,7 @@ import type { Asset, EventHandle, Scene, Texture } from 'playcanvas';
 import { EnvLighting, LAYERID_SKYBOX, Quat, Vec3 } from 'playcanvas';
 
 import type { AppElement } from './app';
-import { AssetElement } from './asset';
+import { useAsset } from './asset';
 import { AsyncElement } from './async-element';
 import { parseBool, parseEnum, parseNumber, parseVec3 } from './parse';
 
@@ -117,7 +117,7 @@ class SkyElement extends AsyncElement {
         this._appElement = appElement;
 
         // Resolving the asset also starts its load when it is lazy and not yet loading
-        const asset = AssetElement._use(this._asset);
+        const asset = useAsset(this._asset);
         if (!asset) {
             return;
         }

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -116,6 +116,7 @@ class SkyElement extends AsyncElement {
 
         this._appElement = appElement;
 
+        // Resolving the asset also starts its load when it is lazy and not yet loading
         const asset = AssetElement.get(this._asset);
         if (!asset) {
             return;
@@ -136,7 +137,6 @@ class SkyElement extends AsyncElement {
                 }
                 this._generateSkybox(asset);
             });
-            app.assets.load(asset);
         }
     }
 

--- a/test/integration/lazy.test.ts
+++ b/test/integration/lazy.test.ts
@@ -29,15 +29,29 @@ describe('pc-asset lazy loading', () => {
         expect(asset!.loading).toBe(false);
     });
 
-    it('starts the load when resolved through AssetElement.get', async () => {
+    it('keeps AssetElement.get a passive lookup', async () => {
+        // get() is public API: looking an asset up must not have the side effect of loading
+        // it. The load-on-first-use trigger lives in the internal _use(), which is what the
+        // elements themselves resolve through.
+        const { get } = await bootApp(LAZY_TEXT);
+        const element = get<AssetElement>('pc-asset');
+
+        const asset = AssetElement.get('cfg');
+
+        expect(asset).toBe(element.asset);
+        expect(asset!.loading, 'get() must not start a load').toBe(false);
+        expect(asset!.loaded).toBe(false);
+    });
+
+    it('starts the load when an element resolves it for use', async () => {
         // Load on first use is the whole lazy contract: every element resolves its asset
-        // references through get(), so resolution is where the load belongs - a consumer
+        // references through _use(), so resolution is where the load belongs - a consumer
         // cannot forget to trigger it.
         const { get } = await bootApp(LAZY_TEXT);
         const element = get<AssetElement>('pc-asset');
         const loaded = loadOf(element);
 
-        const asset = AssetElement.get('cfg');
+        const asset = AssetElement._use('cfg');
 
         expect(asset).toBe(element.asset);
         await loaded;
@@ -54,10 +68,10 @@ describe('pc-asset lazy loading', () => {
         });
         const loaded = loadOf(element);
 
-        AssetElement.get('cfg');
-        AssetElement.get('cfg');
+        AssetElement._use('cfg');
+        AssetElement._use('cfg');
         await loaded;
-        AssetElement.get('cfg');
+        AssetElement._use('cfg');
 
         expect(loads, 'repeated resolution must not reload').toBe(1);
     });

--- a/test/integration/lazy.test.ts
+++ b/test/integration/lazy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { AssetElement } from '../../src/asset';
+import { AssetElement, useAsset } from '../../src/asset';
 import { bootApp } from '../helpers/app';
 import { useGuard } from '../helpers/guard';
 
@@ -31,8 +31,8 @@ describe('pc-asset lazy loading', () => {
 
     it('keeps AssetElement.get a passive lookup', async () => {
         // get() is public API: looking an asset up must not have the side effect of loading
-        // it. The load-on-first-use trigger lives in the internal _use(), which is what the
-        // elements themselves resolve through.
+        // it. The load-on-first-use trigger lives in the internal useAsset(), which is what
+        // the elements themselves resolve through.
         const { get } = await bootApp(LAZY_TEXT);
         const element = get<AssetElement>('pc-asset');
 
@@ -45,13 +45,13 @@ describe('pc-asset lazy loading', () => {
 
     it('starts the load when an element resolves it for use', async () => {
         // Load on first use is the whole lazy contract: every element resolves its asset
-        // references through _use(), so resolution is where the load belongs - a consumer
+        // references through useAsset(), so resolution is where the load belongs - a consumer
         // cannot forget to trigger it.
         const { get } = await bootApp(LAZY_TEXT);
         const element = get<AssetElement>('pc-asset');
         const loaded = loadOf(element);
 
-        const asset = AssetElement._use('cfg');
+        const asset = useAsset('cfg');
 
         expect(asset).toBe(element.asset);
         await loaded;
@@ -68,10 +68,10 @@ describe('pc-asset lazy loading', () => {
         });
         const loaded = loadOf(element);
 
-        AssetElement._use('cfg');
-        AssetElement._use('cfg');
+        useAsset('cfg');
+        useAsset('cfg');
         await loaded;
-        AssetElement._use('cfg');
+        useAsset('cfg');
 
         expect(loads, 'repeated resolution must not reload').toBe(1);
     });

--- a/test/integration/lazy.test.ts
+++ b/test/integration/lazy.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import { AssetElement } from '../../src/asset';
+import { bootApp } from '../helpers/app';
+import { useGuard } from '../helpers/guard';
+
+const LAZY_TEXT = '<pc-asset id="cfg" type="text" src="data:text/plain,cfg" lazy></pc-asset>';
+
+/**
+ * Waits for the asset element's next `load` event.
+ *
+ * @param element - The `pc-asset` element to observe.
+ * @returns A promise that settles when the event fires.
+ */
+const loadOf = (element: AssetElement) =>
+    new Promise<void>((resolve) => {
+        element.addEventListener('load', () => resolve(), { once: true });
+    });
+
+describe('pc-asset lazy loading', () => {
+    useGuard();
+
+    it('stays registered and unloaded until something uses it', async () => {
+        const { get } = await bootApp(LAZY_TEXT);
+        const asset = get<AssetElement>('pc-asset').asset;
+
+        expect(asset).toBeTruthy();
+        expect(asset!.loaded, 'a lazy asset does not load during boot').toBe(false);
+        expect(asset!.loading).toBe(false);
+    });
+
+    it('starts the load when resolved through AssetElement.get', async () => {
+        // Load on first use is the whole lazy contract: every element resolves its asset
+        // references through get(), so resolution is where the load belongs - a consumer
+        // cannot forget to trigger it.
+        const { get } = await bootApp(LAZY_TEXT);
+        const element = get<AssetElement>('pc-asset');
+        const loaded = loadOf(element);
+
+        const asset = AssetElement.get('cfg');
+
+        expect(asset).toBe(element.asset);
+        await loaded;
+        expect(asset!.loaded).toBe(true);
+        expect(asset!.resource).toBe('cfg');
+    });
+
+    it('resolving an asset repeatedly loads it once', async () => {
+        const { get } = await bootApp(LAZY_TEXT);
+        const element = get<AssetElement>('pc-asset');
+        let loads = 0;
+        element.addEventListener('load', () => {
+            loads += 1;
+        });
+        const loaded = loadOf(element);
+
+        AssetElement.get('cfg');
+        AssetElement.get('cfg');
+        await loaded;
+        AssetElement.get('cfg');
+
+        expect(loads, 'repeated resolution must not reload').toBe(1);
+    });
+
+    it('starts the load when the lazy attribute is removed', async () => {
+        // Un-lazying a registered asset is the declarative way to say "load now" without any
+        // element having to reference it.
+        const { get } = await bootApp(LAZY_TEXT);
+        const element = get<AssetElement>('pc-asset');
+        const loaded = loadOf(element);
+
+        element.removeAttribute('lazy');
+
+        await loaded;
+        expect(element.asset!.loaded).toBe(true);
+    });
+
+    it('loads a lazy texture referenced by a material map', async () => {
+        // The regression that motivated load-on-resolution: pc-material subscribed to the
+        // asset's load event but nothing ever started the load, so a lazy map waited forever.
+        // jsdom never completes image loads, so "started" is as far as this can observe.
+        const { get } = await bootApp(`
+            <pc-asset id="tex" src="tex.png" lazy></pc-asset>
+            <pc-material id="m" diffuse-map="tex"></pc-material>
+        `);
+        const asset = get<AssetElement>('pc-asset').asset;
+
+        expect(asset!.loading, 'resolving the map reference starts the load').toBe(true);
+    });
+
+    it('does not load a lazy atlas when a sprite merely declares it', async () => {
+        // Wiring a sprite's data to its atlas at creation time is not a use - the engine's
+        // sprite handler loads the atlas when the sprite itself loads. Loading here would make
+        // lazy meaningless for any atlas a sprite references.
+        const { get } = await bootApp(`
+            <pc-asset id="atlas" type="textureatlas" src="atlas.png" lazy></pc-asset>
+            <pc-asset id="spr" type="sprite" atlas="atlas" frame-keys="0" lazy></pc-asset>
+        `);
+        const atlas = get<AssetElement>('pc-asset[id="atlas"]').asset;
+
+        expect(atlas!.loaded).toBe(false);
+        expect(atlas!.loading, 'declaring a sprite must not load its atlas').toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

`lazy` registered an asset without preloading, but only half the story existed: something had to later call `app.assets.load()`, and only `pc-model`, `pc-sky` and `pc-particles` did. A lazy asset referenced by a material map, a UI element, a button, a sound or a script `asset:` attribute silently never loaded — `pc-material` even subscribed to the asset's `load` event and then waited forever for a load nothing would start.

This takes option 1 from the issue: **`lazy` means load on first use, uniformly.**

The public API stays unsurprising: `AssetElement.get()` remains a passive lookup with no side effects. The load trigger lives in `useAsset(id)` — a module-level helper in `asset.ts`, exported to the element implementations but not from the package entry point, following the same convention as `getEntity` and the `parse.ts` helpers. It is the resolve-for-use path that every consuming element goes through: resolving a registered asset that has not started to load starts it. The engine registry ignores `load()` on an asset that is already loaded or loading (a check its own code relies on), so repeated resolution is free, and a consumer can no longer forget the load. The three consumers that remembered lose their now-redundant explicit `app.assets.load()` calls (which also removes two `!` assertions).

Two refinements complete the contract:

- **Sprite → atlas wiring is not a use.** Sprite creation resolves its atlas through the passive `get()` — that wiring happens at creation time for every sprite, and the engine's sprite handler loads the atlas when the sprite itself loads. Loading there would make `lazy` meaningless for any atlas a sprite references.
- **Clearing `lazy` starts the load.** The attribute is observed, but flipping `preload` after registration did nothing. Removing `lazy` from a registered asset is now the declarative way to say "load now" without any element having to reference it.

Also fixed in passing: `pc-particles` dereferenced a lazy config's `null` resource when building its initial component data; it now returns empty data and lets the post-load path apply the config.

Where the engine already loads a bound asset itself (image elements, fonts via `LocalizedAsset.autoLoad`, sound slots on play, gsplat asset references), the resolution-time load is a harmless earlier duplicate; where it does not (material maps, buttons' state sprites, script `asset:` references), it is the fix.

## Testing

- New `test/integration/lazy.test.ts`: a lazy asset stays registered and unloaded through boot; `AssetElement.get()` stays passive (no load); `useAsset()` starts and completes the load; repeated resolution loads once; removing `lazy` loads; a material `diffuse-map` reference starts its lazy texture's load (the motivating regression); declaring a sprite does *not* load its lazy atlas.
- Existing model/sky/particles lazy tests pass unchanged against the centralized path (637 total green).
- Verified end-to-end on WebGPU: a lazy texture referenced only by a material `diffuse-map` loads after boot and the map is applied to the material — under the old code that load never settled.

The manual's `pc-asset` page documents the supported-consumer list; once this lands it can say simply that lazy assets load on first use.

Fixes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)
