### PR TITLE
Upgrade the pc-app subtree before its boot reads from it

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -252,6 +252,24 @@ class AppElement extends AsyncElement {
             this._bar = new LoadingBar(this);
         }
 
+        // Upgrade the subtree before reading anything out of it. A subtree cloned from a
+        // <template> arrives entirely unupgraded - template content lives in an inert document,
+        // where custom element definitions are never looked up - and appending the clone upgrades
+        // its elements in tree order, this one before its descendants. The module query below would
+        // otherwise find plain HTMLElements with no _getLoadPromise to call, and the boot would die
+        // there, leaving the element permanently unready: no canvas, no entities, no application.
+        //
+        // Upgrading is the fix here rather than skipping whatever has not upgraded, because a
+        // <pc-module> is the one child that nothing else ever builds on its own behalf - skipping
+        // it would drop the wasm module the app asked for, silently and only for cloned apps.
+        // Upgrading runs each descendant's connectedCallback synchronously, a few lines earlier
+        // than the parser's path runs them but into the same state they see there: no application
+        // yet and _hierarchyReady false, so they defer to the sweeps below. A descendant that
+        // disconnects this element from there is caught by the generation check after the await,
+        // as any other disconnect is. An already-upgraded subtree - every other insertion path -
+        // is left completely untouched.
+        customElements.upgrade(this);
+
         // Get all pc-module elements that are direct children of the pc-app element
         const moduleElements = this.querySelectorAll<ModuleElement>(':scope > pc-module');
 

--- a/test/integration/template-clone.test.ts
+++ b/test/integration/template-clone.test.ts
@@ -1,10 +1,16 @@
-import { Vec3 } from 'playcanvas';
-import { describe, expect, it } from 'vitest';
+import { Vec3, WasmModule } from 'playcanvas';
+import { describe, expect, it, vi } from 'vitest';
 
+import type { AppElement } from '../../src/app';
+import type { AssetElement } from '../../src/asset';
 import type { EntityElement } from '../../src/entity';
+import type { MaterialElement } from '../../src/material';
+import type { ModuleElement } from '../../src/module';
 import type { NodeElement } from '../../src/node';
 import { bootApp, settle } from '../helpers/app';
+import { mount } from '../helpers/dom';
 import { useGuard } from '../helpers/guard';
