### PR TITLE
Reconcile example names, titles and categories

### DIFF
--- a/examples/js/example-list.mjs
+++ b/examples/js/example-list.mjs
@@ -1,3 +1,14 @@
+/**
+ * The catalogue behind the example browser's sidebar. Categories appear in the order they first
+ * occur here, and examples in the order they are listed within a category - both hand-authored,
+ * running simplest first so a newcomer can read down a category.
+ *
+ * `examples[0]` is what the browser loads when there is no hash, so Showcases stays first.
+ *
+ * `name` is the single source of truth for a page's <title>, which must read
+ * `PlayCanvas Web Components - ${name}`. test/examples/example-list.test.ts enforces that, and that
+ * every example page in examples/ is listed here - an unlisted page is unreachable from the sidebar.
+ */
 export const examples = [
     // Showcases
     { name: 'Car Configurator', path: 'car-configurator.html', category: 'Showcases' },
@@ -5,19 +16,23 @@ export const examples = [
     { name: 'Shoe Configurator', path: 'shoe-configurator.html', category: 'Showcases' },
     { name: 'Solar System', path: 'solar-system.html', category: 'Showcases' },
     { name: 'Falling Blocks', path: 'vibe-falling-blocks.html', category: 'Showcases' },
+    // Getting Started
+    { name: 'Spinning Cube', path: 'spinning-cube.html', category: 'Getting Started' },
+    { name: 'Spinning Cube (DOM API)', path: 'spinning-cube-api.html', category: 'Getting Started' },
+    { name: 'Spinning Cube (UMD)', path: 'spinning-cube-umd.html', category: 'Getting Started' },
     // Gaussian Splatting
     { name: 'Basic Splat', path: 'splat-simple.html', category: 'Gaussian Splatting' },
     { name: 'Splat Annotations', path: 'splat-annotations.html', category: 'Gaussian Splatting' },
     { name: 'Splat Flipbook', path: 'splat-flipbook.html', category: 'Gaussian Splatting' },
-    // Computer Vision
-    { name: 'AR Avatar', path: 'ar-avatar.html', category: 'Computer Vision' },
-    { name: 'AR Hand Gestures', path: 'ar-hand-gestures.html', category: 'Computer Vision' },
-    { name: 'AR Optic Blast', path: 'ar-optic-blast.html', category: 'Computer Vision' },
-    { name: 'AR Sunglasses', path: 'ar-sunglasses.html', category: 'Computer Vision' },
-    { name: 'Head Tracked Window', path: 'window-tracking.html', category: 'Computer Vision' },
-    // Camera Movement
-    { name: 'First Person Teleport', path: 'first-person-teleport.html', category: 'Camera Movement' },
-    { name: 'FPS Controller', path: 'fps-controller.html', category: 'Camera Movement' },
+    // Webcam AR
+    { name: 'AR Avatar', path: 'ar-avatar.html', category: 'Webcam AR' },
+    { name: 'AR Hand Gestures', path: 'ar-hand-gestures.html', category: 'Webcam AR' },
+    { name: 'AR Optic Blast', path: 'ar-optic-blast.html', category: 'Webcam AR' },
+    { name: 'AR Sunglasses', path: 'ar-sunglasses.html', category: 'Webcam AR' },
+    { name: 'Head Tracked Window', path: 'window-tracking.html', category: 'Webcam AR' },
+    // Controls
+    { name: 'First Person Teleport', path: 'first-person-teleport.html', category: 'Controls' },
+    { name: 'First Person Controller', path: 'fps-controller.html', category: 'Controls' },
     // Graphics
     { name: 'Basic Shapes', path: 'basic-shapes.html', category: 'Graphics' },
     { name: 'Basic Particles', path: 'basic-particles.html', category: 'Graphics' },
@@ -25,13 +40,13 @@ export const examples = [
     { name: 'Video Texture', path: 'video-texture.html', category: 'Graphics' },
     { name: 'Video Recorder', path: 'video-recorder.html', category: 'Graphics' },
     // Animation
-    { name: 'Animation', path: 'animation.html', category: 'Animation' },
+    { name: 'GLB Animation', path: 'animation.html', category: 'Animation' },
     { name: 'Tweening', path: 'tween.html', category: 'Animation' },
     // Physics
-    { name: 'Physics', path: 'physics.html', category: 'Physics' },
+    { name: 'Basic Physics', path: 'physics.html', category: 'Physics' },
     { name: 'Physics Cluster', path: 'physics-cluster.html', category: 'Physics' },
     // Sound
-    { name: 'Sound', path: 'sound.html', category: 'Sound' },
+    { name: 'Basic Sound', path: 'sound.html', category: 'Sound' },
     { name: 'Positional Sound', path: 'positional-sound.html', category: 'Sound' },
     // UI & Text
     { name: '2D Screen', path: 'screen.html', category: 'UI & Text' },

--- a/examples/physics.html
+++ b/examples/physics.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
-        <title>PlayCanvas Web Components - Physics</title>
+        <title>PlayCanvas Web Components - Basic Physics</title>
         <script type="importmap">
             {
                 "imports": {

--- a/examples/shoe-configurator.html
+++ b/examples/shoe-configurator.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
-        <title>PlayCanvas Web Components - GLB Loader</title>
+        <title>PlayCanvas Web Components - Shoe Configurator</title>
         <script type="importmap">
             {
                 "imports": {

--- a/examples/sound.html
+++ b/examples/sound.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
-        <title>PlayCanvas Web Components - Sound</title>
+        <title>PlayCanvas Web Components - Basic Sound</title>
         <script type="importmap">
             {
                 "imports": {

--- a/examples/spinning-cube-api.html
+++ b/examples/spinning-cube-api.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
-        <title>PlayCanvas Web Components - Spinning Cube via DOM API</title>
+        <title>PlayCanvas Web Components - Spinning Cube (DOM API)</title>
         <script type="importmap">
             {
                 "imports": {

--- a/examples/spinning-cube-umd.html
+++ b/examples/spinning-cube-umd.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
-        <title>PlayCanvas Web Components - Spinning Cube</title>
+        <title>PlayCanvas Web Components - Spinning Cube (UMD)</title>
         <script src="/node_modules/playcanvas/build/playcanvas.js"></script>
         <script src="../dist/pwc.js"></script>
         <link rel="stylesheet" href="css/example.css">
@@ -17,7 +17,10 @@
                     }
                 }
 
-                pc.registerScript(Rotate, 'rotate');
+                // registerScript resolves the application's script registry, so it can only run
+                // once the application exists. The <pc-script name="rotate"> below is left pending
+                // until the class arrives, so registering after boot still wires it up.
+                pwc.whenReady('pc-app').then(() => pc.registerScript(Rotate, 'rotate'));
             </script>
             <!-- Scene -->
             <pc-scene>

--- a/examples/splat-annotations.html
+++ b/examples/splat-annotations.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
-        <title>PlayCanvas Web Components - Gaussian Splat Annotations</title>
+        <title>PlayCanvas Web Components - Splat Annotations</title>
         <script type="importmap">
             {
                 "imports": {

--- a/examples/splat-flipbook.html
+++ b/examples/splat-flipbook.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
-        <title>PlayCanvas Web Components - GSplat Flipbook</title>
+        <title>PlayCanvas Web Components - Splat Flipbook</title>
         <script type="importmap">
             {
                 "imports": {

--- a/examples/splat-simple.html
+++ b/examples/splat-simple.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
-        <title>PlayCanvas Web Components - 3D Gaussian Splat</title>
+        <title>PlayCanvas Web Components - Basic Splat</title>
         <script type="importmap">
             {
                 "imports": {

--- a/examples/ui-scroll-view.html
+++ b/examples/ui-scroll-view.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
-        <title>PlayCanvas Web Components - UI Scroll View</title>
+        <title>PlayCanvas Web Components - Scroll View</title>
         <script type="importmap">
             {
                 "imports": {

--- a/examples/video-recorder.html
+++ b/examples/video-recorder.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
-        <title>PlayCanvas Web Components - Video Encoder</title>
+        <title>PlayCanvas Web Components - Video Recorder</title>
         <script type="importmap">
             {
                 "imports": {

--- a/examples/video-texture.html
+++ b/examples/video-texture.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
-        <title>PlayCanvas Web Components - Video Textures</title>
+        <title>PlayCanvas Web Components - Video Texture</title>
         <script type="importmap">
             {
                 "imports": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "test:unit": "vitest run --project unit",
     "test:elements": "vitest run --project elements",
     "test:integration": "vitest run --project integration",
+    "test:examples": "vitest run --project examples",
     "publint": "publint",
     "type-check": "npm run type-check:src && npm run type-check:test",
     "type-check:src": "tsc --noEmit -p tsconfig.json",

--- a/test/README.md
+++ b/test/README.md
@@ -1,16 +1,23 @@
 # Tests
 
-Four tiers, three of which run in Node with jsdom and need neither a build nor a browser.
+Five tiers, four of which run in Node and need neither a build nor a browser.
 
 | Tier        | Command                    | Environment | Covers                                                                  |
 | ----------- | -------------------------- | ----------- | ----------------------------------------------------------------------- |
 | Unit        | `npm run test:unit`        | `node`      | The pure parsers in `src/parse.ts` and the `CSS_COLORS` table           |
 | Elements    | `npm run test:elements`    | `jsdom`     | Attribute and property surface, with no engine created                  |
 | Integration | `npm run test:integration` | `jsdom`     | A real `AppBase` on `NullGraphicsDevice`, via `<pc-app backend="null">` |
+| Examples    | `npm run test:examples`    | `node`      | `examples/` as a set: the catalogue against the pages on disk           |
 | Browser     | _(not yet implemented)_    | Chromium    | The built `dist/` bundle and the example pages                          |
 
-`npm test` runs the three Node tiers. `npm run test:watch` watches them, and
+`npm test` runs the four Node tiers. `npm run test:watch` watches them, and
 `npm run test:coverage` adds a v8 report under `coverage/`.
+
+The Examples tier is the odd one out: it tests the examples rather than the library, and reads sources
+as text instead of importing them. It exists because `examples/js/example-list.mjs` is the only name a
+reader sees in the sidebar while each page carries its own `<title>`, and those two drifted apart
+across a third of the examples before it was added. It also fails on an example page that the
+catalogue never lists — a page nothing imports, which no other tier can see.
 
 ## Why the library is testable headlessly
 

--- a/test/examples/example-list.test.ts
+++ b/test/examples/example-list.test.ts
@@ -1,0 +1,66 @@
+/// <reference types="vite/client" />
+
+import { describe, expect, it, test } from 'vitest';
+
+import { examples } from '../../examples/js/example-list.mjs';
+
+/**
+ * Every page under examples/, inlined by Vite as text. A glob rather than fs reads because the repo
+ * carries no @types/node - and adding it would hand src/ the Node globals too, where a stray
+ * `process` in browser code should stay an error.
+ *
+ * The key set is every page that exists on disk, which is what makes the unlisted-page check below
+ * possible at all.
+ */
+const pages: Record<string, string> = import.meta.glob('../../examples/*.html', {
+    query: '?raw',
+    import: 'default',
+    eager: true
+});
+
+/** The one page under examples/ that is not an example: it is the shell that renders the rest. */
+const NOT_AN_EXAMPLE = ['index.html'];
+
+const titleOf = (page: string): string | undefined =>
+    pages[`../../examples/${page}`]?.match(/<title>([^<]*)<\/title>/)?.[1];
+
+describe('example-list.mjs', () => {
+    it('lists every example page, so none is unreachable from the sidebar', () => {
+        const onDisk = Object.keys(pages)
+            .map((key) => key.slice(key.lastIndexOf('/') + 1))
+            .filter((page) => !NOT_AN_EXAMPLE.includes(page))
+            .sort();
+        const listed = examples.map((example) => example.path).sort();
+
+        expect(listed).toEqual(onDisk);
+    });
+
+    it('lists each page once', () => {
+        const paths = examples.map((example) => example.path);
+        expect(paths).toEqual([...new Set(paths)]);
+    });
+
+    it('gives each example a distinct name, since the name is all the sidebar shows', () => {
+        const names = examples.map((example) => example.name);
+        expect(names).toEqual([...new Set(names)]);
+    });
+
+    /**
+     * The browser groups by category into a Map keyed on the category string, so a category listed
+     * in two separate blocks silently merges into one sidebar section - and the within-category
+     * "simplest first" order the catalogue documents stops describing what a reader sees.
+     */
+    it('keeps each category in one contiguous block', () => {
+        const blocks = examples
+            .map((example) => example.category)
+            .filter((category, index, all) => category !== all[index - 1]);
+
+        expect(blocks).toEqual([...new Set(blocks)]);
+    });
+
+    describe('<title>', () => {
+        test.for(examples)('$name', ({ name, path: page }) => {
+            expect(titleOf(page)).toBe(`PlayCanvas Web Components - ${name}`);
+        });
+    });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -9,10 +9,16 @@
     //
     // `moduleResolution: "bundler"` and `strict` are inherited, so tests resolve extensionless
     // relative imports exactly as src/ does and are held to identical strictness.
+    //
+    // `allowJs` is for the one JS file a test imports: examples/js/example-list.mjs, the example
+    // catalogue. It stays plain JS because the example browser loads it unbuilt in a <script
+    // type="module">, so inference off the object literals is the only way to type it. `checkJs`
+    // stays off, so examples/ is read for types and never reported on.
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "noEmit": true,
-        "rootDir": "."
+        "rootDir": ".",
+        "allowJs": true
     },
     "include": [
         "src/**/*",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -88,6 +88,20 @@ export default defineConfig({
                     include: ['test/integration/**/*.test.ts'],
                     testTimeout: 15000
                 }
+            },
+            {
+                extends: true,
+                test: {
+                    /**
+                     * Consistency of examples/ as a set: the catalogue in example-list.mjs against
+                     * the pages on disk. Reads sources as text rather than loading anything, so it
+                     * needs no DOM - and unlike every tier above, it can fail on a file that
+                     * nothing imports. Last because it tests the examples, not the library.
+                     */
+                    name: 'examples',
+                    environment: 'node',
+                    include: ['test/examples/**/*.test.ts']
+                }
             }
         ],
 


### PR DESCRIPTION
Naming cleanup for the examples, from an audit of names, scripts and categories. This is the non-breaking half — no files are renamed, so every existing URL hash still resolves. The file renames the audit also recommends are deliberately left for a follow-up, since they break bookmarks and deep links and are better landed before 1.0.0.

## One canonical name per example

Every example was named in three independent places — the sidebar entry in `example-list.mjs`, the filename, and the page `<title>` — with nothing keeping them in sync. A third had drifted apart:

| Page | Sidebar said | `<title>` said |
| --- | --- | --- |
| `shoe-configurator.html` | Shoe Configurator | **GLB Loader** |
| `video-recorder.html` | Video Recorder | **Video Encoder** |
| `splat-simple.html` | Basic Splat | 3D Gaussian Splat |
| `splat-annotations.html` | Splat Annotations | Gaussian Splat Annotations |
| `splat-flipbook.html` | Splat Flipbook | GSplat Flipbook |
| `ui-scroll-view.html` | Scroll View | UI Scroll View |
| `video-texture.html` | Video Texture | Video Textures |
| `spinning-cube-umd.html` | *(unlisted)* | Spinning Cube — same as `spinning-cube.html` |

The sidebar `name` is now the single source of truth: a title must read `` `PlayCanvas Web Components - ${name}` ``.

## Categories

- **Animation, Physics and Sound each contained an example of the same name**, so the title bar rendered `Physics / Physics`. Renamed to **GLB Animation**, **Basic Physics** and **Basic Sound**, following the `Basic X` prefix the entry-level examples already use.
- **Computer Vision → Webcam AR.** The old label named the implementation, and four of its five entries were prefixed `AR`, which collides with the WebXR AR used elsewhere in these same examples.
- **Camera Movement → Controls.** It held two first-person character controllers rather than camera moves; the new name leaves room for orbit and third-person.
- **FPS Controller → First Person Controller.** `FPS` also reads as frames-per-second, and the engine's own script is `firstPersonController`.
- **New Getting Started section.** The three `spinning-cube` pages were in no category and unreachable from the sidebar — declarative markup, the imperative DOM API, and the UMD build, which is exactly what a newcomer wants. Placed after Showcases so `examples[0]`, what loads when there is no hash, stays the Car Configurator.

The catalogue now also documents the two rules that were previously implicit: categories and examples are hand-ordered simplest-first, and `name` drives the title.

## A break this surfaced

Listing `spinning-cube-umd.html` exposed a pre-existing failure. It called `pc.registerScript` synchronously from a classic `<script>`, before `<pc-app>` had created the application — so `registerScript` dereferenced an undefined `AppBase.getApplication()`, threw, and the cube never span. It now waits on `pwc.whenReady('pc-app')`, as `spinning-cube-api.html` already did with a comment explaining why. Verified rotating with a clean console.

## New Examples test tier

`npm run test:examples` checks `examples/` as a set: every page's title matches its catalogue entry, every page on disk is listed, no duplicate paths or names, and each category occupies one contiguous block. It is the only tier that can fail on a file nothing imports — these pages are never imported by the library, which is how the drift went unnoticed.

Two notes on how it is wired:

- It reads pages through `import.meta.glob(..., { query: '?raw' })` rather than `fs`. The repo carries no `@types/node`, and adding it would hand `src/` the Node globals too, where a stray `process` in browser code should stay an error.
- `allowJs` is enabled for the test program so the catalogue types by inference — it stays plain JS because the example browser loads it unbuilt in a `<script type="module">`. `checkJs` stays off.

Each guard was confirmed to fail when the thing it protects is broken, not just to pass as written.

## Verification

- `npm test` — 704 passed across 37 files (37 new)
- `npm run lint` and `npm run type-check` clean
- Sidebar renders all 10 categories, breadcrumbs read `Physics / Basic Physics`, `Controls / First Person Controller`, `Getting Started / Spinning Cube`
- All three Getting Started examples load and rotate, clean console

`npm run fmt` is red on `main` for ~116 files and stays red — untouched files like `test/unit/parse.test.ts` fail too. The files here are individually Prettier-clean; reformatting the repo does not belong in a naming PR.

## Not in this PR

The rest of the audit, roughly in order: the file renames (`vibe-falling-blocks.html` → `falling-blocks.html`, `glb.html` → `glb-loader.html`, `fps-controller.html` → `first-person-controller.html`, `text3d.html` → `text-3d.html`, and others); script naming, where `hand-gestures.mjs` exports `HandGestureController`, `morph-update.mjs` names a lifecycle hook rather than its behavior, and `material-variants.mjs` is not a `Script` at all despite living among 28 that are; splitting `assets/scripts/` so shared building blocks are distinguishable from single-example glue; `pc-entity name` using four casing styles for the same concepts (`keyLight` vs `key-light`); and a font asset with spaces and a period in its filename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
