### PR TITLE
Add material-overrides to pc-node

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -124,3 +124,4 @@ export {
 
 export type { AsyncElementTagName } from './async-element';
 export type { HierarchyMaterial, HierarchyNode } from './model';
+export type { MaterialOverrides } from './node';

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,9 +1,10 @@
-import type { Entity, EventHandle, GraphNode, Quat } from 'playcanvas';
+import type { Entity, EventHandle, GraphNode, Material, MeshInstance, Quat, RenderComponent } from 'playcanvas';
 import { Vec3 } from 'playcanvas';
 
 import { ComponentElement } from './components/component';
 import type { EntityElement } from './entity';
 import { EntityBaseElement, POINTER_ATTRIBUTES } from './entity-base';
+import { MaterialElement } from './material';
 import { ModelElement } from './model';
 import { parseBool, parseTags, parseVec3 } from './parse';
 
@@ -25,6 +26,95 @@ type AuthoredState = {
     rotation?: Quat;
     scale?: Vec3;
     tags?: string[];
+};
+
+/**
+ * A sparse mapping from selector to `pc-material` id, as carried by the `material-overrides`
+ * attribute and `materialOverrides` property. A `name:X` key selects every mesh instance of the
+ * bound node's render component whose baseline material is named `X`; an `index:N` key selects
+ * mesh instance `N` and wins over a name rule for the same instance.
+ */
+type MaterialOverrides = Readonly<Record<string, string>>;
+
+/**
+ * One baseline assignment, captured for every mesh instance of the authored render component
+ * when the first material override applies: the mesh instance, the material it displaced, and
+ * that material's name at capture time — the name `name:` selectors match, immune to later
+ * renames. `material` is `null` when a script had already cleared the assignment.
+ */
+type BaselineAssignment = {
+    meshInstance: MeshInstance;
+    material: Material | null;
+    name: string | null;
+};
+
+/** One selector of a material-overrides mapping, in parsed form. */
+type MaterialRule = { kind: 'name'; name: string; id: string } | { kind: 'index'; index: number; id: string };
+
+/**
+ * Parses one mapping into its valid rules, warning for each entry that is not one: an unknown
+ * or missing selector prefix, an empty `name:` value, an `index:` value that is not a
+ * non-negative integer, or a replacement id that is not a non-empty string. An invalid rule
+ * behaves exactly as if absent from the mapping.
+ *
+ * @param overrides - The mapping to parse.
+ * @param label - The element description for warnings.
+ * @returns The valid rules.
+ */
+const parseMaterialRules = (overrides: MaterialOverrides, label: string): MaterialRule[] => {
+    const rules: MaterialRule[] = [];
+    for (const [selector, id] of Object.entries(overrides)) {
+        if (typeof id !== 'string' || id === '') {
+            console.warn(`${label} material-overrides '${selector}' needs a pc-material id - rule ignored`);
+        } else if (selector.startsWith('name:')) {
+            // The text after the prefix is the selector value, exactly as written - a material
+            // name may legitimately begin or end with whitespace
+            const name = selector.slice('name:'.length);
+            if (name === '') {
+                console.warn(`${label} material-overrides 'name:' selector is empty - rule ignored`);
+            } else {
+                rules.push({ kind: 'name', name, id });
+            }
+        } else if (selector.startsWith('index:')) {
+            // Whitespace around the number is tolerated; Number('') is 0, so blank means NaN
+            const text = selector.slice('index:'.length).trim();
+            const index = text === '' ? NaN : Number(text);
+            if (!Number.isInteger(index) || index < 0) {
+                console.warn(
+                    `${label} material-overrides '${selector}' is not a non-negative integer index - rule ignored`
+                );
+            } else {
+                rules.push({ kind: 'index', index, id });
+            }
+        } else {
+            console.warn(`${label} material-overrides '${selector}' has no 'name:' or 'index:' prefix - rule ignored`);
+        }
+    }
+    return rules;
+};
+
+/**
+ * Parses the material-overrides attribute text. Anything but a JSON object — malformed JSON, an
+ * array, a primitive — warns and yields `null`, the absent mapping: a stale mapping must not
+ * survive an attribute value the DOM no longer represents.
+ *
+ * @param text - The attribute text.
+ * @param label - The element description for warnings.
+ * @returns The mapping, or `null`.
+ */
+const parseMaterialOverridesAttribute = (text: string, label: string): MaterialOverrides | null => {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(text);
+    } catch (error) {
+        console.warn(`${label} material-overrides is not valid JSON - treated as absent: ${(error as Error).message}`);
+        return null;
+    }
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        console.warn(`${label} material-overrides must be a JSON object - treated as absent`);
+        return null;
+    }
+    return parsed as MaterialOverrides;
 };
 
 /**
@@ -83,6 +173,13 @@ const levenshtein = (a: string, b: string): number => {
  * "x y z" triple.
  * @attribute {string} scale - Overrides the node's local scale, as an "x y z" triple.
  * @attribute {string} tags - Overrides the node's tags, separated by spaces or commas.
+ * @attribute {string} material-overrides - Overrides material assignments on the bound node's
+ * render component, as a JSON object from selector to `pc-material` id — for example
+ * `{"name:CarPaint": "candy-red", "index:7": "smoked-glass"}`. A `name:X` key selects every mesh
+ * instance whose baseline material is named `X`; an `index:N` key selects mesh instance `N` and
+ * wins over a name rule for the same instance. Assignments no rule matches keep their baseline
+ * materials, and removing the attribute restores all of them. Use `pc-model.hierarchy()` to
+ * discover the names and indices a node offers.
  * @attribute {string} onpointerenter - Script to run when the pointer moves onto the node.
  * @attribute {string} onpointerleave - Script to run when the pointer moves off the node.
  * @attribute {string} onpointermove - Script to run when the pointer moves over the node.
@@ -126,6 +223,20 @@ class NodeElement extends EntityBaseElement {
     /** The authored values displaced by this element's overrides, captured per property. */
     private _authored: AuthoredState = {};
 