+import { expectNeverReady, readyWithin } from '../helpers/ready';
 
 /**
  * A `<template>` whose content is a nested `<pc-entity>` subtree, in the shape the scroll view
@@ -32,6 +38,43 @@ const STAGE_SRC = `data:application/json,${encodeURIComponent(
         nodes: [{ name: 'Podium' }]
     })
 )}`;
+
+/**
+ * A whole `<pc-app>` inside a `<template>`, carrying one of every child the boot sweeps reach for:
+ * a module it must wait on, an asset and a material it creates directly, and a nested entity
+ * hierarchy with a component at the bottom.
+ *
+ * The asset is `lazy` so nothing is fetched - the point is that the element's asset gets created at
+ * all, not that it loads.
+ */
+const APP_TEMPLATE = `
+    <template id="app">
+        <pc-app backend="null">
+            <pc-module name="Ammo" glue="ammo.wasm.js" wasm="ammo.wasm.wasm" fallback="ammo.js"></pc-module>
+            <pc-asset id="cloned-texture" type="texture" src="texture.png" lazy></pc-asset>
+            <pc-material id="cloned-material" diffuse="1 0 0"></pc-material>
+            <pc-entity name="Root" position="1 2 3">
+                <pc-entity name="Child" position="0 1 0">
+                    <pc-render type="box"></pc-render>
+                </pc-entity>
+            </pc-entity>
+        </pc-app>
+    </template>
+`;
+
+/**
+ * Stubs the engine's wasm loader, holding the instance callback until `release()` so a test can
+ * observe the window in which `<pc-app>` is gated on the module. No real network or script
+ * execution can happen in jsdom; the element's contract is what these tests pin.
+ */
+const stubWasmModule = () => {
+    let pending: (() => void) | null = null;
+    const setConfig = vi.spyOn(WasmModule, 'setConfig').mockImplementation(() => undefined);
+    const getInstance = vi.spyOn(WasmModule, 'getInstance').mockImplementation((_name, callback) => {
+        pending = () => callback({});
+    });
+    return { setConfig, getInstance, release: () => pending?.() };
+};
 
 /**
  * Insertion of a subtree cloned from a `<template>`.
@@ -112,6 +155,112 @@ describe('a <template>-cloned subtree', () => {
         expect(marker.entity!.parent, 'and parented under the bound node').toBe(node.entity);
         expect(marker.entity!.getLocalPosition().equals(new Vec3(0, 1, 0))).toBe(true);
 
+        expect(uncaught.seen).toEqual([]);
+    });
+
+    it('boots a cloned <pc-app> whose children are all still unupgraded when it connects', async () => {
+        const { setConfig, getInstance, release } = stubWasmModule();
+        const handle = mount(APP_TEMPLATE);
+        const template = handle.get<HTMLTemplateElement>('template');
+
+        handle.container.appendChild(template.content.cloneNode(true));
+        release();
+
+        const appElement = handle.get<AppElement>('pc-app');
+        await readyWithin(appElement);
+        const app = appElement.app!;
+        app.autoRender = false;
+        await settle(handle.container);
+
+        // The module was loaded, not skipped. Skipping an unupgraded <pc-module> - the guard that
+        // suits a <pc-entity>, which later builds itself - would silently drop the wasm module an
+        // app asked for, since nothing else ever loads it.
+        expect(setConfig).toHaveBeenCalledWith('Ammo', {
+            glueUrl: 'ammo.wasm.js',
+            wasmUrl: 'ammo.wasm.wasm',
+            fallbackUrl: 'ammo.js'
+        });
+        expect(getInstance, 'the module was requested exactly once').toHaveBeenCalledTimes(1);
+        await readyWithin(handle.get<ModuleElement>('pc-module'));
+
+        // The application booted at all: the failure this pins left <pc-app> permanently unready,
+        // with no canvas and no entities.
+        expect(app.graphicsDevice.isNull, 'expected the null graphics device').toBe(true);
+        expect(appElement.querySelector('canvas'), 'the canvas was created').toBeTruthy();
+
+        // The ':scope > pc-asset' and ':scope > pc-material' sweeps run after two awaits, by which
+        // point the clone has upgraded either way - asserted rather than assumed.
+        expect(handle.get<AssetElement>('pc-asset').asset, 'the asset was created').toBeTruthy();
+        expect(handle.get<MaterialElement>('pc-material').material, 'the material was created').toBeTruthy();
+
+        // The entity sweep, and the attribute values it seeds entities from. Upgrading an element
+        // replays attributeChangedCallback for every attribute already on it, ahead of
+        // connectedCallback, so the cached fields are populated before any entity is created.
+        const root = handle.get<EntityElement>('pc-entity[name="Root"]');
+        const child = handle.get<EntityElement>('pc-entity[name="Child"]');
+        expect(root.entity!.parent, 'the outer entity is parented to the app root').toBe(app.root);
+        expect(child.entity!.parent, 'and the nested one under it').toBe(root.entity);
+        expect(root.entity!.getLocalPosition().equals(new Vec3(1, 2, 3)), 'position="1 2 3" applied').toBe(true);
+        expect(child.entity!.getLocalPosition().equals(new Vec3(0, 1, 0))).toBe(true);
+        expect(child.entity!.render, "the nested entity's component was added").toBeTruthy();
+
+        expect(uncaught.seen).toEqual([]);
+    });
+
+    it('gates a cloned <pc-app> on its cloned <pc-module>, rather than racing it', async () => {
+        const { getInstance, release } = stubWasmModule();
+        const handle = mount(APP_TEMPLATE);
+        const template = handle.get<HTMLTemplateElement>('template');
+
+        handle.container.appendChild(template.content.cloneNode(true));
+
+        // The load was started from the element while it was still unupgraded, synchronously -
+        // WasmModule.getInstance is called from the promise executor inside _loadModule.
+        expect(getInstance, 'the module load started during the insertion').toHaveBeenCalledTimes(1);
+
+        // Nothing must proceed until the module reports in: an app that booted here would create
+        // its graphics device before the wasm module backing it was configured.
+        const appElement = handle.get<AppElement>('pc-app');
+        await expectNeverReady(appElement);
+        expect(appElement.app, 'no application while the module is outstanding').toBeNull();
+        expect(uncaught.seen, 'and no rejection from reaching into an unupgraded element').toEqual([]);
+
+        // The entity elements have upgraded and their connectedCallbacks have already run, yet no
+        // entity exists: they saw _hierarchyReady false and deferred to the boot sweep, exactly as
+        // they do on the parser's path. `null` is what distinguishes the two - an element that had
+        // not upgraded would have no `entity` accessor at all, and read back `undefined`.
+        expect(handle.get<EntityElement>('pc-entity[name="Root"]').entity, 'upgraded but deferred').toBeNull();
+        expect(handle.get<EntityElement>('pc-entity[name="Child"]').entity, 'upgraded but deferred').toBeNull();
+
+        release();
+        await readyWithin(appElement);
+        appElement.app!.autoRender = false;
+        await settle(handle.container);
+
+        expect(uncaught.seen).toEqual([]);
+    });
+
+    it('abandons the boot of a cloned <pc-app> detached straight after insertion', async () => {
+        const { getInstance, release } = stubWasmModule();
+        const handle = mount(APP_TEMPLATE);
+        const template = handle.get<HTMLTemplateElement>('template');
+
+        handle.container.appendChild(template.content.cloneNode(true));
+        const appElement = handle.get<AppElement>('pc-app');
+
+        // Upgrading the subtree has already run every descendant's connectedCallback by this point,
+        // so the removal lands on a boot that has done strictly more than the parser's path would
+        // have. Releasing the module then drives it to the generation check after the module await,
+        // which is what has to stop it - a boot that continued would start an rAF ticker on an
+        // element nothing can clean up.
+        appElement.remove();
+        expect(getInstance, 'the module load had already started').toHaveBeenCalledTimes(1);
+        release();
+
+        await expectNeverReady(appElement);
+        expect(appElement.app, 'no application was created').toBeNull();
+        expect(appElement.querySelector('canvas'), 'no canvas was created').toBeNull();
+        expect(appElement.querySelector<EntityElement>('pc-entity[name="Root"]')!.entity, 'no entities').toBeNull();
         expect(uncaught.seen).toEqual([]);
     });
 });


### PR DESCRIPTION
## The bug

A `<pc-app>` inserted as a `<template>` clone never boots. Its element stays permanently unready — no canvas, no entities, no application — and the insertion produces an unhandled rejection:

```
module._getLoadPromise is not a function
```

`connectedCallback`'s first action, before any `await`, was:

```ts
const moduleElements = this.querySelectorAll<ModuleElement>(':scope > pc-module');
await Promise.all(Array.from(moduleElements).map((module) => module._getLoadPromise()));
```

Template content lives in an inert document, so nothing inside a `<template>` is ever looked up against the custom element registry. Appending the clone upgrades its elements in tree order — `pc-app` before its descendants — so `pc-app` runs that query while every `<pc-module>` below it is still a plain `HTMLElement`.

## The fix

`customElements.upgrade(this)` before the query, so the subtree is upgraded and the module elements can report their load promises.

**Skipping unupgraded children would have been the wrong fix here.** A `<pc-module>` is the one child that nothing else ever builds on its own behalf, so a skip guard would silently drop the glslang/twgsl WASM module a WebGPU app needs — with no warning, and only for cloned apps. Unlike a `<pc-entity>`, it gets no second chance from its own `connectedCallback`.

## Why forcing descendant `connectedCallback`s early is safe

`customElements.upgrade()` runs each descendant's `connectedCallback` synchronously, inside `pc-app`'s. Three things were checked rather than assumed:

- **Descendants defer, as they already do.** The upgrade moves them a few lines earlier than the parser's path runs them, but into the same state they see there: no application yet and `_hierarchyReady === false`. They defer, and the boot sweeps build them as usual. The test pins this by asserting `entity` is `null` during the gated window — `null` is only reachable through the upgraded class's accessor, so one assertion proves the element upgraded *and* that it deferred. An unupgraded element would read back `undefined`.
- **`_bootGeneration` needs no new guard.** The upgrade sits after the generation capture, so a descendant that disconnects `pc-app` from its own synchronous `connectedCallback` bumps the counter and the existing post-await check catches it, identically to every other disconnect window.
- **`:scope > pc-asset` and `:scope > pc-material` were already safe.** All descendant upgrade reactions are enqueued in the same element queue as `pc-app`'s `connectedCallback` and drain synchronously before `appendChild` returns, so they complete long before the first `await` resumes. The new tests assert both elements get created rather than assuming it.

An already-upgraded subtree — every other insertion path, including the parser's and `mount()`'s — is left completely untouched, since `upgrade()` skips elements whose state is already `custom`.

## Tests

Three tests added to `test/integration/template-clone.test.ts`, each verified to fail without the fix and pass with it:

1. **Boots a cloned `<pc-app>`.** Reproduces the original failure (before the fix: the exact `_getLoadPromise` rejection plus a 5s readiness timeout), then asserts the canvas, the asset, the material, the nested entity hierarchy with its attribute-seeded transforms, and a component at the bottom.
2. **Gates the app on the cloned module.** Holds the wasm loader's callback and asserts the app stays unready with `app === null` while the module is outstanding, then boots once released. This is the one that rejects a *wrong* fix: a skip guard, or a fire-and-forget module load, passes test 1 and fails this. Test 1 also asserts `getInstance` was called exactly once, since both the module's own `connectedCallback` and the app's query reach `_getLoadPromise()`.
3. **Abandons the boot when the clone is detached straight after insertion.** A genuinely new window, because the upgrade does strictly more work before the first `await` than the parser's path does.

## Reviewer note

Rebased onto #382, which fixed the same bug class for `<pc-entity>` / `<pc-node>` and added `test/integration/template-clone.test.ts`. The add/add conflict on that file is resolved: its two tests are untouched and the three here are appended, with the imports and the `describe` merged.

The two fixes are independent, not overlapping. This one only runs when `pc-app` itself connects, so it does nothing for a subtree appended to an already-running app — and #382 does nothing for a cloned `<pc-app>`, which never gets that far. #382's skip guard is also the right call in its own place: a `<pc-entity>` builds itself moments later from its own `connectedCallback`, which is exactly what a `<pc-module>` never does.

## Verification

`npm test` (742 passed, up from 739 on main), `npm run lint` and `npm run type-check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
