### PR TITLE
Fix the entity sweep for subtrees cloned from a template

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -5,6 +5,33 @@ import { EntityBaseElement, POINTER_ATTRIBUTES } from './entity-base';
 import { parseBool, parseTags, parseVec3 } from './parse';
 
 /**
+ * Creates and parents the entities of every descendant `<pc-entity>` of `root`, in two passes so
+ * that no parent's existence depends on document order. Called wherever a subtree could not build
+ * itself: an element inserted into an application that is already running, and a `<pc-node>` whose
+ * children waited for it to bind.
+ *
+ * Descendants that are not yet custom elements are skipped, because there is nothing useful to do
+ * for them and reaching for `_createEntity` would throw. A subtree cloned from a `<template>`
+ * arrives entirely unupgraded — template content lives in an inert document, where custom element
+ * definitions are never looked up — and appending the clone upgrades its elements in tree order,
+ * an element before its descendants. So a sweep from an element's own `connectedCallback` sees
+ * plain `HTMLElement`s below it. Each becomes an `EntityElement` moments later and its own
+ * `connectedCallback` creates and parents it, by which time the ancestor it parents under has its
+ * entity — the same guarantee tree order gives this sweep.
+ *
+ * @param root - The element whose descendant entities to build.
+ * @param app - The application to create the entities in.
+ * @internal
+ */
+export const buildDescendantEntities = (root: Element, app: AppBase) => {
+    const children = Array.from(root.querySelectorAll('pc-entity')).filter(
+        (child): child is EntityElement => child instanceof EntityElement
+    );
+    children.forEach((child) => child._createEntity(app));
+    children.forEach((child) => child._buildHierarchy(app));
+};
+
+/**
  * The EntityElement interface provides properties and methods for manipulating
  * {@link https://developer.playcanvas.com/user-manual/web-components/tags/pc-entity/ | `<pc-entity>`} elements.
  * The EntityElement interface also inherits the properties and methods of the
@@ -172,13 +199,7 @@ class EntityElement extends EntityBaseElement {
             this._buildHierarchy(app);
 
             // Handle any child entities that might exist
-            const childEntities = this.querySelectorAll<EntityElement>('pc-entity');
-            childEntities.forEach((child) => {
-                child._createEntity(app);
-            });
-            childEntities.forEach((child) => {
-                child._buildHierarchy(app);
-            });
+            buildDescendantEntities(this, app);
         }
     }
 

--- a/src/node.ts
+++ b/src/node.ts
@@ -2,6 +2,7 @@ import type { Entity, EventHandle, GraphNode, Material, MeshInstance, Quat, Rend
 import { Vec3 } from 'playcanvas';
 
 import { ComponentElement } from './components/component';
+import { buildDescendantEntities } from './entity';
 import type { EntityElement } from './entity';
 import { EntityBaseElement, POINTER_ATTRIBUTES } from './entity-base';
 import { MaterialElement } from './material';
@@ -490,13 +491,7 @@ class NodeElement extends EntityBaseElement {
         if (!app) {
             return;
         }
-        const childEntities = this.querySelectorAll<EntityElement>('pc-entity');
-        childEntities.forEach((child) => {
-            child._createEntity(app);
-        });
-        childEntities.forEach((child) => {
-            child._buildHierarchy(app);
-        });
+        buildDescendantEntities(this, app);
     }
 
     /**

--- a/test/integration/template-clone.test.ts
+++ b/test/integration/template-clone.test.ts
@@ -1,0 +1,117 @@
+import { Vec3 } from 'playcanvas';
+import { describe, expect, it } from 'vitest';
+
+import type { EntityElement } from '../../src/entity';
+import type { NodeElement } from '../../src/node';
+import { bootApp, settle } from '../helpers/app';
+import { useGuard } from '../helpers/guard';
+
+/**
+ * A `<template>` whose content is a nested `<pc-entity>` subtree, in the shape the scroll view
+ * example clones per list entry: an outer entity carrying a component of its own, plus child
+ * entities that carry theirs.
+ */
+const ENTRY_TEMPLATE = `
+    <template id="entry">
+        <pc-entity name="Entry" position="1 2 3">
+            <pc-render type="box"></pc-render>
+            <pc-entity name="Label" position="0 1 0">
+                <pc-render type="sphere"></pc-render>
+            </pc-entity>
+            <pc-entity name="Button"></pc-entity>
+        </pc-entity>
+    </template>
+`;
+
+/** A meshless glTF with a single named node, for the `<pc-node>` case. */
+const STAGE_SRC = `data:application/json,${encodeURIComponent(
+    JSON.stringify({
+        asset: { version: '2.0' },
+        scene: 0,
+        scenes: [{ name: 'Stage', nodes: [0] }],
+        nodes: [{ name: 'Podium' }]
+    })
+)}`;
+
+/**
+ * Insertion of a subtree cloned from a `<template>`.
+ *
+ * This is the documented way to build repeated content at runtime, and it is the one insertion
+ * path whose elements are NOT custom elements when they arrive. Template content lives in an
+ * inert document with no browsing context, so nothing in it is ever upgraded; the clone's
+ * elements upgrade only once appended, in tree order - which means an outer element's
+ * connectedCallback runs while every descendant is still a plain HTMLElement. Any sweep that
+ * reaches down into the subtree from there must tolerate that.
+ */
+describe('a <template>-cloned subtree', () => {
+    const { uncaught } = useGuard();
+
+    it('builds a cloned <pc-entity> subtree appended to a running app', async () => {
+        const { get, app, appElement, container } = await bootApp(
+            `<pc-entity name="Content"></pc-entity>${ENTRY_TEMPLATE}`
+        );
+        const content = get<EntityElement>('pc-entity[name="Content"]');
+        const template = get<HTMLTemplateElement>('template');
+
+        content.appendChild(template.content.cloneNode(true));
+
+        // Entities are built synchronously: every reaction the insertion queued - the upgrade of
+        // each cloned element and the connectedCallback it runs - has completed by the time
+        // appendChild returns. (Components are not; they await their host's readiness.)
+        const entry = content.querySelector<EntityElement>(':scope > pc-entity')!;
+        expect(entry.entity, 'the cloned root was created').toBeTruthy();
+        expect(entry.entity!.parent, 'and parented under the entity it was appended to').toBe(content.entity);
+
+        // The attributes were parsed before the entity was created: upgrading an element replays
+        // attributeChangedCallback for every attribute already on it, ahead of connectedCallback.
+        expect(entry.entity!.getLocalPosition().equals(new Vec3(1, 2, 3)), 'position="1 2 3" applied').toBe(true);
+
+        // The descendants that were still plain HTMLElements during the outer connectedCallback
+        expect(entry.entity!.children.map((child) => child.name)).toEqual(['Label', 'Button']);
+
+        const label = content.querySelector<EntityElement>('pc-entity[name="Label"]')!;
+        expect(label.entity, 'a nested cloned entity was created').toBeTruthy();
+        expect(label.entity!.parent, 'and parented under the cloned root').toBe(entry.entity);
+        expect(label.entity!.getLocalPosition().equals(new Vec3(0, 1, 0))).toBe(true);
+
+        // The entities are registered with the application, not merely created - the picker's
+        // reverse lookup joins scene nodes back to elements through that registration.
+        expect(app.root.findByName('Label'), 'the entity is in the scene').toBe(label.entity);
+        expect(appElement.elementFromEntity(label.entity!), 'and joined back to its element').toBe(label);
+
+        // Components attach once their host entity is ready, which is a microtask later
+        await settle(container);
+        expect(entry.entity!.render, "the outer entity's component was added").toBeTruthy();
+        expect(label.entity!.render, "a nested entity's component was added too").toBeTruthy();
+
+        expect(uncaught.seen).toEqual([]);
+    });
+
+    it('builds a cloned <pc-node> subtree appended to an instantiated <pc-model>', async () => {
+        const { get } = await bootApp(`
+            <pc-asset id="stage" type="container" src="${STAGE_SRC}"></pc-asset>
+            <pc-model asset="stage"></pc-model>
+            <template id="attachment">
+                <pc-node name="Podium">
+                    <pc-entity name="Marker" position="0 1 0"></pc-entity>
+                </pc-node>
+            </template>
+        `);
+        const model = get('pc-model');
+        const template = get<HTMLTemplateElement>('template');
+
+        // The host is already instantiated, so the cloned pc-node binds from inside its own
+        // connectedCallback - the one moment its children have not upgraded yet.
+        model.appendChild(template.content.cloneNode(true));
+
+        const node = model.querySelector<NodeElement>(':scope > pc-node')!;
+        expect(node.state, 'the cloned node bound').toBe('bound');
+
+        const marker = node.querySelector<EntityElement>('pc-entity')!;
+        expect(marker.entity, 'the attachment entity was created').toBeTruthy();
+        expect(marker.entity!.parent, 'and parented under the bound node').toBe(node.entity);
+        expect(marker.entity!.getLocalPosition().equals(new Vec3(0, 1, 0))).toBe(true);
+
+        expect(uncaught.seen).toEqual([]);
+    });
+});


