### PR TITLE
Stop the shoe configurator buttons sticking white after a hover

### DIFF
--- a/examples/shoe-configurator.html
+++ b/examples/shoe-configurator.html
@@ -95,14 +95,6 @@
 
                 button.classList.add('example-button');
 
-                button.onmouseenter = () => {
-                    button.style.background = 'rgba(255, 255, 255, 1)';
-                };
-
-                button.onmouseleave = () => {
-                    button.style.background = 'rgba(255, 255, 255, 0.9)';
-                };
-
                 button.addEventListener('click', () => {
                     resource.applyMaterialVariant(entityElement.entity, variant);
                 });


### PR DESCRIPTION
## The bug

Hovering a variant button in the shoe configurator turns it white — and it **stays** white once the pointer leaves.

## Cause

The example attached its own hover handlers on top of the shared `.example-button` styling:

```js
button.onmouseenter = () => { button.style.background = 'rgba(255, 255, 255, 1)'; };
button.onmouseleave = () => { button.style.background = 'rgba(255, 255, 255, 0.9)'; };
```

Two things go wrong:

1. **The leave handler restores nothing.** It writes another near-white value rather than clearing the override, so the button keeps a white background for good after its first hover.
2. **It's an inline style, so it outranks the stylesheet.** `.example-button`'s dark glass can never apply again, hover or not.

The reason it reads as flatly "white" rather than merely wrong is that the shared CSS sets the label to `rgba(255, 255, 255, 0.92)` — so it ends up white text on a white background and the labels all but vanish.

This is leftover from when these buttons were light themed. `examples/css/example.css` has since been restyled to dark glass (its comment reads "Dark glass, matching the shell's chrome") with a complete `:hover` rule of its own:

```css
.example-button:hover {
    background-color: rgba(18, 18, 18, 0.82);
    border-color: rgba(255, 255, 255, 0.22);
    color: #fff;
}
```

The handlers were overriding exactly that, and bypassing its `0.2s` transition.

## Fix

Delete both handlers and let the stylesheet do it. No CSS changes needed.

This was the last example still writing hover styles by hand — nothing else in `examples/` touches `onmouseenter`/`onmouseleave`, and the only other `style.background` writes are the car configurator's colour swatches and the video recorder's progress bar, both intentional.

## Verification

Built `dist/`, served the examples and drove **real pointer hover** — synthetic events would not do, since `:hover` only responds to the real input pipeline. Computed styles on the "Midnight" button:

| Stage | `background-color` | border | text | inline style |
| --- | --- | --- | --- | --- |
| before hover | `rgba(18,18,18,0.66)` | 12% white | 92% white | none |
| during hover | `rgba(18,18,18,0.82)` | 22% white | `#fff` | none |
| after hover ends | `rgba(18,18,18,0.66)` | 12% white | 92% white | none |

It returns to exactly its base value. The old handlers were then re-attached in the live page to confirm the diagnosis rather than assume it: during hover the button read `rgb(255,255,255)` background with `rgb(255,255,255)` text, and after hover ended it stayed at `rgba(255,255,255,0.9)` with the inline style still set.

`npm run test:examples` passes (70 tests). The change is inside an HTML file's inline module script, which `npm run lint` does not cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
