### PR TITLE
Develop against playcanvas 2.21.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "jsdom": "30.0.1",
         "mediabunny": "1.53.1",
         "opentype.js": "2.0.0",
-        "playcanvas": "2.22.0-beta.12",
+        "playcanvas": "2.21.4",
         "prettier": "3.9.6",
         "publint": "0.3.23",
         "rollup": "4.62.4",
@@ -8382,9 +8382,9 @@
       }
     },
     "node_modules/playcanvas": {
-      "version": "2.22.0-beta.12",
-      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.22.0-beta.12.tgz",
-      "integrity": "sha512-RxVFnLmfd391aYLYBFjQHySNKFMRiLal/eXE7F2/lbzf3NiH4b1fHpVShkORGryPg6g4N/38SEErNEevRJ64iw==",
+      "version": "2.21.4",
+      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.21.4.tgz",
+      "integrity": "sha512-L4UGy3z/YT8AaNBEY4ITsZup548UFMabF7loh0YQ0DRwQLdjIW8grmZPoQ1+B83+N6sejRS0/XlXV2Vfb11+fw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "jsdom": "30.0.1",
     "mediabunny": "1.53.1",
     "opentype.js": "2.0.0",
-    "playcanvas": "2.22.0-beta.12",
+    "playcanvas": "2.21.4",
     "prettier": "3.9.6",
     "publint": "0.3.23",
     "rollup": "4.62.4",


### PR DESCRIPTION
Moves the `playcanvas` devDependency from the `2.22.0-beta.12` prerelease down to `2.21.4`, so the build, tests and examples all run against the latest stable release rather than a beta.

```diff
-    "playcanvas": "2.22.0-beta.12",
+    "playcanvas": "2.21.4",
```

`peerDependencies` stays at `^2.20.1`, which already admits 2.21.4 — no change needed there.

The lockfile diff is 4 lines, only the `playcanvas` version. No unrelated dependency churn.

## What 2.21.4 drops

2.21.4 ships six fewer engine ESM scripts than the beta:

```
camera/perspective-correction.mjs
vat/vat-characters.mjs
vat/vat-chunks.mjs
vat/vat-converter.mjs
vat/vat-data.mjs
vat/vat-material.mjs
```

None are loaded by any example. All eleven that the examples *do* load — `annotations`, `camera-controls`, `camera-frame`, `first-person-controller`, `grid`, `gsplat/gsplat-flipbook`, `shadow-catcher` and the four `xr/*` — are present.

## Verification

- `npm run type-check` clean — no `src/` or `test/` code depends on a 2.22-only API
- `npm run build` succeeds, manifest validated at 28 elements
- `npm test` — 737 passed across 37 files
- `npm run lint` clean
- Rebuilt `dist/` and loaded **all 33 examples**: every app boots, every `<pc-script>` instantiates, no console errors

The one exception in that sweep is `scroll-view.html`, which logs `child._createEntity is not a function`. That is the pre-existing template-clone bug already filed separately — I saw it on 2.22.0-beta.12 earlier today, so it is version-independent and not a regression from this change.

Camera access is blocked in my browser pane, so the five webcam examples were checked for boot and script wiring only, not for tracking behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
