### PR TITLE
Strip internal helpers from the shipped typings

### DIFF
--- a/src/colors.ts
+++ b/src/colors.ts
@@ -1,3 +1,8 @@
+/**
+ * The CSS color keywords, lowercase name to hex value. Read by `parseColor` to accept color
+ * names as attribute values.
+ * @internal
+ */
 export const CSS_COLORS: Record<string, string> = {
     aliceblue: '#f0f8ff',
     antiquewhite: '#faebd7',

--- a/src/entity-base.ts
+++ b/src/entity-base.ts
@@ -6,9 +6,9 @@ import { AsyncElement } from './async-element';
 /**
  * The attribute names of the inline `onpointer*` event handlers, shared by every element that
  * fronts an engine entity. Spread into `observedAttributes` by subclasses.
- * @ignore
+ * @internal
  */
-const POINTER_ATTRIBUTES = [
+export const POINTER_ATTRIBUTES = [
     'onpointerenter',
     'onpointerleave',
     'onpointerdown',
@@ -133,4 +133,4 @@ class EntityBaseElement extends AsyncElement {
     }
 }
 
-export { EntityBaseElement, POINTER_ATTRIBUTES };
+export { EntityBaseElement };

--- a/src/loading-bar.ts
+++ b/src/loading-bar.ts
@@ -8,8 +8,9 @@ const REMOVAL_DELAY_MS = 250;
  * All styling is inline, so the library injects no stylesheet. The colors and height resolve CSS
  * custom properties — `--pc-loading-bar-color`, `--pc-loading-bar-background` and
  * `--pc-loading-bar-height` — so a page can theme the bar from `pc-app` or `:root`.
+ * @internal
  */
-class LoadingBar {
+export class LoadingBar {
     private _track: HTMLDivElement;
 
     private _fill: HTMLDivElement;
@@ -118,5 +119,3 @@ class LoadingBar {
         this._track.remove();
     }
 }
-
-export { LoadingBar };

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -28,7 +28,7 @@ import { CSS_COLORS } from './colors';
  * @param value - The value to split.
  * @param count - The required number of components.
  * @returns The parsed components, or `null`.
- * @ignore
+ * @internal
  */
 export const parseComponents = (value: string, count: number): number[] | null => {
     const components = value.trim().split(/\s+/).map(Number);
@@ -61,6 +61,7 @@ const cloneDefault = <T extends Color | Quat | Vec2 | Vec3 | Vec4 | null>(value:
  * @param value - The attribute value to parse (`null` when the attribute is absent).
  * @param defaultValue - The value to use when the attribute is absent or removed.
  * @returns The parsed boolean.
+ * @internal
  */
 export const parseBool = (value: string | null, defaultValue: boolean): boolean => {
     return value === null ? defaultValue : value !== 'false';
@@ -77,6 +78,7 @@ export const parseBool = (value: string | null, defaultValue: boolean): boolean 
  * @param defaultValue - The value to use when the attribute is absent or invalid.
  * @param attribute - The attribute name, used in the warning message.
  * @returns The parsed Color object.
+ * @internal
  */
 export const parseColor = <T extends Color | null>(
     value: string | null,
@@ -129,6 +131,7 @@ export const parseColor = <T extends Color | null>(
  * @param defaultValue - The value to use when the attribute is absent or invalid.
  * @param attribute - The attribute name, used in the warning message.
  * @returns The resolved enum name.
+ * @internal
  */
 export const parseEnum = <T extends string>(
     value: string | null,
@@ -158,6 +161,7 @@ export const parseEnum = <T extends string>(
  * @param defaultValue - The value to use when the attribute is absent or invalid.
  * @param attribute - The attribute name, used in the warning message.
  * @returns The parsed number.
+ * @internal
  */
 export const parseNumber = <T extends number | null>(
     value: string | null,
@@ -187,6 +191,7 @@ export const parseNumber = <T extends number | null>(
  * @param defaultValue - The value to use when the attribute is absent or invalid.
  * @param attribute - The attribute name, used in the warning message.
  * @returns The parsed Quat object.
+ * @internal
  */
 export const parseQuat = <T extends Quat | null>(
     value: string | null,
@@ -217,6 +222,7 @@ export const parseQuat = <T extends Quat | null>(
  * @param value - The attribute value to parse (`null` when the attribute is absent).
  * @param defaultValue - The value to use when the attribute is absent or removed.
  * @returns The parsed tag names.
+ * @internal
  */
 export const parseTags = (value: string | null, defaultValue: string[] = []): string[] => {
     if (value === null) {
@@ -239,6 +245,7 @@ export const parseTags = (value: string | null, defaultValue: string[] = []): st
  * @param defaultValue - The value to use when the attribute is absent or invalid.
  * @param attribute - The attribute name, used in the warning message.
  * @returns The parsed Vec2 object.
+ * @internal
  */
 export const parseVec2 = <T extends Vec2 | null>(
     value: string | null,
@@ -267,6 +274,7 @@ export const parseVec2 = <T extends Vec2 | null>(
  * @param defaultValue - The value to use when the attribute is absent or invalid.
  * @param attribute - The attribute name, used in the warning message.
  * @returns The parsed Vec3 object.
+ * @internal
  */
 export const parseVec3 = <T extends Vec3 | null>(
     value: string | null,
@@ -295,6 +303,7 @@ export const parseVec3 = <T extends Vec3 | null>(
  * @param defaultValue - The value to use when the attribute is absent or invalid.
  * @param attribute - The attribute name, used in the warning message.
  * @returns The parsed Vec4 object.
+ * @internal
  */
 export const parseVec4 = <T extends Vec4 | null>(
     value: string | null,
@@ -321,6 +330,7 @@ export const parseVec4 = <T extends Vec4 | null>(
  *
  * @param ref - The reference string to resolve.
  * @returns The resolved entity, or `null`.
+ * @internal
  */
 export const getEntity = (ref: string): Entity | null => {
     if (!ref) {


### PR DESCRIPTION
# Summary

The `"./dist/*"` exports passthrough makes every emitted declaration file reachable at the types level, so module-level helpers that `index.ts` never re-exports still surfaced as importable, documented API: the eleven `parse.ts` helpers (`parseBool`, `parseColor`, `parseComponents`, `parseEnum`, `parseNumber`, `parseQuat`, `parseTags`, `parseVec2`/`3`/`4`, `getEntity`), `CSS_COLORS` in `colors.ts`, `POINTER_ATTRIBUTES` in `entity-base.ts`, and the `LoadingBar` class.

This applies the pattern #368 established for `useAsset` to every remaining non-public export:

- Each is tagged `@internal` in its JSDoc — `tsconfig.json` has `stripInternal: true`, so the declaration is dropped from the emitted `.d.ts`, and typedoc (`excludeInternal: true`) skips it too. The two existing `@ignore` tags (`parseComponents`, `POINTER_ATTRIBUTES`) become `@internal`, which covers both tools.
- Each is exported **inline at its declaration**, because `stripInternal` removes the declaration but not its name in a bottom `export { ... }` clause, leaving a malformed declaration file behind. `POINTER_ATTRIBUTES` and `LoadingBar` therefore move out of their modules' bottom export clauses; `EntityBaseElement`, which is public, keeps its.

Two things deliberately stay:

- The script event types (`ScriptAttributesChangeEvent` et al) are not re-exported from `index.ts` either, but its global `HTMLElementEventMap` augmentation references them — they are load-bearing public surface for typed `addEventListener` calls.
- Stripping `LoadingBar` cannot break `app.d.ts`: declaration emit erases private member types, so `AppElement` emits `private _bar;` with no reference to the class.

`dist/parse.d.ts`, `dist/colors.d.ts` and `dist/loading-bar.d.ts` now emit just `export {}` (plus the parse module's header comment). Runtime output is unchanged — `stripInternal` affects only declarations, and these modules only ever existed as declaration files in `dist` anyway (the runtime ships as bundles).

# Testing

- `npm run build`, then grepped every `dist/**/*.d.ts` and `.d.cts` for all fifteen names: no declarations remain (the only hits are prose mentions inside doc comments).
- Both flavors of the emitted declaration tree compile standalone: `tsc --noEmit` over `dist/index.d.ts` (bundler resolution) and `dist/index.d.cts` (nodenext) — this is the check that would catch a `stripInternal` dangling-name break.
- `npm run publint` passes, all 637 tests green, `npm run lint` and `npm run type-check` clean, prettier check clean on the four changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
