### PR TITLE
Report material assignments from pc-model hierarchy()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -123,4 +123,4 @@ export {
 };
 
 export type { AsyncElementTagName } from './async-element';
-export type { HierarchyNode } from './model';
+export type { HierarchyMaterial, HierarchyNode } from './model';

--- a/src/model.ts
+++ b/src/model.ts
@@ -4,6 +4,22 @@ import { useAsset } from './asset';
 import { AsyncElement } from './async-element';
 
 /**
+ * One material assignment of a {@link HierarchyNode} with a render component: a mesh instance's
+ * position within the component and the runtime name of its current material.
+ */
+type HierarchyMaterial = {
+    /** The mesh instance's position in the render component's `meshInstances` array. */
+    index: number;
+    /**
+     * The runtime name of the mesh instance's current material, reported as-is: the engine
+     * names an unnamed glTF material `Untitled`, and assigns a shared material named
+     * `defaultGlbMaterial` to a primitive authored without one — neither is a unique authored
+     * identifier. `null` when a script has cleared the assignment.
+     */
+    name: string | null;
+};
+
+/**
  * One node of the tree returned by {@link ModelElement.hierarchy}. A plain-data snapshot —
  * `JSON.stringify` serializes it — whose `toString()` renders the node's subtree as a printable
  * tree.
@@ -29,19 +45,25 @@ type HierarchyNode = {
     index: number;
     /** The types of the components attached to the node (e.g. 'render'), sorted. */
     components: string[];
+    /**
+     * The material assignments of the node's render component, one entry per mesh instance in
+     * component order. Empty for a node without a render component.
+     */
+    materials: HierarchyMaterial[];
     /** The node's children. */
     children: HierarchyNode[];
     /**
      * Renders the subtree rooted at this node as a printable tree, one line per node: the name,
-     * `[index]` after a name that several nodes in the model share, and the component types in
-     * parentheses.
+     * `[index]` after a name that several nodes in the model share, the component types in
+     * parentheses, and the material names of a render component in braces.
      */
     toString(): string;
 };
 
 /**
  * Formats one line of the printable hierarchy: the node's name, an `[index]` marker when the
- * name is shared by several nodes in the model, and the attached component types.
+ * name is shared by several nodes in the model, the attached component types, and the material
+ * names of a render component.
  *
  * @param node - The node to format.
  * @param counts - The number of nodes bearing each name.
@@ -50,7 +72,10 @@ type HierarchyNode = {
 const formatNode = (node: HierarchyNode, counts: ReadonlyMap<string, number>): string => {
     const index = (counts.get(node.name) ?? 0) > 1 ? ` [${node.index}]` : '';
     const components = node.components.length > 0 ? ` (${node.components.join(', ')})` : '';
-    return `${node.name}${index}${components}`;
+    // Braces rather than brackets: `[N]` already means a match index on this line
+    const materials =
+        node.materials.length > 0 ? ` {${node.materials.map((slot) => slot.name ?? 'null').join(', ')}}` : '';
+    return `${node.name}${index}${components}${materials}`;
 };
 
 /**
@@ -130,7 +155,8 @@ class ModelElement extends AsyncElement {
      * container asset has not loaded, or the element has left the document). One call grounds a
      * session — a browser console, a test, an agent — in the vocabulary `pc-node` binding
      * resolves against: the instantiated names ({@link HierarchyNode.name}), paths, match
-     * indices and attached component types. `String(...)` of the result, or of any node in it,
+     * indices, attached component types and the material assignments of render components
+     * ({@link HierarchyNode.materials}). `String(...)` of the result, or of any node in it,
      * is the printable form.
      *
      * The snapshot is plain data, computed afresh each call: it does not follow later changes
@@ -162,6 +188,10 @@ class ModelElement extends AsyncElement {
                 index,
                 // A plain GraphNode grafted into the hierarchy has no component storage
                 components: Object.keys(entity.c ?? {}).sort(),
+                materials: (entity.render?.meshInstances ?? []).map((meshInstance, slot) => ({
+                    index: slot,
+                    name: meshInstance.material?.name ?? null
+                })),
                 children: entity.children.map((child) =>
                     describe(child as Entity, pathBelowRoot ? `${pathBelowRoot}/${child.name}` : child.name)
                 )
@@ -360,4 +390,4 @@ class ModelElement extends AsyncElement {
 customElements.define('pc-model', ModelElement);
 
 export { ModelElement };
-export type { HierarchyNode };
+export type { HierarchyMaterial, HierarchyNode };

--- a/test/integration/hierarchy.test.ts
+++ b/test/integration/hierarchy.test.ts
@@ -1,3 +1,4 @@
+import { StandardMaterial } from 'playcanvas';
 import { describe, expect, it } from 'vitest';
 
 import type { ModelElement } from '../../src/model';
@@ -16,6 +17,19 @@ import { readyWithin } from '../helpers/ready';
  */
 const positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
 const positionsBase64 = btoa(String.fromCharCode(...new Uint8Array(positions.buffer)));