+    /**
+     * The model-authored render component of the bound node, recorded at bind — before child
+     * decorations build — so a render component added later by a child `pc-render` can never
+     * become the override target. `null` when the bound node has none.
+     */
+    private _authoredRender: RenderComponent | null = null;
+
+    /**
+     * The baseline assignments displaced by the material overrides, captured for every mesh
+     * instance when the first non-empty mapping applies and released when the mapping goes
+     * absent (restoring them) or the binding dissolves.
+     */
+    private _baseline: BaselineAssignment[] | null = null;
+
     // Override values. `null` means "no override": the authored value stays in force.
 
     private _enabled: boolean | null = null;
@@ -137,6 +248,8 @@ class NodeElement extends EntityBaseElement {
     private _scale: Vec3 | null = null;
 
     private _tags: string[] | null = null;
+
+    private _materialOverrides: MaterialOverrides | null = null;
 
     /**
      * The binding state: `pending` until the host instantiates and `name` resolves, `bound`
@@ -298,6 +411,7 @@ class NodeElement extends EntityBaseElement {
         this._destroyHandle = target.once('destroy', this._onEntityDestroy, this);
         this._state = 'bound';
         this._path = this._pathOf(target, hostEntity);
+        this._authoredRender = target.render ?? null;
 
         this._applyOverrides();
         this._onReady();
@@ -333,6 +447,7 @@ class NodeElement extends EntityBaseElement {
         this._entity = null;
         this._path = null;
         this._authored = {};
+        this._authoredRender = null;
 
         // Component decorations come off through the same hook the host-ready cycle uses. A
         // dissolve that never rebinds fires no ready event, so the sweep is explicit - after
@@ -357,6 +472,9 @@ class NodeElement extends EntityBaseElement {
         this._entity = null;
         this._path = null;
         this._authored = {};
+        this._authoredRender = null;
+        // The mesh instances died with the entity - the capture is dropped, not restored
+        this._baseline = null;
         this._state = 'pending';
         this._resetReady();
     }
@@ -400,6 +518,9 @@ class NodeElement extends EntityBaseElement {
         if (this._tags !== null) {
             this.tags = this._tags;
         }
+        if (this._materialOverrides !== null) {
+            this._applyMaterialOverrides();
+        }
     }
 
     /**
@@ -426,6 +547,120 @@ class NodeElement extends EntityBaseElement {
             entity.tags.add(authored.tags);
         }
         this._authored = {};
+        this._restoreBaseline();
+    }
+
+    /**
+     * Applies the material mapping to the authored render component: parse the mapping's valid
+     * rules, capture the baseline on first application, then recompute every assignment from
+     * that baseline - name rules write over it, index rules write over them, so `index:` wins -
+     * and assign whatever changed. An absent mapping, or one with no valid rules, restores the
+     * baseline instead. Called while bound, from `_applyOverrides` and the property setter.
+     */
+    private _applyMaterialOverrides() {
+        const label = `pc-node '${this._name}'`;
+
+        const rules = this._materialOverrides ? parseMaterialRules(this._materialOverrides, label) : [];
+        if (rules.length === 0) {
+            this._restoreBaseline();
+            return;
+        }
+
+        if (!this._baseline) {
+            if (!this._authoredRender) {
+                console.warn(
+                    `${label} is bound to a node without an authored render component - material-overrides ignored`
+                );
+                return;
+            }
+            this._baseline = this._authoredRender.meshInstances.map((meshInstance) => ({
+                meshInstance,
+                material: (meshInstance.material as Material | null) ?? null,
+                name: meshInstance.material?.name ?? null
+            }));
+        }
+
+        const baseline = this._baseline;
+
+        /** Resolves a replacement id, warning when it does not resolve. */
+        const resolveReplacement = (id: string): Material | null => {
+            const material = MaterialElement.get(id);
+            if (!material) {
+                console.warn(`${label} material-overrides could not resolve pc-material '${id}' - rule ignored`);
+            }
+            return material ?? null;
+        };
+
+        // Recompute the whole list from the baseline: name rules write over it, index rules
+        // write over them. Recomputing makes mapping edits order-independent, and a rule whose
+        // replacement does not resolve simply leaves the layer below it in force.
+        const resolved = baseline.map((assignment) => assignment.material);
+
+        for (const rule of rules) {
+            if (rule.kind !== 'name') {
+                continue;
+            }
+            const material = resolveReplacement(rule.id);
+            if (!material) {
+                continue;
+            }
+            let matched = false;
+            baseline.forEach((assignment, index) => {
+                if (assignment.name === rule.name) {
+                    resolved[index] = material;
+                    matched = true;
+                }
+            });
+            if (!matched) {
+                const names = baseline.map((assignment) => `'${assignment.name}'`).join(', ');
+                console.warn(
+                    `${label} material-overrides 'name:${rule.name}' matches no assignment - ` +
+                        `baseline names: ${names || '(none)'}`
+                );
+            }
+        }
+
+        for (const rule of rules) {
+            if (rule.kind !== 'index') {
+                continue;
+            }
+            if (rule.index >= baseline.length) {
+                console.warn(
+                    `${label} material-overrides 'index:${rule.index}' is out of range - ` +
+                        `${baseline.length} assignment(s)`
+                );
+                continue;
+            }
+            const material = resolveReplacement(rule.id);
+            if (material) {
+                resolved[rule.index] = material;
+            }
+        }
+
+        baseline.forEach((assignment, index) => {
+            // The engine setter rebuilds material and shader state even for a redundant write,
+            // so only actual changes are assigned
+            if (assignment.meshInstance.material !== resolved[index]) {
+                assignment.meshInstance.material = resolved[index] as Material;
+            }
+        });
+    }
+
+    /**
+     * Restores every baseline assignment the material overrides displaced and releases the
+     * capture, so the next non-empty mapping captures afresh. Safe to call without a capture.
+     */
+    private _restoreBaseline() {
+        const baseline = this._baseline;
+        if (!baseline) {
+            return;
+        }
+        this._baseline = null;
+        for (const assignment of baseline) {
+            if (assignment.meshInstance.material !== assignment.material) {
+                assignment.meshInstance.material = assignment.material as Material;
+            }
+        }
     }
 
     /**
@@ -659,8 +894,43 @@ class NodeElement extends EntityBaseElement {
         return this._tags;
     }
 
+    /**
+     * Sets the material overrides: a sparse mapping from selector to `pc-material` id, applied
+     * to the bound node's authored render component. A `name:X` key selects every mesh instance
+     * whose baseline material is named `X`; an `index:N` key selects mesh instance `N` and wins
+     * over a name rule for the same instance. Assignments no rule matches keep their baseline
+     * materials. `null` clears the mapping, restoring every baseline assignment.
+     * @param value - The mapping, or `null`.
+     */
+    set materialOverrides(value: MaterialOverrides | null) {
+        // Copied and frozen: later caller mutation of the passed object must not silently
+        // disagree with the mapping the element applied
+        this._materialOverrides = value === null ? null : Object.freeze({ ...value });
+        if (this._state === 'bound') {
+            this._applyMaterialOverrides();
+        }
+    }
+
+    /**
+     * Gets the material overrides.
+     * @returns The mapping, or `null` while no override is set.
+     */
+    get materialOverrides(): MaterialOverrides | null {
+        return this._materialOverrides;
+    }
+
     static get observedAttributes() {
-        return ['enabled', 'index', 'name', 'position', 'rotation', 'scale', 'tags', ...POINTER_ATTRIBUTES];
+        return [
+            'enabled',
+            'index',
+            'material-overrides',
+            'name',
+            'position',
+            'rotation',
+            'scale',
+            'tags',
+            ...POINTER_ATTRIBUTES
+        ];
     }
 
     attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
@@ -683,6 +953,10 @@ class NodeElement extends EntityBaseElement {
                         this.index = index;
                     }
                 }
