### PR TITLE
Add hierarchy() introspection to pc-model

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -123,3 +123,4 @@ export {
 };
 
 export type { AsyncElementTagName } from './async-element';
+export type { HierarchyNode } from './model';

--- a/src/model.ts
+++ b/src/model.ts
@@ -4,6 +4,76 @@ import { useAsset } from './asset';
 import { AsyncElement } from './async-element';
 
 /**
+ * One node of the tree returned by {@link ModelElement.hierarchy}. A plain-data snapshot —
+ * `JSON.stringify` serializes it — whose `toString()` renders the node's subtree as a printable
+ * tree.
+ */
+type HierarchyNode = {
+    /**
+     * The node's name as instantiated, which is the name `pc-node` binding resolves: the engine
+     * parser synthesizes `node_<index>` names for unnamed nodes and renames identically named
+     * siblings apart (`Wheel`, `Wheel1`, ...), so it can differ from the name authored in the
+     * source asset.
+     */
+    name: string;
+    /**
+     * The node's `/`-separated path below the model root — the path a `pc-node` bound to this
+     * node reports. The root's path is its own name.
+     */
+    path: string;
+    /**
+     * The node's position among identically named nodes in the model, counted in depth-first
+     * order over the whole tree: the match a `pc-node`'s `index` attribute selects when `name`
+     * alone is ambiguous.
+     */
+    index: number;
+    /** The types of the components attached to the node (e.g. 'render'), sorted. */
+    components: string[];
+    /** The node's children. */
+    children: HierarchyNode[];
+    /**
+     * Renders the subtree rooted at this node as a printable tree, one line per node: the name,
+     * `[index]` after a name that several nodes in the model share, and the component types in
+     * parentheses.
+     */
+    toString(): string;
+};
+
+/**
+ * Formats one line of the printable hierarchy: the node's name, an `[index]` marker when the
+ * name is shared by several nodes in the model, and the attached component types.
+ *
+ * @param node - The node to format.
+ * @param counts - The number of nodes bearing each name.
+ * @returns The formatted line.
+ */
+const formatNode = (node: HierarchyNode, counts: ReadonlyMap<string, number>): string => {
+    const index = (counts.get(node.name) ?? 0) > 1 ? ` [${node.index}]` : '';
+    const components = node.components.length > 0 ? ` (${node.components.join(', ')})` : '';
+    return `${node.name}${index}${components}`;
+};
+
+/**
+ * Formats the printable form of a hierarchy subtree.
+ *
+ * @param root - The subtree root.
+ * @param counts - The number of nodes bearing each name.
+ * @returns The tree, one line per node.
+ */
+const formatHierarchy = (root: HierarchyNode, counts: ReadonlyMap<string, number>): string => {
+    const lines = [formatNode(root, counts)];
+    const walk = (node: HierarchyNode, prefix: string) => {
+        node.children.forEach((child, i) => {
+            const last = i === node.children.length - 1;
+            lines.push(`${prefix}${last ? '└─ ' : '├─ '}${formatNode(child, counts)}`);
+            walk(child, `${prefix}${last ? '   ' : '│  '}`);
+        });
+    };
+    walk(root, '');
+    return lines.join('\n');
+};
+
+/**
  * The ModelElement interface provides properties and methods for manipulating
  * {@link https://developer.playcanvas.com/user-manual/web-components/tags/pc-model/ | `<pc-model>`} elements.
  * The ModelElement interface also inherits the properties and methods of the
@@ -53,6 +123,60 @@ class ModelElement extends AsyncElement {
      */
     get entity(): Entity | null {
         return this._entity;
+    }
+
+    /**
+     * Returns a snapshot of the instantiated node tree, or `null` while there is none (the
+     * container asset has not loaded, or the element has left the document). One call grounds a
+     * session — a browser console, a test, an agent — in the vocabulary `pc-node` binding
+     * resolves against: the instantiated names ({@link HierarchyNode.name}), paths, match
+     * indices and attached component types. `String(...)` of the result, or of any node in it,
+     * is the printable form.
+     *
+     * The snapshot is plain data, computed afresh each call: it does not follow later changes
+     * to the hierarchy, and mutating it changes nothing.
+     *
+     * @returns The root of the instantiated node tree, or `null`.
+     */
+    hierarchy(): HierarchyNode | null {
+        const root = this._entity;
+        if (!root) {
+            return null;
+        }
+
+        // Ordinals are assigned in the traversal resolution searches — pre-order depth-first
+        // from the model root, the root itself included — so each node's index is exactly what
+        // a pc-node's index attribute selects. Once the walk completes, the map holds the total
+        // count per name, which is what the printable form reads to annotate only shared names.
+        const ordinals = new Map<string, number>();
+
+        const describe = (entity: Entity, pathBelowRoot: string): HierarchyNode => {
+            const index = ordinals.get(entity.name) ?? 0;
+            ordinals.set(entity.name, index + 1);
+
+            const node: HierarchyNode = {
+                name: entity.name,
+                // The root has no path below itself; its own name stands in, as it does for
+                // the path a pc-node bound to the root reports.
+                path: pathBelowRoot || entity.name,
+                index,
+                // A plain GraphNode grafted into the hierarchy has no component storage
+                components: Object.keys(entity.c ?? {}).sort(),
+                children: entity.children.map((child) =>
+                    describe(child as Entity, pathBelowRoot ? `${pathBelowRoot}/${child.name}` : child.name)
+                )
+            };
+
+            // Non-enumerable, keeping the snapshot plain data under JSON.stringify, spreads and
+            // key enumeration. Deferred to call time, by which the ordinal map holds its totals.
+            Object.defineProperty(node, 'toString', {
+                value: () => formatHierarchy(node, ordinals)
+            });
+
+            return node;
+        };
+
+        return describe(root, '');
     }
 
     connectedCallback() {
@@ -235,3 +359,4 @@ class ModelElement extends AsyncElement {
 customElements.define('pc-model', ModelElement);
 
 export { ModelElement };
+export type { HierarchyNode };

--- a/src/model.ts
+++ b/src/model.ts
@@ -170,6 +170,7 @@ class ModelElement extends AsyncElement {
             // Non-enumerable, keeping the snapshot plain data under JSON.stringify, spreads and
             // key enumeration. Deferred to call time, by which the ordinal map holds its totals.
             Object.defineProperty(node, 'toString', {
+                enumerable: false,
                 value: () => formatHierarchy(node, ordinals)
             });
 

--- a/test/integration/hierarchy.test.ts
+++ b/test/integration/hierarchy.test.ts
@@ -116,6 +116,16 @@ describe('<pc-model> hierarchy()', () => {
                 { name: 'Wing1', path: 'Wing1', index: 0, components: [], children: [] }
             ]
         });
+
+        // The round trip alone cannot see toString - JSON.stringify skips functions whether or
+        // not they are enumerable - so the data-only key set is pinned directly.
+        expect(Object.keys(model.hierarchy()!), 'toString stays non-enumerable').toEqual([
+            'name',
+            'path',
+            'index',
+            'components',
+            'children'
+        ]);
         expect(uncaught.seen).toEqual([]);
     });
 