### PR DESCRIPTION
`examples/ui-scroll-view.html` throws `child._createEntity is not a function` 15 times on page load — once per list entry the scroll controller clones. The defect is pre-existing and reproduces on `main`; it was found while renaming that example, and the rename itself was content-identical.

## Root cause

`EntityElement.connectedCallback` assumed every `pc-entity` its `querySelectorAll` returns is an upgraded `EntityElement`:

```ts
const childEntities = this.querySelectorAll<EntityElement>('pc-entity');
childEntities.forEach((child) => {
    child._createEntity(app);
});
```

That holds for markup the parser produced, and for elements built with `createElement`, but not for a subtree cloned from a `<template>`. Template content lives in an inert document with no browsing context, where custom element definitions are never looked up, so **nothing in a clone is upgraded**. Appending the clone upgrades its elements in tree order — an element before its descendants — so the outer `pc-entity`'s `connectedCallback` ran while every descendant was still a plain `HTMLElement`, with no `_createEntity` to call.

Cloning a `<template>` is a documented, first-class way to build repeated content with this library (`examples/physics-cluster.html` does it too, and only escapes the bug because its template has no nested `pc-entity`), so the library should tolerate it.

## The fix

Descendants that are not yet custom elements are skipped. There is nothing useful to do for them: each becomes an `EntityElement` moments later and its own `connectedCallback` creates and parents it, by which time the ancestor it parents under has its entity. Already-upgraded children still go through both passes unchanged.