+                break;
+            case 'material-overrides':
+                this.materialOverrides =
+                    newValue === null ? null : parseMaterialOverridesAttribute(newValue, `pc-node '${this._name}'`);
                 break;
             case 'name':
                 this.name = newValue ?? '';
@@ -713,3 +987,4 @@ class NodeElement extends EntityBaseElement {
 customElements.define('pc-node', NodeElement);
 
 export { NodeElement };
+export type { MaterialOverrides };

--- a/test/integration/material-overrides.test.ts
+++ b/test/integration/material-overrides.test.ts
@@ -89,7 +89,7 @@ const SKINNED_SRC = `data:application/json,${encodeURIComponent(
 )}`;
 
 const PRELUDE = `
-    <pc-material id="candy-red"></pc-material>
+    <pc-material id="candy-red" name="Candy Red"></pc-material>
     <pc-material id="smoked-glass"></pc-material>
     <pc-asset id="body" type="container" src="${BODY_SRC}"></pc-asset>
     <pc-asset id="skinned" type="container" src="${SKINNED_SRC}"></pc-asset>
@@ -394,7 +394,7 @@ describe('<pc-node> material-overrides', () => {
     });
 
     describe('discovery', () => {
-        it('reports replacements through hierarchy() by their pc-material ids', async () => {
+        it('reports replacements through hierarchy() by their material names', async () => {
             const { model, node } = await bootAuthored();
 
             expect(model.hierarchy()!.materials.map((slot) => slot.name)).toEqual([
@@ -405,14 +405,17 @@ describe('<pc-node> material-overrides', () => {
                 'CarPaint'
             ]);
 
-            node.materialOverrides = { 'name:CarPaint': 'candy-red' };
+            node.materialOverrides = { 'name:CarPaint': 'candy-red', 'name:Glass': 'smoked-glass' };
 
+            // The id is a reference key, never a label: a replacement whose pc-material carries
+            // a name attribute reports it, and one without reads the engine default - label the
+            // materials that should be identifiable in hierarchy() output.
             expect(model.hierarchy()!.materials.map((slot) => slot.name)).toEqual([
-                'candy-red',
+                'Candy Red',
                 'Untitled',
-                'Glass',
+                'Untitled',
                 'defaultGlbMaterial',
-                'candy-red'
+                'Candy Red'
             ]);
             expect(uncaught.seen).toEqual([]);
         });

--- a/test/integration/material-overrides.test.ts
+++ b/test/integration/material-overrides.test.ts
@@ -1,0 +1,442 @@
+import type { Entity } from 'playcanvas';
+import { describe, expect, it } from 'vitest';
+
+import type { MaterialElement } from '../../src/material';
+import type { ModelElement } from '../../src/model';
+import type { NodeElement } from '../../src/node';
+import { bootApp } from '../helpers/app';
+import { useGuard } from '../helpers/guard';
+import { readyWithin } from '../helpers/ready';
+
+/**
+ * A glTF exercising every selector the mapping grammar offers: a render node whose five
+ * primitives cover a named material, an unnamed one (runtime name `Untitled`), a duplicated
+ * name (two distinct materials both named `CarPaint`), and a primitive authored without a
+ * material (the engine's shared `defaultGlbMaterial`). `Trim` is a render descendant sharing
+ * `CarPaint`, which node scoping must leave alone, and `Mount` is a meshless attachment node.
+ */
+const positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+const positionsBase64 = btoa(String.fromCharCode(...new Uint8Array(positions.buffer)));
+const BODY_SRC = `data:application/json,${encodeURIComponent(
+    JSON.stringify({
+        asset: { version: '2.0' },
+        scene: 0,
+        scenes: [{ nodes: [0] }],
+        nodes: [{ name: 'Body', mesh: 0, children: [1, 2] }, { name: 'Trim', mesh: 1 }, { name: 'Mount' }],
+        materials: [{ name: 'CarPaint' }, { name: 'Glass' }, { name: 'CarPaint' }, {}],
+        meshes: [
+            {
+                primitives: [
+                    { attributes: { POSITION: 0 }, material: 0 },
+                    { attributes: { POSITION: 0 }, material: 3 },
+                    { attributes: { POSITION: 0 }, material: 1 },
+                    { attributes: { POSITION: 0 } },
+                    { attributes: { POSITION: 0 }, material: 2 }
+                ]
+            },
+            { primitives: [{ attributes: { POSITION: 0 }, material: 0 }] }
+        ],
+        accessors: [{ bufferView: 0, componentType: 5126, count: 3, type: 'VEC3', min: [0, 0, 0], max: [1, 1, 0] }],
+        bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: positions.byteLength }],
+        buffers: [
+            {
+                uri: `data:application/octet-stream;base64,${positionsBase64}`,
+                byteLength: positions.byteLength
+            }
+        ]
+    })
+)}`;
+
+/**
+ * A minimally skinned glTF: one bone, identity bind matrix, every vertex weighted to it. The
+ * mesh instance carries a skin instance, which a material swap must leave in place.
+ */
+const skinnedBytes = new Uint8Array(160);
+skinnedBytes.set(new Uint8Array(positions.buffer), 0);
+// Joints (UBYTE4 x 3) at offset 36 stay zero; weights bind every vertex fully to joint 0
+skinnedBytes.set(new Uint8Array(new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0]).buffer), 48);
+// prettier-ignore
+skinnedBytes.set(new Uint8Array(new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]).buffer), 96);
+const skinnedBase64 = btoa(String.fromCharCode(...skinnedBytes));
+const SKINNED_SRC = `data:application/json,${encodeURIComponent(
+    JSON.stringify({
+        asset: { version: '2.0' },
+        scene: 0,
+        scenes: [{ nodes: [0] }],
+        nodes: [{ name: 'Root', children: [1, 2] }, { name: 'Bone' }, { name: 'Skinny', mesh: 0, skin: 0 }],
+        skins: [{ joints: [1], inverseBindMatrices: 3 }],
+        materials: [{ name: 'Skin' }],
+        meshes: [{ primitives: [{ attributes: { POSITION: 0, JOINTS_0: 1, WEIGHTS_0: 2 }, material: 0 }] }],
+        accessors: [
+            { bufferView: 0, componentType: 5126, count: 3, type: 'VEC3', min: [0, 0, 0], max: [1, 1, 0] },
+            { bufferView: 1, componentType: 5121, count: 3, type: 'VEC4' },
+            { bufferView: 2, componentType: 5126, count: 3, type: 'VEC4' },
+            { bufferView: 3, componentType: 5126, count: 1, type: 'MAT4' }
+        ],
+        bufferViews: [
+            { buffer: 0, byteOffset: 0, byteLength: 36 },
+            { buffer: 0, byteOffset: 36, byteLength: 12 },
+            { buffer: 0, byteOffset: 48, byteLength: 48 },
+            { buffer: 0, byteOffset: 96, byteLength: 64 }
+        ],
+        buffers: [
+            {
+                uri: `data:application/octet-stream;base64,${skinnedBase64}`,
+                byteLength: skinnedBytes.byteLength
+            }
+        ]
+    })
+)}`;
+
+const PRELUDE = `
+    <pc-material id="candy-red"></pc-material>
+    <pc-material id="smoked-glass"></pc-material>
+    <pc-asset id="body" type="container" src="${BODY_SRC}"></pc-asset>
+    <pc-asset id="skinned" type="container" src="${SKINNED_SRC}"></pc-asset>
+`;
+
+describe('<pc-node> material-overrides', () => {
+    const { uncaught, warnings } = useGuard();
+
+    /** Boots the body model with one pc-node carrying `nodeAttributes`. */
+    const bootBody = async (nodeAttributes: string) => {
+        const booted = await bootApp(`${PRELUDE}<pc-model asset="body"><pc-node ${nodeAttributes}></pc-node></pc-model>`);
+        const model = booted.get<ModelElement>('pc-model');
+        const node = booted.get<NodeElement>('pc-node');
+        const replacements = {
+            candyRed: booted.get<MaterialElement>('pc-material[id="candy-red"]').material!,
+            smokedGlass: booted.get<MaterialElement>('pc-material[id="smoked-glass"]').material!
+        };
+        /** The body render component's mesh instances, read fresh from the current hierarchy. */
+        const meshInstances = () => model.entity!.render!.meshInstances;
+        return { ...booted, model, node, replacements, meshInstances };
+    };
+
+    /** Boots the body model with an unmapped pc-node and captures the authored assignments. */
+    const bootAuthored = async () => {
+        const booted = await bootBody('name="Body"');
+        const authored = booted.meshInstances().map((meshInstance) => meshInstance.material);
+        return { ...booted, authored };
+    };
+
+    describe('selection', () => {
+        it('replaces sparsely by name and index, leaving unmatched assignments untouched', async () => {
+            const { authored, meshInstances, node, replacements } = await bootAuthored();
+
+            node.setAttribute('material-overrides', '{"name:Glass": "smoked-glass", "index:1": "candy-red"}');
+
+            const current = meshInstances().map((meshInstance) => meshInstance.material);
+            expect(current[2], 'name:Glass replaced its one assignment').toBe(replacements.smokedGlass);
+            expect(current[1], 'index:1 replaced the unnamed assignment').toBe(replacements.candyRed);
+            for (const slot of [0, 3, 4]) {
+                expect(current[slot], `slot ${slot} keeps its authored material`).toBe(authored[slot]);
+            }
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('replaces every assignment matching a name rule, and only on the bound node', async () => {
+            const { meshInstances, model, node, replacements } = await bootBody(
+                `name="Body" material-overrides='{"name:CarPaint": "candy-red"}'`
+            );
+
+            const current = meshInstances().map((meshInstance) => meshInstance.material);
+            expect(current[0], 'both CarPaint assignments replaced').toBe(replacements.candyRed);
+            expect(current[4], 'the duplicated name matches too').toBe(replacements.candyRed);
+
+            const trim = (model.entity!.findByName('Trim') as Entity).render!.meshInstances[0];
+            expect(trim.material, "the descendant's CarPaint is out of scope").not.toBe(replacements.candyRed);
+            expect(trim.material.name).toBe('CarPaint');
+            expect(node.state).toBe('bound');
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('lets an index rule win over a name rule for the same instance', async () => {
+            const { meshInstances, node, replacements } = await bootAuthored();
+
+            node.materialOverrides = { 'name:CarPaint': 'candy-red', 'index:0': 'smoked-glass' };
+
+            const current = meshInstances().map((meshInstance) => meshInstance.material);
+            expect(current[0], 'index beats name on the shared instance').toBe(replacements.smokedGlass);
+            expect(current[4], 'the name rule still covers the other match').toBe(replacements.candyRed);
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('falls back from an unresolved index rule to the name rule beneath it', async () => {
+            const { meshInstances, node, replacements } = await bootAuthored();
+
+            node.materialOverrides = { 'name:CarPaint': 'candy-red', 'index:0': 'missing' };
+
+            expect(meshInstances()[0].material, 'the invalid rule behaves as absent').toBe(replacements.candyRed);
+            warnings.expect("pc-node 'Body' material-overrides could not resolve pc-material 'missing'");
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('matches against the baseline captured at first application, immune to renames', async () => {
+            const { authored, meshInstances, node, replacements } = await bootAuthored();
+
+            node.materialOverrides = { 'name:CarPaint': 'candy-red' };
+            authored[2]!.name = 'Resprayed';
+
+            // Edits recompute from the baseline: names are matched as captured, never against a
+            // replacement (no chaining) and never against a later rename.
+            node.materialOverrides = { 'name:CarPaint': 'smoked-glass', 'name:Glass': 'candy-red' };
+
+            const current = meshInstances().map((meshInstance) => meshInstance.material);
+            expect(current[0], 'rematched by baseline name, not by the previous replacement').toBe(
+                replacements.smokedGlass
+            );
+            expect(current[4]).toBe(replacements.smokedGlass);
+            expect(current[2], 'matched by its captured name despite the rename').toBe(replacements.candyRed);
+            expect(uncaught.seen).toEqual([]);
+        });
+    });
+
+    describe('lifecycle', () => {
+        it('restores the exact authored references on attribute removal, null, empty and malformed mappings', async () => {
+            const { authored, meshInstances, node, replacements } = await bootAuthored();
+            const restored = () => meshInstances().map((meshInstance) => meshInstance.material);
+            const expectAuthored = (reason: string) => {
+                restored().forEach((material, slot) => {
+                    expect(material, `slot ${slot} ${reason}`).toBe(authored[slot]);
+                });
+            };
+
+            node.setAttribute('material-overrides', '{"name:CarPaint": "candy-red"}');
+            expect(restored()[0]).toBe(replacements.candyRed);
+            node.removeAttribute('material-overrides');
+            expectAuthored('restored on attribute removal');
+
+            node.materialOverrides = { 'name:CarPaint': 'candy-red' };
+            node.materialOverrides = null;
+            expectAuthored('restored on null assignment');
+
+            node.materialOverrides = { 'name:CarPaint': 'candy-red' };
+            node.setAttribute('material-overrides', '{}');
+            expectAuthored('an empty mapping behaves as absent');
+
+            node.materialOverrides = { 'name:CarPaint': 'candy-red' };
+            node.setAttribute('material-overrides', '{not json');
+            expectAuthored('malformed JSON must not leave a stale mapping in force');
+            warnings.expect("pc-node 'Body' material-overrides is not valid JSON");
+
+            node.setAttribute('material-overrides', '["candy-red"]');
+            expectAuthored('an array is not a mapping');
+            warnings.expect("pc-node 'Body' material-overrides must be a JSON object");
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('restores the old node on retarget and applies to the new one', async () => {
+            const { authored, meshInstances, model, node, replacements } = await bootAuthored();
+
+            node.setAttribute('material-overrides', '{"name:CarPaint": "candy-red"}');
+            node.setAttribute('name', 'Trim');
+
+            expect(meshInstances()[0].material, 'the old node reads as authored again').toBe(authored[0]);
+            const trim = (model.entity!.findByName('Trim') as Entity).render!.meshInstances[0];
+            expect(trim.material, 'the mapping now covers the new node').toBe(replacements.candyRed);
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('restores the authored materials when the element is removed', async () => {
+            const { authored, meshInstances, node } = await bootAuthored();
+
+            node.setAttribute('material-overrides', '{"name:CarPaint": "candy-red"}');
+            node.remove();
+
+            meshInstances().forEach((meshInstance, slot) => {
+                expect(meshInstance.material, `slot ${slot} survives the element`).toBe(authored[slot]);
+            });
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('captures a fresh baseline and reapplies across a model reload', async () => {
+            const { meshInstances, model, node, replacements } = await bootBody(
+                `name="Body" material-overrides='{"name:CarPaint": "candy-red"}'`
+            );
+            const before = meshInstances();
+
+            model.setAttribute('asset', 'body');
+            await readyWithin(model);
+            await readyWithin(node);
+
+            const after = meshInstances();
+            expect(after[0], 'the fresh hierarchy is new').not.toBe(before[0]);
+            expect(after[0].material, 'the mapping reapplied to the fresh assignments').toBe(replacements.candyRed);
+            expect(after[4].material).toBe(replacements.candyRed);
+            expect(after[2].material.name, 'unmatched fresh assignments stay authored').toBe('Glass');
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('keeps a replacement across disable and re-enable without reapplication', async () => {
+            const { meshInstances, node, replacements } = await bootBody(
+                `name="Body" enabled="false" material-overrides='{"name:CarPaint": "candy-red"}'`
+            );
+
+            expect(meshInstances()[0].material, 'applied while disabled').toBe(replacements.candyRed);
+            node.enabled = null;
+            expect(meshInstances()[0].material, 'still in place once enabled').toBe(replacements.candyRed);
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('freezes the property mapping and does not reflect it to the attribute', async () => {
+            const { node, replacements, meshInstances } = await bootAuthored();
+
+            const mapping: Record<string, string> = { 'name:CarPaint': 'candy-red' };
+            node.materialOverrides = mapping;
+            mapping['name:Glass'] = 'smoked-glass';
+
+            expect(node.materialOverrides, 'later caller mutation is invisible').toEqual({
+                'name:CarPaint': 'candy-red'
+            });
+            expect(Object.isFrozen(node.materialOverrides)).toBe(true);
+            expect(node.hasAttribute('material-overrides'), 'property writes do not reflect').toBe(false);
+            expect(meshInstances()[2].material, 'the mutated-in rule never applied').not.toBe(
+                replacements.smokedGlass
+            );
+            expect(uncaught.seen).toEqual([]);
+        });
+    });
+
+    describe('diagnostics', () => {
+        it('warns per invalid rule and applies the rest of the mapping', async () => {
+            const { authored, meshInstances, node, replacements } = await bootAuthored();
+
+            node.materialOverrides = {
+                CarPaint: 'candy-red',
+                'name:': 'candy-red',
+                'index:x': 'candy-red',
+                'index:-1': 'candy-red',
+                'name:Glass': 'smoked-glass'
+            };
+
+            warnings.expect("pc-node 'Body' material-overrides 'CarPaint' has no 'name:' or 'index:' prefix");
+            warnings.expect("pc-node 'Body' material-overrides 'name:' selector is empty");
+            warnings.expect("pc-node 'Body' material-overrides 'index:x' is not a non-negative integer");
+            warnings.expect("pc-node 'Body' material-overrides 'index:-1' is not a non-negative integer");
+            expect(meshInstances()[2].material, 'the valid rule still applied').toBe(replacements.smokedGlass);
+            expect(meshInstances()[0].material, 'invalid rules changed nothing').toBe(authored[0]);
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('warns on a non-string replacement id, an out-of-range index and an unmatched name', async () => {
+            const { authored, meshInstances, node } = await bootAuthored();
+
+            node.materialOverrides = {
+                'index:0': 42,
+                'index:9': 'candy-red',
+                'name:Chrome': 'candy-red'
+            } as unknown as Record<string, string>;
+
+            warnings.expect("pc-node 'Body' material-overrides 'index:0' needs a pc-material id");
+            warnings.expect("pc-node 'Body' material-overrides 'index:9' is out of range - 5 assignment(s)");
+            warnings.expect(
+                "pc-node 'Body' material-overrides 'name:Chrome' matches no assignment - baseline names: " +
+                    "'CarPaint', 'Untitled', 'Glass', 'defaultGlbMaterial', 'CarPaint'"
+            );
+            meshInstances().forEach((meshInstance, slot) => {
+                expect(meshInstance.material, `slot ${slot} untouched`).toBe(authored[slot]);
+            });
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('warns and does nothing on a node without an authored render component, decorations aside', async () => {
+            const booted = await bootApp(
+                `${PRELUDE}<pc-model asset="body">
+                    <pc-node name="Mount"><pc-render type="box"></pc-render></pc-node>
+                </pc-model>`
+            );
+            const node = booted.get<NodeElement>('pc-node');
+            const decoration = node.querySelector('pc-render')!;
+
+            node.materialOverrides = { 'name:CarPaint': 'candy-red' };
+
+            warnings.expect(
+                "pc-node 'Mount' is bound to a node without an authored render component - material-overrides ignored"
+            );
+            const decorated = node.entity!.render!.meshInstances[0];
+            expect(decorated.material.name, 'the decoration-owned component is never a target').not.toBe(
+                'candy-red'
+            );
+            expect(decoration.isConnected).toBe(true);
+            expect(booted.get<ModelElement>('pc-model').entity).toBeTruthy();
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('takes the last of duplicate JSON keys, as JSON.parse defines', async () => {
+            const { meshInstances, node, replacements } = await bootAuthored();
+
+            node.setAttribute('material-overrides', '{"index:0": "candy-red", "index:0": "smoked-glass"}');
+
+            expect(meshInstances()[0].material).toBe(replacements.smokedGlass);
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('does not react to a pc-material inserted later, but a mapping retry resolves it', async () => {
+            const { appElement, authored, meshInstances, node } = await bootAuthored();
+
+            const late = document.createElement('pc-material') as MaterialElement;
+            late.id = 'late';
+            appElement.appendChild(late);
+            node.materialOverrides = { 'name:Glass': 'late' };
+
+            warnings.expect("pc-node 'Body' material-overrides could not resolve pc-material 'late'");
+            expect(meshInstances()[2].material, 'unresolved leaves the baseline in force').toBe(authored[2]);
+
+            await new Promise((resolve) => {
+                setTimeout(resolve, 0);
+            });
+            expect(meshInstances()[2].material, 'insertion alone changes nothing').toBe(authored[2]);
+
+            node.materialOverrides = { 'name:Glass': 'late' };
+            expect(meshInstances()[2].material, 'the retry resolves the id').toBe(late.material);
+            expect(uncaught.seen).toEqual([]);
+        });
+    });
+
+    describe('discovery', () => {
+        it('reports replacements through hierarchy() by their pc-material ids', async () => {
+            const { model, node } = await bootAuthored();
+
+            expect(model.hierarchy()!.materials.map((slot) => slot.name)).toEqual([
+                'CarPaint',
+                'Untitled',
+                'Glass',
+                'defaultGlbMaterial',
+                'CarPaint'
+            ]);
+
+            node.materialOverrides = { 'name:CarPaint': 'candy-red' };
+
+            expect(model.hierarchy()!.materials.map((slot) => slot.name)).toEqual([
+                'candy-red',
+                'Untitled',
+                'Glass',
+                'defaultGlbMaterial',
+                'candy-red'
+            ]);
+            expect(uncaught.seen).toEqual([]);
+        });
+    });
+
+    describe('skinning', () => {
+        it('swaps the material of a skinned mesh instance without touching its skin instance', async () => {
+            const booted = await bootApp(
+                `${PRELUDE}<pc-model asset="skinned"><pc-node name="Skinny"></pc-node></pc-model>`
+            );
+            const node = booted.get<NodeElement>('pc-node');
+            const candyRed = booted.get<MaterialElement>('pc-material[id="candy-red"]').material!;
+            const meshInstance = node.entity!.render!.meshInstances[0];
+            const skinInstance = meshInstance.skinInstance;
+            expect(skinInstance, 'the fixture really is skinned').toBeTruthy();
+
+            node.materialOverrides = { 'name:Skin': 'candy-red' };
+            expect(meshInstance.material).toBe(candyRed);
+            expect(meshInstance.skinInstance, 'the swap preserves the skin instance').toBe(skinInstance);
+
+            node.materialOverrides = null;
+            expect(meshInstance.material.name, 'restored').toBe('Skin');
+            expect(meshInstance.skinInstance).toBe(skinInstance);
+            expect(uncaught.seen).toEqual([]);
+        });
+    });
+});


### PR DESCRIPTION
Closes #371: node-scoped glTF material overrides on `pc-node`. Final PR of the three-PR sequence, following #373 and #374, now rebased onto main so the diff is the feature alone.

```html
<pc-app>
    <pc-material id="candy-red" diffuse="#b40018" metalness="0.8" roughness="0.25"></pc-material>
    <pc-material id="smoked-glass" diffuse="#202830" opacity="0.45" blend-type="normal"></pc-material>

    <pc-model asset="car">
        <pc-node
            name="Body"
            material-overrides='{
                "name:CarPaint": "candy-red",
                "index:7": "smoked-glass"
            }'>
        </pc-node>
    </pc-model>