--- a/test/integration/hierarchy.test.ts
+++ b/test/integration/hierarchy.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ModelElement } from '../../src/model';
+import { bootApp } from '../helpers/app';
+import { useGuard } from '../helpers/guard';
+import { readyWithin } from '../helpers/ready';
+
+/**
+ * A glTF exercising everything hierarchy() reports: real geometry (the wheels share one triangle
+ * mesh, so instantiation attaches render components), identically named nodes under different
+ * parents (the two wheels — cross-parent duplicates survive parsing, which is what match indices
+ * disambiguate), and identically named siblings (the two wings — which the engine parser renames
+ * apart to `Wing`, `Wing1` as it builds the hierarchy). The vertex buffer is built here rather
+ * than pasted as opaque base64 (via btoa: the test tsconfig deliberately carries no node types,
+ * so Buffer is unavailable).
+ */
+const positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+const positionsBase64 = btoa(String.fromCharCode(...new Uint8Array(positions.buffer)));
+const CAR_SRC = `data:application/json,${encodeURIComponent(
+    JSON.stringify({
+        asset: { version: '2.0' },
+        scene: 0,
+        scenes: [{ nodes: [0] }],
+        nodes: [
+            { name: 'Car', children: [1, 3, 5, 6] },
+            { name: 'FrontAxle', children: [2] },
+            { name: 'Wheel', mesh: 0 },
+            { name: 'RearAxle', children: [4] },
+            { name: 'Wheel', mesh: 0 },
+            { name: 'Wing' },
+            { name: 'Wing' }
+        ],
+        meshes: [{ primitives: [{ attributes: { POSITION: 0 } }] }],
+        accessors: [{ bufferView: 0, componentType: 5126, count: 3, type: 'VEC3', min: [0, 0, 0], max: [1, 1, 0] }],
+        bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: positions.byteLength }],
+        buffers: [
+            {
+                uri: `data:application/octet-stream;base64,${positionsBase64}`,
+                byteLength: positions.byteLength
+            }
+        ]
+    })
+)}`;
+
+/**
+ * A meshless glTF whose single scene holds two root nodes: the engine parser wraps them in a
+ * scene-root node named after the scene, and hierarchy() reports that wrapper — the instantiated
+ * tree is the authority, not the source asset's node list.
+ */
+const STAGE_SRC = `data:application/json,${encodeURIComponent(
+    JSON.stringify({
+        asset: { version: '2.0' },
+        scene: 0,
+        scenes: [{ name: 'Stage', nodes: [0, 1] }],
+        nodes: [{ name: 'Podium' }, { name: 'Backdrop' }]
+    })
+)}`;
+
+const ASSETS = `
+    <pc-asset id="car" type="container" src="${CAR_SRC}"></pc-asset>
+    <pc-asset id="stage" type="container" src="${STAGE_SRC}"></pc-asset>
+`;
+
+describe('<pc-model> hierarchy()', () => {
+    const { uncaught } = useGuard();
+
+    /** Boots an app with both container assets and a car model. */
+    const bootCar = async () => {
+        const booted = await bootApp(`${ASSETS}<pc-model asset="car"></pc-model>`);
+        return { ...booted, model: booted.get<ModelElement>('pc-model') };
+    };
+
+    it('returns null while there is no instantiated hierarchy', async () => {
+        const { model } = await bootCar();
+
+        expect(document.createElement('pc-model').hierarchy(), 'nothing instantiated yet').toBeNull();
+        expect(model.hierarchy(), 'the booted model has a tree').not.toBeNull();
+
+        model.remove();
+        expect(model.hierarchy(), 'removal tears the hierarchy down').toBeNull();
+        expect(uncaught.seen).toEqual([]);
+    });
+
+    it('mirrors the instantiated tree as plain serializable data', async () => {
+        const { model } = await bootCar();
+
+        // The JSON round trip is part of the assertion: the snapshot must carry no cycles and
+        // no enumerable extras beyond the data itself.
+        const tree = JSON.parse(JSON.stringify(model.hierarchy()));
+
+        expect(tree).toEqual({
+            name: 'Car',
+            path: 'Car',
+            index: 0,
+            components: [],
+            children: [
+                {
+                    name: 'FrontAxle',
+                    path: 'FrontAxle',
+                    index: 0,
+                    components: [],
+                    children: [
+                        { name: 'Wheel', path: 'FrontAxle/Wheel', index: 0, components: ['render'], children: [] }
+                    ]
+                },
+                {
+                    name: 'RearAxle',
+                    path: 'RearAxle',
+                    index: 0,
+                    components: [],
+                    children: [
+                        { name: 'Wheel', path: 'RearAxle/Wheel', index: 1, components: ['render'], children: [] }
+                    ]
+                },
+                { name: 'Wing', path: 'Wing', index: 0, components: [], children: [] },
+                { name: 'Wing1', path: 'Wing1', index: 0, components: [], children: [] }
+            ]
+        });
+        expect(uncaught.seen).toEqual([]);
+    });
+
+    it('gives each node the index a pc-node needs to bind it', async () => {
+        const { model } = await bootCar();
+        const tree = model.hierarchy()!;
+        const wheels = [tree.children[0].children[0], tree.children[1].children[0]];
+
+        for (const wheel of wheels) {
+            const node = document.createElement('pc-node');
+            node.setAttribute('name', wheel.name);
+            node.setAttribute('index', String(wheel.index));
+            model.appendChild(node);
+
+            expect(node.state, `'${wheel.path}' bound without ambiguity`).toBe('bound');
+            expect(node.path, 'the index selected exactly the node hierarchy() described').toBe(wheel.path);
+            node.remove();
+        }
+        expect(uncaught.seen).toEqual([]);
+    });
+
+    it('reads the components attached at call time', async () => {
+        const { model } = await bootCar();
+        expect(model.hierarchy()!.components).toEqual([]);
+
+        model.entity!.addComponent('camera');
+
+        expect(model.hierarchy()!.components, 'a fresh snapshot sees the new component').toEqual(['camera']);
+        expect(uncaught.seen).toEqual([]);
+    });
+
+    it('renders a printable tree from toString', async () => {
+        const { model } = await bootCar();
+        const tree = model.hierarchy()!;
+
+        expect(String(tree)).toBe(
+            [
+                'Car',
+                '├─ FrontAxle',
+                '│  └─ Wheel [0] (render)',
+                '├─ RearAxle',
+                '│  └─ Wheel [1] (render)',
+                '├─ Wing',
+                '└─ Wing1'
+            ].join('\n')
+        );
+        expect(String(tree.children[0]), 'any node prints its own subtree').toBe('FrontAxle\n└─ Wheel [0] (render)');
+        expect(uncaught.seen).toEqual([]);
+    });
+
+    it('reports the wrapper root the engine creates for a multi-root scene', async () => {
+        const { get } = await bootApp(`${ASSETS}<pc-model asset="stage"></pc-model>`);
+        const tree = get<ModelElement>('pc-model').hierarchy()!;
+
+        expect(tree.name, 'the scene wrapper is part of the instantiated tree').toBe('Stage');
+        expect(tree.path, "the root's path is its own name").toBe('Stage');
+        expect(tree.children.map((child) => child.name)).toEqual(['Podium', 'Backdrop']);
+        expect(uncaught.seen).toEqual([]);
+    });
+
+    it('snapshots the current hierarchy across a reload', async () => {
+        const { model } = await bootCar();
+        const before = model.hierarchy()!;
+
+        model.setAttribute('asset', 'stage');
+        expect(model.hierarchy(), 'torn down synchronously with the old hierarchy').toBeNull();
+
+        await readyWithin(model);
+        expect(model.hierarchy()!.name, 'the snapshot follows the new asset').toBe('Stage');
+        expect(before.name, 'the old snapshot is inert data').toBe('Car');
+        expect(uncaught.seen).toEqual([]);
+    });
+});

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -304,7 +304,7 @@ if (manifest) {
         // roughness and roughnessMap are the alias accessors: their attributes resolve to the
         // gloss fields, so no attribute claims them as its backing member
         ['pc-material', ['get', 'material', 'roughness', 'roughnessMap']],
-        ['pc-model', ['entity', ...ASYNC_MEMBERS]],
+        ['pc-model', ['entity', 'hierarchy', ...ASYNC_MEMBERS]],
         ['pc-module', [...ASYNC_MEMBERS]],
         ['pc-node', ['addEventListener', 'entity', 'path', 'removeEventListener', 'state', ...ASYNC_MEMBERS]],
         ['pc-particles', ['component', 'pause', 'play', 'reset', 'stop', ...ASYNC_MEMBERS]],


### PR DESCRIPTION
# Summary

The first of #354's two conveniences (the `material` override follows separately): `hierarchy()` on `pc-model`, the grounding call from #297's Machine authoring section. One call returns the instantiated node tree — names, paths, match indices, attached component types — so a session (browser console, test, or agent tool) can address nodes without engine-API knowledge.

This also settles the issue's open question, the return shape: **one value carries both forms**. `hierarchy()` returns a plain-data tree of `HierarchyNode` records (`name`, `path`, `index`, `components`, `children`) — `JSON.stringify` works on it, and a non-enumerable per-node `toString()` renders any subtree as a printable tree:

```
Car
├─ FrontAxle
│  └─ Wheel [0] (render)
├─ RearAxle
│  └─ Wheel [1] (render)
├─ Wing
└─ Wing1
```

The shape deliberately speaks the vocabulary the binding warnings established in #353, because agents parse both:

- `path` is exactly what a bound `pc-node`'s `path` property reports: `/`-separated below the model root, the root's path being its own name.
- `index` is assigned in the engine's own `find()` traversal — pre-order depth-first from the model root, root included — so it is precisely the match a `pc-node`'s `index` attribute selects. A test pins the contract end to end: binding a `pc-node` from a hierarchy node's `name` + `index` lands on an entity whose `path` equals the hierarchy node's.
- The `[n]` markers in the printable form reuse the ambiguity warning's `[i] path` notation, and appear only on names that several nodes share — the case where markup actually needs `index` (or nesting).

The tree is the authority the RFC promises, not a reflection of the source asset: engine-synthesized `node_<index>` names, the parser's sibling renames (two `Wing` siblings surface as `Wing`, `Wing1`), and the scene-root wrapper of a multi-root scene all appear as instantiated. Components are read live at call time; each call returns a fresh snapshot, so a stale one is inert data.

Two supporting changes:

- `HierarchyNode` is exported from the package entry — it is the return type of a public method, the opposite case from the internal helpers #369 stripped.
- The CEM validator's pinned member list for `pc-model` gains `hierarchy`, which is exactly the update that mechanism demands when a genuine public member lands.

Part of #354; the `material="id"` half remains open there. Once this lands, the `pc-model` manual page can document `hierarchy()` as the way to discover node names before writing `pc-node` markup.

# Testing

- Seven new integration tests against a fixture that exercises everything the tree reports: real geometry (render components), cross-parent duplicate names (match indices), sibling duplicates (parser renames), and a second multi-root asset (scene wrapper). They cover the null lifecycle (before instantiation, after removal), a full-tree deep-equal through a JSON round trip, the `name`+`index` → `pc-node` binding tie, live component reads, exact printable output for the root and for a subtree node, and a reload.
- Full suite green (644 tests). `npm run lint`, `npm run type-check`, publint and prettier (`--end-of-line auto`) all clean; both flavors of the emitted declaration tree compile standalone; typedoc builds with the same 15 pre-existing warnings as `main`, with `HierarchyNode` documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