+
+/** The buffer plumbing every primitive below shares: one triangle, referenced by accessor 0. */
+const GEOMETRY = {
+    accessors: [{ bufferView: 0, componentType: 5126, count: 3, type: 'VEC3', min: [0, 0, 0], max: [1, 1, 0] }],
+    bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: positions.byteLength }],
+    buffers: [
+        {
+            uri: `data:application/octet-stream;base64,${positionsBase64}`,
+            byteLength: positions.byteLength
+        }
+    ]
+};
+
 const CAR_SRC = `data:application/json,${encodeURIComponent(
     JSON.stringify({
         asset: { version: '2.0' },
@@ -31,14 +45,35 @@ const CAR_SRC = `data:application/json,${encodeURIComponent(
             { name: 'Wing' }
         ],
         meshes: [{ primitives: [{ attributes: { POSITION: 0 } }] }],
-        accessors: [{ bufferView: 0, componentType: 5126, count: 3, type: 'VEC3', min: [0, 0, 0], max: [1, 1, 0] }],
-        bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: positions.byteLength }],
-        buffers: [
+        ...GEOMETRY
+    })
+)}`;
+
+/**
+ * A glTF exercising the material assignments hierarchy() reports: one render node whose five
+ * primitives cover a named material, an unnamed one (which keeps the engine's runtime default
+ * name `Untitled`), a second distinct material duplicating the first's name, and a primitive
+ * authored without any material (which the engine gives its shared `defaultGlbMaterial`).
+ */
+const BODY_SRC = `data:application/json,${encodeURIComponent(
+    JSON.stringify({
+        asset: { version: '2.0' },
+        scene: 0,
+        scenes: [{ nodes: [0] }],
+        nodes: [{ name: 'Body', mesh: 0 }],
+        materials: [{ name: 'CarPaint' }, { name: 'Glass' }, { name: 'CarPaint' }, {}],
+        meshes: [
             {
-                uri: `data:application/octet-stream;base64,${positionsBase64}`,
-                byteLength: positions.byteLength
+                primitives: [
+                    { attributes: { POSITION: 0 }, material: 0 },
+                    { attributes: { POSITION: 0 }, material: 3 },
+                    { attributes: { POSITION: 0 }, material: 1 },
+                    { attributes: { POSITION: 0 } },
+                    { attributes: { POSITION: 0 }, material: 2 }
+                ]
             }
-        ]
+        ],
+        ...GEOMETRY
     })
 )}`;
 
@@ -58,6 +93,7 @@ const STAGE_SRC = `data:application/json,${encodeURIComponent(
 
 const ASSETS = `
     <pc-asset id="car" type="container" src="${CAR_SRC}"></pc-asset>
+    <pc-asset id="body" type="container" src="${BODY_SRC}"></pc-asset>
     <pc-asset id="stage" type="container" src="${STAGE_SRC}"></pc-asset>
 `;
 
@@ -88,19 +124,32 @@ describe('<pc-model> hierarchy()', () => {
         // no enumerable extras beyond the data itself.
         const tree = JSON.parse(JSON.stringify(model.hierarchy()));
 
+        // The wheels' shared mesh is authored without a material, so each render component
+        // carries the engine's shared default - reported by its runtime name like any other.
+        const wheelMaterials = [{ index: 0, name: 'defaultGlbMaterial' }];
+
         expect(tree).toEqual({
             name: 'Car',
             path: 'Car',
             index: 0,
             components: [],
+            materials: [],
             children: [
                 {
                     name: 'FrontAxle',
                     path: 'FrontAxle',
                     index: 0,
                     components: [],
+                    materials: [],
                     children: [
-                        { name: 'Wheel', path: 'FrontAxle/Wheel', index: 0, components: ['render'], children: [] }
+                        {
+                            name: 'Wheel',
+                            path: 'FrontAxle/Wheel',
+                            index: 0,
+                            components: ['render'],
+                            materials: wheelMaterials,
+                            children: []
+                        }
                     ]
                 },
                 {
@@ -108,12 +157,20 @@ describe('<pc-model> hierarchy()', () => {
                     path: 'RearAxle',
                     index: 0,
                     components: [],
+                    materials: [],
                     children: [
-                        { name: 'Wheel', path: 'RearAxle/Wheel', index: 1, components: ['render'], children: [] }
+                        {
+                            name: 'Wheel',
+                            path: 'RearAxle/Wheel',
+                            index: 1,
+                            components: ['render'],
+                            materials: wheelMaterials,
+                            children: []
+                        }
                     ]
                 },
-                { name: 'Wing', path: 'Wing', index: 0, components: [], children: [] },
-                { name: 'Wing1', path: 'Wing1', index: 0, components: [], children: [] }
+                { name: 'Wing', path: 'Wing', index: 0, components: [], materials: [], children: [] },
+                { name: 'Wing1', path: 'Wing1', index: 0, components: [], materials: [], children: [] }
             ]
         });
 
@@ -124,6 +181,7 @@ describe('<pc-model> hierarchy()', () => {
             'path',
             'index',
             'components',
+            'materials',
             'children'
         ]);
         expect(uncaught.seen).toEqual([]);
@@ -165,14 +223,56 @@ describe('<pc-model> hierarchy()', () => {
             [
                 'Car',
                 '├─ FrontAxle',
-                '│  └─ Wheel [0] (render)',
+                '│  └─ Wheel [0] (render) {defaultGlbMaterial}',
                 '├─ RearAxle',
-                '│  └─ Wheel [1] (render)',
+                '│  └─ Wheel [1] (render) {defaultGlbMaterial}',
                 '├─ Wing',
                 '└─ Wing1'
             ].join('\n')
         );
-        expect(String(tree.children[0]), 'any node prints its own subtree').toBe('FrontAxle\n└─ Wheel [0] (render)');
+        expect(String(tree.children[0]), 'any node prints its own subtree').toBe(
+            'FrontAxle\n└─ Wheel [0] (render) {defaultGlbMaterial}'
+        );
+        expect(uncaught.seen).toEqual([]);
+    });
+
+    it('reports material assignments by their runtime names, as-is', async () => {
+        const { get } = await bootApp(`${ASSETS}<pc-model asset="body"></pc-model>`);
+        const tree = get<ModelElement>('pc-model').hierarchy()!;
+
+        // Names are the instantiated runtime names: the unnamed material keeps the engine
+        // default 'Untitled', the material-less primitive carries the engine's shared
+        // 'defaultGlbMaterial', and duplicated authored names stay duplicated. None of those
+        // are unique authored identifiers - the index is the unambiguous handle.
+        expect(tree.materials).toEqual([
+            { index: 0, name: 'CarPaint' },
+            { index: 1, name: 'Untitled' },
+            { index: 2, name: 'Glass' },
+            { index: 3, name: 'defaultGlbMaterial' },
+            { index: 4, name: 'CarPaint' }
+        ]);
+
+        expect(String(tree), 'the printable form appends the material names in slot order').toBe(
+            'Body (render) {CarPaint, Untitled, Glass, defaultGlbMaterial, CarPaint}'
+        );
+        expect(uncaught.seen).toEqual([]);
+    });
+
+    it('reads the material assignments at call time', async () => {
+        const { get } = await bootApp(`${ASSETS}<pc-model asset="body"></pc-model>`);
+        const model = get<ModelElement>('pc-model');
+        const meshInstances = model.entity!.render!.meshInstances;
+
+        const replacement = new StandardMaterial();
+        replacement.name = 'Resprayed';
+        meshInstances[0].material = replacement;
+        // The engine types material as always assigned; a script clearing it is exactly the
+        // state this pins, so the write goes through a cast.
+        meshInstances[1].material = null as unknown as StandardMaterial;
+
+        const materials = model.hierarchy()!.materials;
+        expect(materials[0], 'a fresh snapshot sees the swap').toEqual({ index: 0, name: 'Resprayed' });
+        expect(materials[1], 'a cleared assignment reports a null name').toEqual({ index: 1, name: null });
         expect(uncaught.seen).toEqual([]);
     });
 


### PR DESCRIPTION
Second of the three-PR sequence implementing #371 (node-scoped glTF material overrides): the discovery surface. Builds on #370's `hierarchy()`.

Nodes with render components now expose their material assignments:

```js
{
    name: 'Body',
    path: 'Body',
    index: 0,
    components: ['render'],
    materials: [
        { index: 0, name: 'CarPaint' },
        { index: 1, name: 'Untitled' },
        { index: 2, name: 'Glass' }
    ],
    children: []
}
```

- `index` is the mesh instance's position in the render component's `meshInstances` array — exactly the value #371's `index:N` selector will accept.
- `name` follows the same instantiated-runtime rule as `HierarchyNode.name`: reported as-is, so an unnamed glTF material shows the engine default `Untitled`, a primitive authored without a material shows the engine's shared `defaultGlbMaterial`, duplicate authored names stay duplicated, and a script-cleared assignment reports `null`. None of those are unique authored identifiers — the RFC's docs steer authors to `index:` for them.
- `materials` is always present (empty for nodes without a render component), keeping the snapshot uniformly plain data.
- The printable form appends the names in braces to render nodes (braces because `[N]` already means a match index on the line):

```
Car
├─ FrontAxle
│  └─ Wheel [0] (render) {defaultGlbMaterial}
├─ RearAxle
│  └─ Wheel [1] (render) {defaultGlbMaterial}
├─ Wing
└─ Wing1
```

The test fixture grows the multi-primitive render node the RFC's test plan calls for — distinct named materials, a duplicated name, an unnamed material, and a primitive without one — which the `material-overrides` PR will reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