</pc-app>
```

Semantics, per the RFC:

- **Selection.** `name:X` matches every mesh instance of the bound node's render component whose baseline material is named `X` (multi-match intentional); `index:N` matches mesh instance `N` and wins over a name rule for the same instance. Precedence is structural — name rules write over the baseline, index rules write over them — so JSON property order never matters. An invalid rule (unknown prefix, empty `name:`, non-integer `index:`, non-string id) warns and behaves exactly as if absent, which also yields the RFC's fallback chain: unresolved `index:` → applicable `name:` → baseline.
- **Baseline capture.** The full assignment list — `(meshInstance, material, name)` — is captured when the first non-empty valid mapping applies, matching the `pc-node` first-displacement contract. Matching always evaluates against captured names, so replacements never chain and post-capture renames can't retarget rules.
- **Scope.** Only the model-authored render component recorded at bind. Descendants are untouched, and a render component added later by a child `<pc-render>` decoration is never a target (a node with no authored render component warns and does nothing).
- **Lifecycle.** Every mapping change recomputes from the baseline, assigning only actual changes (the engine setter rebuilds shader state even on redundant writes). Removal, `null`, an empty mapping, or malformed JSON restore the exact captured references and release the capture; retarget/element-removal/model-reload inherit the established override lifecycle; the property setter freezes a defensive copy and never reflects to the attribute.
- **Diagnostics.** Malformed JSON is treated as an absent mapping (a stale mapping must not survive an attribute the DOM no longer represents). Per-rule warnings name the element, selector, and — for unmatched names — the baseline names on offer. `hierarchy()` (#374) is the discovery surface, and with #373 an overridden slot reports the replacement's `pc-material[name]` label (falling back to the engine default when unlabeled — the id is a reference key, never a label).

Tests cover the RFC's full plan: sparse name/index replacement, multi-match names, node scoping, index-beats-name, unresolved-index fallback, baseline recompute + rename immunity, restore-on-removal/null/empty/malformed with exact references, retarget, element removal, model reload, disabled re-enable, decoration exclusion, per-rule diagnostics, duplicate JSON keys, non-reactive late `pc-material` insertion with mapping retry, skinned mesh instances keeping their `skinInstance`, and `hierarchy()` before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


