### PR TITLE
Record the edit made to the resident-evil splat

### DIFF
--- a/examples/assets/splats/resident-evil.txt
+++ b/examples/assets/splats/resident-evil.txt
@@ -5,4 +5,5 @@ https://superspl.at/scene/67841e9d
 
 CC BY 4.0 https://creativecommons.org/licenses/by/4.0/
 
-Converted to SOG with splat-transform v3.1.7.
+Modified from the original: the second subject has been edited out, and the
+result converted to SOG with splat-transform v3.1.7.


### PR DESCRIPTION
Follow-up to #377.

The `resident-evil.sog` capture originally had two subjects; one was edited out before the asset was added here. CC BY 4.0 permits adaptations but requires indicating that changes were made, and the attribution file only mentioned the SOG conversion.

```
Modified from the original: the second subject has been edited out, and the
result converted to SOG with splat-transform v3.1.7.
```

Attribution text only — no code or asset changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