`NodeElement._buildChildren` carried a copy of the same sweep and the same defect — reachable when a cloned `pc-node` binds from inside its own `connectedCallback`, which I confirmed rather than assumed (see the second test). Both call sites now share one `@internal` helper, since a duplicated order-sensitive sweep is how this came to exist in two places. The helper is not re-exported from `index.ts`; I checked it is absent from the built `.d.ts`/`.d.cts` and that the type tree still checks standalone.

## On the two-pass order

`customElements.upgrade()` was the other candidate, and worth recording why it lost: **it cannot preserve the two-pass order either.** Upgrading a *connected* element runs its `connectedCallback`, which both creates and parents — so both approaches interleave create/build per element, and there is no way to get "create all, then build all" for a clone without a larger refactor.

That order turns out not to matter. The two passes are defensive rather than load bearing: `_buildHierarchy` only needs `closestEntity.entity`, and `querySelectorAll` returns document order, so an ancestor is always reached before its descendants — the same guarantee tree order gives the upgrade cascade. The skip is the smaller change, leaning on the browser's own ordering (which the library already depends on everywhere else) rather than forcing a synchronous upgrade cascade from inside a custom element reaction.

## Testing

New integration-tier test — it needs a running application. It builds and clones a `<template>` explicitly, because the suite's `mount()` helper produces already-upgraded elements. Verified by `git stash`-ing only `src/` that both cases fail on the exact error without the fix.

The console guard is what pins the `pc-node` case: that test would otherwise pass either way, since the marker entity self-builds once it upgrades — only the uncaught `TypeError` distinguishes fixed from broken.

Beyond `npm test` (706 pass), `npm run lint`, `npm run type-check`, `npm run build` and `npm run publint`, I loaded the rebuilt `dist/` in a browser against `examples/ui-scroll-view.html`: zero console errors, all 15 entries built with their full `Background, Remove Button, Text` subtrees, components attached, labels set, content refit to 700px, entities registered for the reverse lookup. The runtime add and remove paths are clean too.

## For a reviewer

`src/app.ts:259` has the same bug class and is **not** fixed here. A template-cloned `<pc-app>` hits `module._getLoadPromise is not a function` and then never becomes ready — no canvas, no entities, the whole application dead. Measured, not inferred.

It is deliberately left out because the fix is different in kind, not mechanical: skipping an unupgraded `<pc-module>` would silently never load the module (unlike a `pc-entity`, nothing later builds it on its own behalf), so it wants `customElements.upgrade()` plus its own verification of the boot path. It is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
