### PR TITLE
Mirror StandardMaterial.name as a pc-material attribute

### DIFF
--- a/src/material.ts
+++ b/src/material.ts
@@ -136,8 +136,6 @@ type TextureSlot =
  * The two aliases are documented here rather than on an accessor, because they resolve to the
  * `gloss` properties and would otherwise inherit gloss's description - which reads inverted.
  *
- * @attribute {string} id - The id other elements reference the material by (see `pc-render`'s
- * `material` attribute).
  * @attribute {number} roughness - The roughness of the material, from 0 (shiny) to 1 (rough). An
  * alias for `gloss` that also inverts it, so do not combine it with the `gloss` attributes.
  * @attribute {string} roughness-map - The id of the `pc-asset` to use as the roughness map. An

--- a/src/material.ts
+++ b/src/material.ts
@@ -251,7 +251,6 @@ class MaterialElement extends HTMLElement {
 
     private _metalnessMapUv = 0;
 
-    // The engine default, pinned against StandardMaterial by the element tier's drift suite
     private _name = 'Untitled';
 
     private _normalMap = '';
@@ -2472,8 +2471,6 @@ class MaterialElement extends HTMLElement {
                 this.metalnessMapUv = parseNumber(newValue, 0, name);
                 break;
             case 'name':
-                // Removal restores the engine default, which the element tier pins against a
-                // bare StandardMaterial
                 this.name = newValue ?? 'Untitled';
                 break;
             case 'normal-map':

--- a/src/material.ts
+++ b/src/material.ts
@@ -137,8 +137,7 @@ type TextureSlot =
  * `gloss` properties and would otherwise inherit gloss's description - which reads inverted.
  *
  * @attribute {string} id - The id other elements reference the material by (see `pc-render`'s
- * `material` attribute). The created material is also named after it, and the name follows later
- * id changes.
+ * `material` attribute).
  * @attribute {number} roughness - The roughness of the material, from 0 (shiny) to 1 (rough). An
  * alias for `gloss` that also inverts it, so do not combine it with the `gloss` attributes.
  * @attribute {string} roughness-map - The id of the `pc-asset` to use as the roughness map. An
@@ -254,6 +253,9 @@ class MaterialElement extends HTMLElement {
 
     private _metalnessMapUv = 0;
 
+    // The engine default, pinned against StandardMaterial by the element tier's drift suite
+    private _name = 'Untitled';
+
     private _normalMap = '';
 
     private _normalMapOffset = new Vec2(0, 0);
@@ -357,13 +359,6 @@ class MaterialElement extends HTMLElement {
         const material = new StandardMaterial();
         this.material = material;
 
-        // Engine materials are all named 'Untitled' by default; the element id makes this one
-        // identifiable wherever materials surface by name - profilers, GPU captures, and the
-        // material assignments pc-model.hierarchy() reports.
-        if (this.id) {
-            material.name = this.id;
-        }
-
         material.alphaTest = this._alphaTest;
         material.alphaToCoverage = this._alphaToCoverage;
         material.aoIntensity = this._aoIntensity;
@@ -412,6 +407,7 @@ class MaterialElement extends HTMLElement {
         material.metalnessMapRotation = this._metalnessMapRotation;
         material.metalnessMapTiling = this._metalnessMapTiling;
         material.metalnessMapUv = this._metalnessMapUv;
+        material.name = this._name;
         material.normalMapOffset = this._normalMapOffset;
         material.normalMapRotation = this._normalMapRotation;
         material.normalMapTiling = this._normalMapTiling;
@@ -1626,6 +1622,28 @@ class MaterialElement extends HTMLElement {
     }
 
     /**
+     * Sets the name of the material.
+     * @param value - The material name.
+     */
+    set name(value: string) {
+        this._name = value;
+        if (this.material) {
+            // A label rather than shader state, so no update() is scheduled
+            this.material.name = value;
+        }
+    }
+
+    /**
+     * Gets the name of the material - the label shown wherever materials surface by name, such
+     * as profilers, GPU captures and the assignments `pc-model.hierarchy()` reports. Purely a
+     * label: element references resolve through `id`.
+     * @returns The material name.
+     */
+    get name() {
+        return this._name;
+    }
+
+    /**
      * Sets the id of the `pc-asset` to use as the normal map.
      * @param value - The asset id.
      */
@@ -2246,7 +2264,6 @@ class MaterialElement extends HTMLElement {
             'height-map-rotation',
             'height-map-tiling',
             'height-map-uv',
-            'id',
             'metalness',
             'metalness-map',
             'metalness-map-channel',
@@ -2254,6 +2271,7 @@ class MaterialElement extends HTMLElement {
             'metalness-map-rotation',
             'metalness-map-tiling',
             'metalness-map-uv',
+            'name',
             'normal-map',
             'normal-map-offset',
             'normal-map-rotation',
@@ -2434,14 +2452,6 @@ class MaterialElement extends HTMLElement {
             case 'height-map-uv':
                 this.heightMapUv = parseNumber(newValue, 0, name);
                 break;
-            case 'id':
-                // The name follows the id, staying consistent with what MaterialElement.get()
-                // resolves. A removed or emptied id keeps the last name - a stale label reads
-                // better than an anonymous one.
-                if (this.material && newValue) {
-                    this.material.name = newValue;
-                }
-                break;
             case 'metalness':
                 this.metalness = parseNumber(newValue, 0, name);
                 break;
@@ -2462,6 +2472,11 @@ class MaterialElement extends HTMLElement {
                 break;
             case 'metalness-map-uv':
                 this.metalnessMapUv = parseNumber(newValue, 0, name);
+                break;
+            case 'name':
+                // Removal restores the engine default, which the element tier pins against a
+                // bare StandardMaterial
+                this.name = newValue ?? 'Untitled';
                 break;
             case 'normal-map':
                 this.normalMap = newValue ?? '';

--- a/src/material.ts
+++ b/src/material.ts
@@ -136,6 +136,9 @@ type TextureSlot =
  * The two aliases are documented here rather than on an accessor, because they resolve to the
  * `gloss` properties and would otherwise inherit gloss's description - which reads inverted.
  *
+ * @attribute {string} id - The id other elements reference the material by (see `pc-render`'s
+ * `material` attribute). The created material is also named after it, and the name follows later
+ * id changes.
  * @attribute {number} roughness - The roughness of the material, from 0 (shiny) to 1 (rough). An
  * alias for `gloss` that also inverts it, so do not combine it with the `gloss` attributes.
  * @attribute {string} roughness-map - The id of the `pc-asset` to use as the roughness map. An
@@ -2243,6 +2246,7 @@ class MaterialElement extends HTMLElement {
             'height-map-rotation',
             'height-map-tiling',
             'height-map-uv',
+            'id',
             'metalness',
             'metalness-map',
             'metalness-map-channel',
@@ -2429,6 +2433,14 @@ class MaterialElement extends HTMLElement {
                 break;
             case 'height-map-uv':
                 this.heightMapUv = parseNumber(newValue, 0, name);
+                break;
+            case 'id':
+                // The name follows the id, staying consistent with what MaterialElement.get()
+                // resolves. A removed or emptied id keeps the last name - a stale label reads
+                // better than an anonymous one.
+                if (this.material && newValue) {
+                    this.material.name = newValue;
+                }
                 break;
             case 'metalness':
                 this.metalness = parseNumber(newValue, 0, name);

--- a/src/material.ts
+++ b/src/material.ts
@@ -354,6 +354,13 @@ class MaterialElement extends HTMLElement {
         const material = new StandardMaterial();
         this.material = material;
 
+        // Engine materials are all named 'Untitled' by default; the element id makes this one
+        // identifiable wherever materials surface by name - profilers, GPU captures, and the
+        // material assignments pc-model.hierarchy() reports.
+        if (this.id) {
+            material.name = this.id;
+        }
+
         material.alphaTest = this._alphaTest;
         material.alphaToCoverage = this._alphaToCoverage;
         material.aoIntensity = this._aoIntensity;

--- a/test/elements/material.test.ts
+++ b/test/elements/material.test.ts
@@ -55,7 +55,11 @@ describe('<pc-material>', () => {
 
     const create = () => document.createElement('pc-material') as MaterialElement;
 
-    const attributes = MaterialElement.observedAttributes;
+    const observed = MaterialElement.observedAttributes;
+
+    // Every observed attribute except the global 'id': element identity rather than a mirror of
+    // an engine property, its side effect - naming the material - is covered at integration tier
+    const attributes = observed.filter((attribute) => attribute !== 'id');
 
     const propertyOf = (attribute: string) => ALIASES[attribute] ?? kebabToCamel(attribute);
 
@@ -64,9 +68,9 @@ describe('<pc-material>', () => {
     };
 
     it('observes a large, duplicate-free attribute surface', () => {
-        expect(attributes.length).toBeGreaterThan(80);
-        expect(new Set(attributes).size).toBe(attributes.length);
-        expect([...attributes]).toEqual([...attributes].sort());
+        expect(observed.length).toBeGreaterThan(80);
+        expect(new Set(observed).size).toBe(observed.length);
+        expect([...observed]).toEqual([...observed].sort());
     });
 
     /**

--- a/test/elements/material.test.ts
+++ b/test/elements/material.test.ts
@@ -55,11 +55,7 @@ describe('<pc-material>', () => {
 
     const create = () => document.createElement('pc-material') as MaterialElement;
 
-    const observed = MaterialElement.observedAttributes;
-
-    // Every observed attribute except the global 'id': element identity rather than a mirror of
-    // an engine property, its side effect - naming the material - is covered at integration tier
-    const attributes = observed.filter((attribute) => attribute !== 'id');
+    const attributes = MaterialElement.observedAttributes;
 
     const propertyOf = (attribute: string) => ALIASES[attribute] ?? kebabToCamel(attribute);
 
@@ -68,9 +64,9 @@ describe('<pc-material>', () => {
     };
 
     it('observes a large, duplicate-free attribute surface', () => {
-        expect(observed.length).toBeGreaterThan(80);
-        expect(new Set(observed).size).toBe(observed.length);
-        expect([...observed]).toEqual([...observed].sort());
+        expect(attributes.length).toBeGreaterThan(80);
+        expect(new Set(attributes).size).toBe(attributes.length);
+        expect([...attributes]).toEqual([...attributes].sort());
     });
 
     /**
@@ -149,7 +145,7 @@ describe('<pc-material>', () => {
             if (current instanceof Color) {
                 return { value: '1 0 0', expected: new Color(1, 0, 0) };
             }
-            // The remaining string-valued attributes are the map channels
+            // The remaining string-valued attributes are the map channels and the name
             return { value: 'r', expected: 'r' };
         };
 

--- a/test/integration/material.test.ts
+++ b/test/integration/material.test.ts
@@ -42,29 +42,24 @@ describe('<pc-material> integration', () => {
         expect(material!.twoSidedLighting).toBe(true);
     });
 
-    it('names the material after the element id, following later id changes', async () => {
+    it('names the material from the name attribute, independent of the id', async () => {
         const { all } = await bootApp(`
-            <pc-material id="candy-red"></pc-material>
-            <pc-material></pc-material>
+            <pc-material id="candy-red" name="Candy Red"></pc-material>
+            <pc-material id="smoked-glass"></pc-material>
         `);
 
-        const [named, anonymous] = all<MaterialElement>('pc-material');
+        const [labeled, unlabeled] = all<MaterialElement>('pc-material');
 
-        expect(named.material!.name).toBe('candy-red');
-        // Compared against a fresh material rather than the literal 'Untitled': the contract is
-        // "left at the engine default", whatever the engine names it.
-        expect(anonymous.material!.name, 'no id keeps the engine default').toBe(new StandardMaterial().name);
+        expect(labeled.material!.name).toBe('Candy Red');
+        // Compared against a fresh material rather than the literal 'Untitled': the id is a
+        // reference key, never a label, so without a name the engine default stands
+        expect(unlabeled.material!.name, 'no name keeps the engine default').toBe(new StandardMaterial().name);
 
-        named.id = 'resprayed';
-        expect(named.material!.name, 'the name follows an id change').toBe('resprayed');
+        labeled.setAttribute('name', 'Resprayed');
+        expect(labeled.material!.name, 'the label follows the attribute').toBe('Resprayed');
 
-        anonymous.id = 'adopted';
-        expect(anonymous.material!.name, 'a late id names a previously anonymous material').toBe('adopted');
-
-        named.removeAttribute('id');
-        expect(named.material!.name, 'removal keeps the last name rather than orphaning the label').toBe(
-            'resprayed'
-        );
+        labeled.removeAttribute('name');
+        expect(labeled.material!.name, 'removal restores the engine default').toBe(new StandardMaterial().name);
     });
 
     it('enables the metalness workflow on a dielectric, unlike a bare StandardMaterial', async () => {

--- a/test/integration/material.test.ts
+++ b/test/integration/material.test.ts
@@ -42,6 +42,18 @@ describe('<pc-material> integration', () => {
         expect(material!.twoSidedLighting).toBe(true);
     });
 
+    it('names the material after the element id', async () => {
+        const { all } = await bootApp(`
+            <pc-material id="candy-red"></pc-material>
+            <pc-material></pc-material>
+        `);
+
+        const [named, anonymous] = all<MaterialElement>('pc-material');
+
+        expect(named.material!.name).toBe('candy-red');
+        expect(anonymous.material!.name, 'no id keeps the engine default').toBe('Untitled');
+    });
+
     it('enables the metalness workflow on a dielectric, unlike a bare StandardMaterial', async () => {
         // Without useMetalness, metalnessMap is never sampled - the LIT_METALNESS define is driven
         // straight off it - so the metalness-* attributes would do nothing at all. metalness has to

--- a/test/integration/material.test.ts
+++ b/test/integration/material.test.ts
@@ -1,4 +1,4 @@
-import { BLEND_NORMAL, CULLFACE_FRONT, Texture, Vec2 } from 'playcanvas';
+import { BLEND_NORMAL, CULLFACE_FRONT, StandardMaterial, Texture, Vec2 } from 'playcanvas';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { AssetElement } from '../../src/asset';
@@ -42,7 +42,7 @@ describe('<pc-material> integration', () => {
         expect(material!.twoSidedLighting).toBe(true);
     });
 
-    it('names the material after the element id', async () => {
+    it('names the material after the element id, following later id changes', async () => {
         const { all } = await bootApp(`
             <pc-material id="candy-red"></pc-material>
             <pc-material></pc-material>
@@ -51,7 +51,20 @@ describe('<pc-material> integration', () => {
         const [named, anonymous] = all<MaterialElement>('pc-material');
 
         expect(named.material!.name).toBe('candy-red');
-        expect(anonymous.material!.name, 'no id keeps the engine default').toBe('Untitled');
+        // Compared against a fresh material rather than the literal 'Untitled': the contract is
+        // "left at the engine default", whatever the engine names it.
+        expect(anonymous.material!.name, 'no id keeps the engine default').toBe(new StandardMaterial().name);
+
+        named.id = 'resprayed';
+        expect(named.material!.name, 'the name follows an id change').toBe('resprayed');
+
+        anonymous.id = 'adopted';
+        expect(anonymous.material!.name, 'a late id names a previously anonymous material').toBe('adopted');
+
+        named.removeAttribute('id');
+        expect(named.material!.name, 'removal keeps the last name rather than orphaning the label').toBe(
+            'resprayed'
+        );
     });
 
     it('enables the metalness workflow on a dielectric, unlike a bare StandardMaterial', async () => {

--- a/utils/cem/attributes-plugin.mjs
+++ b/utils/cem/attributes-plugin.mjs
@@ -70,6 +70,14 @@ const EMPTY_CONSTRUCTORS = {
 const kebabToCamel = name => name.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
 
 /**
+ * Global attributes an element may observe for a side effect (pc-material follows `id` into its
+ * material's name). They are not backed by an accessor of the library's uniform shape, so their
+ * manifest entries come from explicit `@attribute` tags - deriving one here would publish a
+ * phantom fieldName.
+ */
+const GLOBAL_ATTRIBUTES = new Set(['id']);
+
+/**
  * Extracts `name === 'some-attribute'` comparisons, so that elements handling a single attribute
  * with an `if` rather than a `switch` (see `src/asset.ts`) are covered too.
  *
@@ -393,6 +401,9 @@ export const attributesFromCallbackPlugin = () => ({
         const sourceFile = node.getSourceFile();
 
         for (const branch of collectBranches(ts, callback.body)) {
+            if (GLOBAL_ATTRIBUTES.has(branch.name)) {
+                continue;
+            }
             const assignment = findAssignment(ts, branch.statements);
             const fieldName = assignment?.fieldName ?? kebabToCamel(branch.name);
             const { type, default: defaultValue, format } = describeValue(

--- a/utils/cem/attributes-plugin.mjs
+++ b/utils/cem/attributes-plugin.mjs
@@ -70,14 +70,6 @@ const EMPTY_CONSTRUCTORS = {
 const kebabToCamel = name => name.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
 
 /**
- * Global attributes an element may observe for a side effect (pc-material follows `id` into its
- * material's name). They are not backed by an accessor of the library's uniform shape, so their
- * manifest entries come from explicit `@attribute` tags - deriving one here would publish a
- * phantom fieldName.
- */
-const GLOBAL_ATTRIBUTES = new Set(['id']);
-
-/**
  * Extracts `name === 'some-attribute'` comparisons, so that elements handling a single attribute
  * with an `if` rather than a `switch` (see `src/asset.ts`) are covered too.
  *
@@ -401,9 +393,6 @@ export const attributesFromCallbackPlugin = () => ({
         const sourceFile = node.getSourceFile();
 
         for (const branch of collectBranches(ts, callback.body)) {
-            if (GLOBAL_ATTRIBUTES.has(branch.name)) {
-                continue;
-            }
             const assignment = findAssignment(ts, branch.statements);
             const fieldName = assignment?.fieldName ?? kebabToCamel(branch.name);
             const { type, default: defaultValue, format } = describeValue(

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -194,6 +194,10 @@ if (manifest) {
     for (const name of ['name', 'glue', 'wasm', 'fallback']) {
         expectAttribute('pc-module', name, { type: 'string' });
     }
+
+    // A global attribute observed for its side effect (the material's name follows the id):
+    // declared with @attribute, and the callback branch must not derive a phantom fieldName
+    expectAttribute('pc-material', 'id', { type: 'string', fieldName: undefined });
     for (const name of ['id', 'src', 'type', 'data', 'atlas', 'frame-keys', 'pixels-per-unit', 'render-mode']) {
         check(Boolean(attribute('pc-asset', name)), `pc-asset is missing the '${name}' attribute`);
     }

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -195,9 +195,13 @@ if (manifest) {
         expectAttribute('pc-module', name, { type: 'string' });
     }
 
-    // A global attribute observed for its side effect (the material's name follows the id):
-    // declared with @attribute, and the callback branch must not derive a phantom fieldName
+    // The registry key other elements resolve materials by: a global attribute read through
+    // querySelector rather than an accessor, so declared with @attribute like pc-asset's id
     expectAttribute('pc-material', 'id', { type: 'string', fieldName: undefined });
+
+    // The one engine property whose attribute shares a name with a built-in on other elements;
+    // pinned so the accessor keeps backing it
+    expectAttribute('pc-material', 'name', { type: 'string', fieldName: 'name' });
     for (const name of ['id', 'src', 'type', 'data', 'atlas', 'frame-keys', 'pixels-per-unit', 'render-mode']) {
         check(Boolean(attribute('pc-asset', name)), `pc-asset is missing the '${name}' attribute`);
     }

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -195,12 +195,8 @@ if (manifest) {
         expectAttribute('pc-module', name, { type: 'string' });
     }
 
-    // The registry key other elements resolve materials by: a global attribute read through
-    // querySelector rather than an accessor, so declared with @attribute like pc-asset's id
-    expectAttribute('pc-material', 'id', { type: 'string', fieldName: undefined });
-
-    // The one engine property whose attribute shares a name with a built-in on other elements;
-    // pinned so the accessor keeps backing it
+    // The one engine property that is a pure label rather than shader state; pinned so the
+    // accessor keeps backing it
     expectAttribute('pc-material', 'name', { type: 'string', fieldName: 'name' });
     for (const name of ['id', 'src', 'type', 'data', 'atlas', 'frame-keys', 'pixels-per-unit', 'render-mode']) {
         check(Boolean(attribute('pc-asset', name)), `pc-asset is missing the '${name}' attribute`);


### PR DESCRIPTION
First of the three-PR sequence around #371. Original scope was "name the created material after the element id"; review direction (correctly) called that a conflation — the id is a reference key, the name is a label — so the PR now mirrors `StandardMaterial.name` as an ordinary attribute instead:

```html
<pc-material id="candy-red" name="Candy Red" diffuse="#b40018"></pc-material>
```

- `name` behaves like every other mirrored engine property: engine default (`Untitled`) when absent, applied at creation and on change, restored on removal. It is purely a label — element references resolve through `id` — and it is what profilers, GPU captures and `pc-model.hierarchy()` display, so labeling materials is opt-in and author-controlled (including labeling a replacement after the authored slot it fills).
- No `update()` is scheduled on a name write; it is not shader state.
- The generated element-tier suites (default drift against a bare `StandardMaterial`, attribute round trip) cover `name` automatically, and the drift suite is what fails loudly if the engine ever renames its default.
- `id` is untouched: no observation, no doc tag, no manifest entry — it is a reference key, and this PR's surface is the label only. The validator pins the `name` attribute instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

