### PR TITLE
Add pc-joint for declarative physics joints

### DIFF
--- a/examples/js/example-list.mjs
+++ b/examples/js/example-list.mjs
@@ -54,6 +54,7 @@ export const examples = [
     // Physics
     { name: 'Basic Physics', path: 'basic-physics.html', category: 'Physics' },
     { name: 'Physics Cluster', path: 'physics-cluster.html', category: 'Physics' },
+    { name: 'Physics Joints', path: 'physics-joints.html', category: 'Physics' },
     // Sound
     { name: 'Basic Sound', path: 'basic-sound.html', category: 'Sound' },
     { name: 'Positional Sound', path: 'positional-sound.html', category: 'Sound' },

--- a/examples/physics-joints.html
+++ b/examples/physics-joints.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+        <title>PlayCanvas Web Components - Physics Joints</title>
+        <script type="importmap">
+            {
+                "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
+                    "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
+                }
+            }
+        </script>
+        <script type="module" src="../dist/pwc.mjs"></script>
+        <link rel="stylesheet" href="css/example.css">
+    </head>
+    <body>
+        <pc-app>
+            <!-- Modules -->
+            <pc-module name="Ammo" glue="modules/ammo/ammo.wasm.js" wasm="modules/ammo/ammo.wasm.wasm" fallback="modules/ammo/ammo.js"></pc-module>
+            <!-- Assets -->
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
+            <pc-asset src="assets/skies/octagon-lamps-photo-studio-2k.hdr" id="studio"></pc-asset>
+            <!-- Materials -->
+            <pc-material id="ground-mat" diffuse="lightgray"></pc-material>
+            <pc-material id="anchor-mat" diffuse="slategray"></pc-material>
+            <pc-material id="fixed-mat" diffuse="tomato"></pc-material>
+            <pc-material id="ball-mat" diffuse="gold"></pc-material>
+            <pc-material id="hinge-mat" diffuse="mediumseagreen"></pc-material>
+            <pc-material id="slider-mat" diffuse="cornflowerblue"></pc-material>
+            <pc-material id="sixdof-mat" diffuse="orchid"></pc-material>
+            <!-- Scene -->
+            <pc-scene>
+                <!-- Sky -->
+                <pc-sky asset="studio" type="none" lighting></pc-sky>
+                <!-- Camera -->
+                <pc-entity name="camera" position="0 6 18">
+                    <pc-camera clear-color="#222222"></pc-camera>
+                    <pc-scripts>
+                        <pc-script name="cameraControls" focus-point="0 3 0" zoom-range="2 60"></pc-script>
+                    </pc-scripts>
+                </pc-entity>
+                <!-- Light -->
+                <pc-entity name="light" rotation="45 30 0">
+                    <pc-light cast-shadows></pc-light>
+                </pc-entity>
+                <!-- Each joint entity below is not itself a body: its world transform is the joint
+                     frame, and its local X axis is the hinge axis, slider axis or ball twist axis.
+                     A rotation of "0 -90 0" points that axis along world Z. -->
+                <!-- Fixed joint: a breakable weld cantilevers the box in mid-air beside the anchor
+                     until the dropped ball snaps it. The <pc-joint> element fires a bubbling
+                     'break' DOM event at that moment. -->
+                <pc-entity id="fixed-anchor" name="fixed-anchor" position="-8 4.5 0" scale="0.5 0.5 0.5">
+                    <pc-render type="box" material="anchor-mat"></pc-render>
+                    <pc-collision half-extents="0.25 0.25 0.25"></pc-collision>
+                    <pc-rigidbody></pc-rigidbody>
+                </pc-entity>
+                <pc-entity id="fixed-box" name="fixed-box" position="-8.9 4.5 0">
+                    <pc-render type="box" material="fixed-mat"></pc-render>
+                    <pc-collision></pc-collision>
+                    <pc-rigidbody type="dynamic"></pc-rigidbody>
+                </pc-entity>
+                <pc-entity id="fixed-ball" name="fixed-ball" position="-8.9 9 0" scale="0.8 0.8 0.8">
+                    <pc-render type="sphere" material="fixed-mat"></pc-render>
+                    <pc-collision type="sphere" radius="0.4"></pc-collision>
+                    <pc-rigidbody type="dynamic" mass="6"></pc-rigidbody>
+                </pc-entity>
+                <pc-entity name="fixed-joint" position="-8.33 4.5 0">
+                    <pc-joint type="fixed" entity-a="#fixed-box" entity-b="#fixed-anchor" break-impulse="8"></pc-joint>
+                </pc-entity>
+                <!-- Ball joints: a chain of three links falls from horizontal and comes to hang
+                     within the swing and twist limits of each joint. -->
+                <pc-entity id="ball-anchor" name="ball-anchor" position="-4 5 0" scale="0.4 0.4 0.4">
+                    <pc-render type="box" material="anchor-mat"></pc-render>
+                    <pc-collision half-extents="0.2 0.2 0.2"></pc-collision>
+                    <pc-rigidbody></pc-rigidbody>
+                </pc-entity>
+                <pc-entity id="ball-link-1" name="ball-link-1" position="-4 5 0.75" scale="0.24 0.24 1">
+                    <pc-render type="box" material="ball-mat"></pc-render>
+                    <pc-collision half-extents="0.12 0.12 0.5"></pc-collision>
+                    <pc-rigidbody type="dynamic"></pc-rigidbody>
+                </pc-entity>
+                <pc-entity id="ball-link-2" name="ball-link-2" position="-4 5 1.85" scale="0.24 0.24 1">
+                    <pc-render type="box" material="ball-mat"></pc-render>
+                    <pc-collision half-extents="0.12 0.12 0.5"></pc-collision>
+                    <pc-rigidbody type="dynamic"></pc-rigidbody>
+                </pc-entity>
+                <pc-entity id="ball-link-3" name="ball-link-3" position="-4 5 2.95" scale="0.24 0.24 1">
+                    <pc-render type="box" material="ball-mat"></pc-render>
+                    <pc-collision half-extents="0.12 0.12 0.5"></pc-collision>
+                    <pc-rigidbody type="dynamic"></pc-rigidbody>
+                </pc-entity>
+                <pc-entity name="ball-joint-1" position="-4 5 0.2" rotation="0 -90 0">
+                    <pc-joint type="ball" entity-a="#ball-link-1" entity-b="#ball-anchor" enable-limits swing-limit-y="35" swing-limit-z="35" twist-limit="10"></pc-joint>
+                </pc-entity>
+                <pc-entity name="ball-joint-2" position="-4 5 1.3" rotation="0 -90 0">
+                    <pc-joint type="ball" entity-a="#ball-link-2" entity-b="#ball-link-1" enable-limits swing-limit-y="35" swing-limit-z="35" twist-limit="10"></pc-joint>
+                </pc-entity>
+                <pc-entity name="ball-joint-3" position="-4 5 2.4" rotation="0 -90 0">
+                    <pc-joint type="ball" entity-a="#ball-link-3" entity-b="#ball-link-2" enable-limits swing-limit-y="35" swing-limit-z="35" twist-limit="10"></pc-joint>
+                </pc-entity>
+                <!-- Hinge joint: the arm falls from horizontal and swings about the world Z axis,
+                     bouncing between the -100 and +100 degree stops. -->
+                <pc-entity id="hinge-anchor" name="hinge-anchor" position="0 5 0" scale="0.5 0.5 0.5">
+                    <pc-render type="box" material="anchor-mat"></pc-render>
+                    <pc-collision half-extents="0.25 0.25 0.25"></pc-collision>
+                    <pc-rigidbody></pc-rigidbody>
+                </pc-entity>
+                <pc-entity id="hinge-arm" name="hinge-arm" position="1.35 5 0" scale="2 0.2 0.2">
+                    <pc-render type="box" material="hinge-mat"></pc-render>
+                    <pc-collision half-extents="1 0.1 0.1"></pc-collision>
+                    <pc-rigidbody type="dynamic"></pc-rigidbody>
+                </pc-entity>
+                <pc-entity name="hinge-joint" position="0.3 5 0" rotation="0 -90 0">
+                    <pc-joint type="hinge" entity-a="#hinge-arm" entity-b="#hinge-anchor" enable-limits limits="-100 100"></pc-joint>
+                </pc-entity>
+                <!-- Slider joint: gravity slides the block down the tilted rail until it reaches
+                     the limit of its travel, 1.8 meters from where it started. Set motor-speed and
+                     max-motor-force to drive it back up. -->
+                <pc-entity id="slider-rail" name="slider-rail" position="4 3 0" rotation="0 0 -12" scale="4.5 0.15 0.15">
+                    <pc-render type="box" material="anchor-mat"></pc-render>
+                    <pc-collision half-extents="2.25 0.075 0.075"></pc-collision>
+                    <pc-rigidbody></pc-rigidbody>
+                </pc-entity>
+                <pc-entity id="slider-block" name="slider-block" position="2.34 3.35 0" rotation="0 0 -12" scale="0.6 0.6 0.6">
+                    <pc-render type="box" material="slider-mat"></pc-render>
+                    <pc-collision half-extents="0.3 0.3 0.3"></pc-collision>
+                    <pc-rigidbody type="dynamic"></pc-rigidbody>
+                </pc-entity>
+                <pc-entity name="slider-joint" position="4 3 0" rotation="0 0 -12">
+                    <pc-joint type="slider" entity-a="#slider-block" entity-b="#slider-rail" enable-limits limits="-1.8 1.8"></pc-joint>
+                </pc-entity>
+                <!-- 6dof joint: every axis is locked except vertical translation, which is limited
+                     and sprung - the box sags under gravity, bobs on the spring and settles. -->
+                <pc-entity id="sixdof-anchor" name="sixdof-anchor" position="8 5.5 0" scale="0.5 0.5 0.5">
+                    <pc-render type="box" material="anchor-mat"></pc-render>
+                    <pc-collision half-extents="0.25 0.25 0.25"></pc-collision>
+                    <pc-rigidbody></pc-rigidbody>
+                </pc-entity>
+                <pc-entity id="sixdof-box" name="sixdof-box" position="8 4.6 0" scale="0.8 0.8 0.8">
+                    <pc-render type="box" material="sixdof-mat"></pc-render>
+                    <pc-collision half-extents="0.4 0.4 0.4"></pc-collision>
+                    <pc-rigidbody type="dynamic"></pc-rigidbody>
+                </pc-entity>
+                <pc-entity name="sixdof-joint" position="8 5.2 0">
+                    <pc-joint type="6dof" entity-a="#sixdof-box" entity-b="#sixdof-anchor" linear-motion-y="limited" linear-limits-y="-2.2 2.2" linear-stiffness="0 12 0" linear-damping="1 0.3 1"></pc-joint>
+                </pc-entity>
+                <!-- Ground -->
+                <pc-entity name="ground" position="0 -0.25 0" scale="30 0.5 10">
+                    <pc-render type="box" material="ground-mat"></pc-render>
+                    <pc-collision half-extents="15 0.25 5"></pc-collision>
+                    <pc-rigidbody></pc-rigidbody>
+                </pc-entity>
+            </pc-scene>
+        </pc-app>
+        <script type="module" src="js/example.mjs"></script>
+    </body>
+</html>

--- a/examples/physics-joints.html
+++ b/examples/physics-joints.html
@@ -43,7 +43,7 @@
                 </pc-entity>
                 <!-- Light -->
                 <pc-entity name="light" rotation="45 30 0">
-                    <pc-light cast-shadows></pc-light>
+                    <pc-light cast-shadows shadow-distance="60" shadow-resolution="2048"></pc-light>
                 </pc-entity>
                 <!-- Each joint entity below is not itself a body: its world transform is the joint
                      frame, and its local X axis is the hinge axis, slider axis or ball twist axis.

--- a/src/components/joint-component.ts
+++ b/src/components/joint-component.ts
@@ -1,0 +1,984 @@
+import type { JointComponent } from 'playcanvas';
+import { Vec2, Vec3 } from 'playcanvas';
+
+import { getEntity, parseBool, parseEnum, parseNumber, parseVec2, parseVec3 } from '../parse';
+
+import { ComponentElement } from './component';
+
+type JointType = 'fixed' | 'ball' | 'hinge' | 'slider' | '6dof';
+
+type MotionMode = 'locked' | 'limited' | 'free';
+
+/**
+ * The JointComponentElement interface provides properties and methods for manipulating
+ * {@link https://developer.playcanvas.com/user-manual/web-components/tags/pc-joint/ | `<pc-joint>`} elements.
+ * The JointComponentElement interface also inherits the properties and methods of the
+ * {@link HTMLElement} interface.
+ *
+ * The entity holding the joint is not itself constrained. Its world transform defines the joint
+ * frame — the anchor point and axes the constraint operates about — with the local X axis as the
+ * primary axis: a hinge rotates about it, a slider translates along it and a ball joint twists
+ * about it. The constrained bodies are referenced by `entity-a` and `entity-b`, both of which need
+ * a rigid body component; leaving `entity-b` empty constrains `entity-a` to a fixed point in world
+ * space. The underlying engine component is in alpha, so its API may change.
+ *
+ * @fires {CustomEvent} break - Fired when the impulse on the joint exceeds `break-impulse` and the
+ * constraint breaks. A broken joint no longer constrains its bodies; calling `refreshFrames()` on
+ * the underlying component re-attaches it. Bubbles and is composed.
+ *
+ * @category Components
+ */
+class JointComponentElement extends ComponentElement {
+    /**
+     * The spring damping of the joint per angular axis.
+     */
+    private _angularDamping = new Vec3(1, 1, 1);
+
+    /**
+     * The rest angle of the joint's angular springs.
+     */
+    private _angularEquilibrium = new Vec3();
+
+    /**
+     * The rotation limits of the joint about its X axis.
+     */
+    private _angularLimitsX = new Vec2();
+
+    /**
+     * The rotation limits of the joint about its Y axis.
+     */
+    private _angularLimitsY = new Vec2();
+
+    /**
+     * The rotation limits of the joint about its Z axis.
+     */
+    private _angularLimitsZ = new Vec2();
+
+    /**
+     * The rotational degree of freedom of the joint about its X axis.
+     */
+    private _angularMotionX: MotionMode = 'locked';
+
+    /**
+     * The rotational degree of freedom of the joint about its Y axis.
+     */
+    private _angularMotionY: MotionMode = 'locked';
+
+    /**
+     * The rotational degree of freedom of the joint about its Z axis.
+     */
+    private _angularMotionZ: MotionMode = 'locked';
+
+    /**
+     * The spring stiffness of the joint per angular axis.
+     */
+    private _angularStiffness = new Vec3();
+
+    /**
+     * The impulse above which the joint breaks.
+     */
+    private _breakImpulse = Infinity;
+
+    /**
+     * Whether collision is enabled between the constrained bodies.
+     */
+    private _enableCollision = false;
+
+    /**
+     * Whether the joint's limits are enforced.
+     */
+    private _enableLimits = false;
+
+    /**
+     * The reference to the entity providing the first constrained body.
+     */
+    private _entityA = '';
+
+    /**
+     * The reference to the entity providing the second constrained body.
+     */
+    private _entityB = '';
+
+    /**
+     * The rotation or travel limits of the joint.
+     */
+    private _limits = new Vec2(-45, 45);
+
+    /**
+     * The spring damping of the joint per linear axis.
+     */
+    private _linearDamping = new Vec3(1, 1, 1);
+
+    /**
+     * The rest point of the joint's linear springs.
+     */
+    private _linearEquilibrium = new Vec3();
+
+    /**
+     * The translation limits of the joint along its X axis.
+     */
+    private _linearLimitsX = new Vec2();
+
+    /**
+     * The translation limits of the joint along its Y axis.
+     */
+    private _linearLimitsY = new Vec2();
+
+    /**
+     * The translation limits of the joint along its Z axis.
+     */
+    private _linearLimitsZ = new Vec2();
+
+    /**
+     * The linear degree of freedom of the joint along its X axis.
+     */
+    private _linearMotionX: MotionMode = 'locked';
+
+    /**
+     * The linear degree of freedom of the joint along its Y axis.
+     */
+    private _linearMotionY: MotionMode = 'locked';
+
+    /**
+     * The linear degree of freedom of the joint along its Z axis.
+     */
+    private _linearMotionZ: MotionMode = 'locked';
+
+    /**
+     * The spring stiffness of the joint per linear axis.
+     */
+    private _linearStiffness = new Vec3();
+
+    /**
+     * The maximum torque or force of the joint's motor.
+     */
+    private _maxMotorForce = 0;
+
+    /**
+     * The target speed of the joint's motor.
+     */
+    private _motorSpeed = 0;
+
+    /**
+     * The maximum swing of the joint around the joint frame's Y axis.
+     */
+    private _swingLimitY = 45;
+
+    /**
+     * The maximum swing of the joint around the joint frame's Z axis.
+     */
+    private _swingLimitZ = 45;
+
+    /**
+     * The maximum twist of the joint about its primary axis.
+     */
+    private _twistLimit = 20;
+
+    /**
+     * The type of the joint.
+     */
+    private _type: JointType = 'fixed';
+
+    /** @ignore */
+    constructor() {
+        super('joint');
+    }
+
+    protected getInitialComponentData() {
+        return {
+            angularDamping: this._angularDamping,
+            angularEquilibrium: this._angularEquilibrium,
+            angularLimitsX: this._angularLimitsX,
+            angularLimitsY: this._angularLimitsY,
+            angularLimitsZ: this._angularLimitsZ,
+            angularMotionX: this._angularMotionX,
+            angularMotionY: this._angularMotionY,
+            angularMotionZ: this._angularMotionZ,
+            angularStiffness: this._angularStiffness,
+            breakImpulse: this._breakImpulse,
+            enableCollision: this._enableCollision,
+            enableLimits: this._enableLimits,
+            entityA: getEntity(this._entityA),
+            entityB: getEntity(this._entityB),
+            limits: this._limits,
+            linearDamping: this._linearDamping,
+            linearEquilibrium: this._linearEquilibrium,
+            linearLimitsX: this._linearLimitsX,
+            linearLimitsY: this._linearLimitsY,
+            linearLimitsZ: this._linearLimitsZ,
+            linearMotionX: this._linearMotionX,
+            linearMotionY: this._linearMotionY,
+            linearMotionZ: this._linearMotionZ,
+            linearStiffness: this._linearStiffness,
+            maxMotorForce: this._maxMotorForce,
+            motorSpeed: this._motorSpeed,
+            swingLimitY: this._swingLimitY,
+            swingLimitZ: this._swingLimitZ,
+            twistLimit: this._twistLimit,
+            type: this._type
+        };
+    }
+
+    private _onBreak() {
+        this.dispatchEvent(new CustomEvent('break', { bubbles: true, composed: true }));
+    }
+
+    protected initComponent() {
+        const component = this.component;
+        if (!component) {
+            return;
+        }
+
+        // A host readiness cycle can re-run this against the same surviving component instance,
+        // so the off/on pair keeps the subscription single either way. Component removal destroys
+        // the instance and its listeners with it, so there is no disconnect-side teardown.
+        component.off('break', this._onBreak, this);
+        component.on('break', this._onBreak, this);
+    }
+
+    /**
+     * Gets the underlying PlayCanvas joint component.
+     * @returns The joint component.
+     */
+    get component(): JointComponent {
+        return super.component as JointComponent;
+    }
+
+    /**
+     * Sets the spring damping of a 6dof joint per angular axis, used on axes with a non-zero
+     * angular-stiffness.
+     * @param value - The angular spring damping.
+     */
+    set angularDamping(value: Vec3) {
+        this._angularDamping = value;
+        if (this.component) {
+            this.component.angularDamping = value;
+        }
+    }
+
+    /**
+     * Gets the spring damping of the joint per angular axis.
+     * @returns The angular spring damping.
+     */
+    get angularDamping() {
+        return this._angularDamping;
+    }
+
+    /**
+     * Sets the rest angle of a 6dof joint's angular springs in degrees per axis, used on axes with
+     * a non-zero angular-stiffness.
+     * @param value - The angular spring rest angles.
+     */
+    set angularEquilibrium(value: Vec3) {
+        this._angularEquilibrium = value;
+        if (this.component) {
+            this.component.angularEquilibrium = value;
+        }
+    }
+
+    /**
+     * Gets the rest angle of the joint's angular springs.
+     * @returns The angular spring rest angles.
+     */
+    get angularEquilibrium() {
+        return this._angularEquilibrium;
+    }
+
+    /**
+     * Sets the lower and upper rotation limit of a 6dof joint about its X axis in degrees, used
+     * when angular-motion-x is limited.
+     * @param value - The X axis rotation limits.
+     */
+    set angularLimitsX(value: Vec2) {
+        this._angularLimitsX = value;
+        if (this.component) {
+            this.component.angularLimitsX = value;
+        }
+    }
+
+    /**
+     * Gets the rotation limits of the joint about its X axis.
+     * @returns The X axis rotation limits.
+     */
+    get angularLimitsX() {
+        return this._angularLimitsX;
+    }
+
+    /**
+     * Sets the lower and upper rotation limit of a 6dof joint about its Y axis in degrees, used
+     * when angular-motion-y is limited.
+     * @param value - The Y axis rotation limits.
+     */
+    set angularLimitsY(value: Vec2) {
+        this._angularLimitsY = value;
+        if (this.component) {
+            this.component.angularLimitsY = value;
+        }
+    }
+
+    /**
+     * Gets the rotation limits of the joint about its Y axis.
+     * @returns The Y axis rotation limits.
+     */
+    get angularLimitsY() {
+        return this._angularLimitsY;
+    }
+
+    /**
+     * Sets the lower and upper rotation limit of a 6dof joint about its Z axis in degrees, used
+     * when angular-motion-z is limited.
+     * @param value - The Z axis rotation limits.
+     */
+    set angularLimitsZ(value: Vec2) {
+        this._angularLimitsZ = value;
+        if (this.component) {
+            this.component.angularLimitsZ = value;
+        }
+    }
+
+    /**
+     * Gets the rotation limits of the joint about its Z axis.
+     * @returns The Z axis rotation limits.
+     */
+    get angularLimitsZ() {
+        return this._angularLimitsZ;
+    }
+
+    /**
+     * Sets how a 6dof joint constrains rotation about its X axis. Can be `locked`, `limited` or
+     * `free`. Defaults to `locked`.
+     * @param value - The X axis rotational degree of freedom.
+     */
+    set angularMotionX(value: MotionMode) {
+        this._angularMotionX = value;
+        if (this.component) {
+            this.component.angularMotionX = value;
+        }
+    }
+
+    /**
+     * Gets how the joint constrains rotation about its X axis.
+     * @returns The X axis rotational degree of freedom.
+     */
+    get angularMotionX() {
+        return this._angularMotionX;
+    }
+
+    /**
+     * Sets how a 6dof joint constrains rotation about its Y axis. Can be `locked`, `limited` or
+     * `free`. Defaults to `locked`.
+     * @param value - The Y axis rotational degree of freedom.
+     */
+    set angularMotionY(value: MotionMode) {
+        this._angularMotionY = value;
+        if (this.component) {
+            this.component.angularMotionY = value;
+        }
+    }
+
+    /**
+     * Gets how the joint constrains rotation about its Y axis.
+     * @returns The Y axis rotational degree of freedom.
+     */
+    get angularMotionY() {
+        return this._angularMotionY;
+    }
+
+    /**
+     * Sets how a 6dof joint constrains rotation about its Z axis. Can be `locked`, `limited` or
+     * `free`. Defaults to `locked`.
+     * @param value - The Z axis rotational degree of freedom.
+     */
+    set angularMotionZ(value: MotionMode) {
+        this._angularMotionZ = value;
+        if (this.component) {
+            this.component.angularMotionZ = value;
+        }
+    }
+
+    /**
+     * Gets how the joint constrains rotation about its Z axis.
+     * @returns The Z axis rotational degree of freedom.
+     */
+    get angularMotionZ() {
+        return this._angularMotionZ;
+    }
+
+    /**
+     * Sets the spring stiffness of a 6dof joint per angular axis, where 0 disables the spring on
+     * that axis.
+     * @param value - The angular spring stiffness.
+     */
+    set angularStiffness(value: Vec3) {
+        this._angularStiffness = value;
+        if (this.component) {
+            this.component.angularStiffness = value;
+        }
+    }
+
+    /**
+     * Gets the spring stiffness of the joint per angular axis.
+     * @returns The angular spring stiffness.
+     */
+    get angularStiffness() {
+        return this._angularStiffness;
+    }
+
+    /**
+     * Sets the impulse in newton seconds above which the joint breaks. Defaults to `Infinity`,
+     * which makes the joint unbreakable.
+     * @param value - The break impulse.
+     */
+    set breakImpulse(value: number) {
+        this._breakImpulse = value;
+        if (this.component) {
+            this.component.breakImpulse = value;
+        }
+    }
+
+    /**
+     * Gets the impulse above which the joint breaks.
+     * @returns The break impulse.
+     */
+    get breakImpulse() {
+        return this._breakImpulse;
+    }
+
+    /**
+     * Sets whether collision is enabled between the two constrained bodies.
+     * @param value - Whether collision is enabled.
+     */
+    set enableCollision(value: boolean) {
+        this._enableCollision = value;
+        if (this.component) {
+            this.component.enableCollision = value;
+        }
+    }
+
+    /**
+     * Gets whether collision is enabled between the two constrained bodies.
+     * @returns Whether collision is enabled.
+     */
+    get enableCollision() {
+        return this._enableCollision;
+    }
+
+    /**
+     * Sets whether the limits of a hinge, slider or ball joint are enforced.
+     * @param value - Whether the limits are enforced.
+     */
+    set enableLimits(value: boolean) {
+        this._enableLimits = value;
+        if (this.component) {
+            this.component.enableLimits = value;
+        }
+    }
+
+    /**
+     * Gets whether the limits of the joint are enforced.
+     * @returns Whether the limits are enforced.
+     */
+    get enableLimits() {
+        return this._enableLimits;
+    }
+
+    /**
+     * Sets the reference (CSS selector, element id or entity name) to the `<pc-entity>` providing
+     * the first constrained body. The reference resolves when it is set, so an entity created
+     * later is picked up by setting the attribute again.
+     * @param value - The first body's entity reference.
+     */
+    set entityA(value: string) {
+        this._entityA = value;
+        if (this.component) {
+            this.component.entityA = getEntity(value);
+        }
+    }
+
+    /**
+     * Gets the reference to the `<pc-entity>` providing the first constrained body.
+     * @returns The first body's entity reference.
+     */
+    get entityA() {
+        return this._entityA;
+    }
+
+    /**
+     * Sets the reference (CSS selector, element id or entity name) to the `<pc-entity>` providing
+     * the second constrained body, or empty to constrain the first body to a fixed point in world
+     * space. The reference resolves when it is set, so an entity created later is picked up by
+     * setting the attribute again.
+     * @param value - The second body's entity reference.
+     */
+    set entityB(value: string) {
+        this._entityB = value;
+        if (this.component) {
+            this.component.entityB = getEntity(value);
+        }
+    }
+
+    /**
+     * Gets the reference to the `<pc-entity>` providing the second constrained body.
+     * @returns The second body's entity reference.
+     */
+    get entityB() {
+        return this._entityB;
+    }
+
+    /**
+     * Sets the lower and upper limit of a hinge joint's rotation in degrees, or a slider joint's
+     * travel in meters, applied when enable-limits is set.
+     * @param value - The rotation or travel limits.
+     */
+    set limits(value: Vec2) {
+        this._limits = value;
+        if (this.component) {
+            this.component.limits = value;
+        }
+    }
+
+    /**
+     * Gets the rotation or travel limits of the joint.
+     * @returns The rotation or travel limits.
+     */
+    get limits() {
+        return this._limits;
+    }
+
+    /**
+     * Sets the spring damping of a 6dof joint per linear axis, used on axes with a non-zero
+     * linear-stiffness.
+     * @param value - The linear spring damping.
+     */
+    set linearDamping(value: Vec3) {
+        this._linearDamping = value;
+        if (this.component) {
+            this.component.linearDamping = value;
+        }
+    }
+
+    /**
+     * Gets the spring damping of the joint per linear axis.
+     * @returns The linear spring damping.
+     */
+    get linearDamping() {
+        return this._linearDamping;
+    }
+
+    /**
+     * Sets the rest point of a 6dof joint's linear springs in meters per axis, used on axes with a
+     * non-zero linear-stiffness.
+     * @param value - The linear spring rest points.
+     */
+    set linearEquilibrium(value: Vec3) {
+        this._linearEquilibrium = value;
+        if (this.component) {
+            this.component.linearEquilibrium = value;
+        }
+    }
+
+    /**
+     * Gets the rest point of the joint's linear springs.
+     * @returns The linear spring rest points.
+     */
+    get linearEquilibrium() {
+        return this._linearEquilibrium;
+    }
+
+    /**
+     * Sets the lower and upper translation limit of a 6dof joint along its X axis in meters, used
+     * when linear-motion-x is limited.
+     * @param value - The X axis translation limits.
+     */
+    set linearLimitsX(value: Vec2) {
+        this._linearLimitsX = value;
+        if (this.component) {
+            this.component.linearLimitsX = value;
+        }
+    }
+
+    /**
+     * Gets the translation limits of the joint along its X axis.
+     * @returns The X axis translation limits.
+     */
+    get linearLimitsX() {
+        return this._linearLimitsX;
+    }
+
+    /**
+     * Sets the lower and upper translation limit of a 6dof joint along its Y axis in meters, used
+     * when linear-motion-y is limited.
+     * @param value - The Y axis translation limits.
+     */
+    set linearLimitsY(value: Vec2) {
+        this._linearLimitsY = value;
+        if (this.component) {
+            this.component.linearLimitsY = value;
+        }
+    }
+
+    /**
+     * Gets the translation limits of the joint along its Y axis.
+     * @returns The Y axis translation limits.
+     */
+    get linearLimitsY() {
+        return this._linearLimitsY;
+    }
+
+    /**
+     * Sets the lower and upper translation limit of a 6dof joint along its Z axis in meters, used
+     * when linear-motion-z is limited.
+     * @param value - The Z axis translation limits.
+     */
+    set linearLimitsZ(value: Vec2) {
+        this._linearLimitsZ = value;
+        if (this.component) {
+            this.component.linearLimitsZ = value;
+        }
+    }
+
+    /**
+     * Gets the translation limits of the joint along its Z axis.
+     * @returns The Z axis translation limits.
+     */
+    get linearLimitsZ() {
+        return this._linearLimitsZ;
+    }
+
+    /**
+     * Sets how a 6dof joint constrains translation along its X axis. Can be `locked`, `limited` or
+     * `free`. Defaults to `locked`.
+     * @param value - The X axis linear degree of freedom.
+     */
+    set linearMotionX(value: MotionMode) {
+        this._linearMotionX = value;
+        if (this.component) {
+            this.component.linearMotionX = value;
+        }
+    }
+
+    /**
+     * Gets how the joint constrains translation along its X axis.
+     * @returns The X axis linear degree of freedom.
+     */
+    get linearMotionX() {
+        return this._linearMotionX;
+    }
+
+    /**
+     * Sets how a 6dof joint constrains translation along its Y axis. Can be `locked`, `limited` or
+     * `free`. Defaults to `locked`.
+     * @param value - The Y axis linear degree of freedom.
+     */
+    set linearMotionY(value: MotionMode) {
+        this._linearMotionY = value;
+        if (this.component) {
+            this.component.linearMotionY = value;
+        }
+    }
+
+    /**
+     * Gets how the joint constrains translation along its Y axis.
+     * @returns The Y axis linear degree of freedom.
+     */
+    get linearMotionY() {
+        return this._linearMotionY;
+    }
+
+    /**
+     * Sets how a 6dof joint constrains translation along its Z axis. Can be `locked`, `limited` or
+     * `free`. Defaults to `locked`.
+     * @param value - The Z axis linear degree of freedom.
+     */
+    set linearMotionZ(value: MotionMode) {
+        this._linearMotionZ = value;
+        if (this.component) {
+            this.component.linearMotionZ = value;
+        }
+    }
+
+    /**
+     * Gets how the joint constrains translation along its Z axis.
+     * @returns The Z axis linear degree of freedom.
+     */
+    get linearMotionZ() {
+        return this._linearMotionZ;
+    }
+
+    /**
+     * Sets the spring stiffness of a 6dof joint per linear axis, where 0 disables the spring on
+     * that axis.
+     * @param value - The linear spring stiffness.
+     */
+    set linearStiffness(value: Vec3) {
+        this._linearStiffness = value;
+        if (this.component) {
+            this.component.linearStiffness = value;
+        }
+    }
+
+    /**
+     * Gets the spring stiffness of the joint per linear axis.
+     * @returns The linear spring stiffness.
+     */
+    get linearStiffness() {
+        return this._linearStiffness;
+    }
+
+    /**
+     * Sets the maximum torque in newton meters of a hinge joint's motor, or the maximum force in
+     * newtons of a slider joint's motor, where 0 disables the motor.
+     * @param value - The maximum motor torque or force.
+     */
+    set maxMotorForce(value: number) {
+        this._maxMotorForce = value;
+        if (this.component) {
+            this.component.maxMotorForce = value;
+        }
+    }
+
+    /**
+     * Gets the maximum torque or force of the joint's motor.
+     * @returns The maximum motor torque or force.
+     */
+    get maxMotorForce() {
+        return this._maxMotorForce;
+    }
+
+    /**
+     * Sets the target speed of a hinge joint's motor in degrees per second, or a slider joint's
+     * motor in meters per second, active while max-motor-force is greater than 0.
+     * @param value - The motor's target speed.
+     */
+    set motorSpeed(value: number) {
+        this._motorSpeed = value;
+        if (this.component) {
+            this.component.motorSpeed = value;
+        }
+    }
+
+    /**
+     * Gets the target speed of the joint's motor.
+     * @returns The motor's target speed.
+     */
+    get motorSpeed() {
+        return this._motorSpeed;
+    }
+
+    /**
+     * Sets the maximum swing of a ball joint around the joint frame's Y axis in degrees, applied
+     * when enable-limits is set.
+     * @param value - The Y axis swing limit.
+     */
+    set swingLimitY(value: number) {
+        this._swingLimitY = value;
+        if (this.component) {
+            this.component.swingLimitY = value;
+        }
+    }
+
+    /**
+     * Gets the maximum swing of the joint around the joint frame's Y axis.
+     * @returns The Y axis swing limit.
+     */
+    get swingLimitY() {
+        return this._swingLimitY;
+    }
+
+    /**
+     * Sets the maximum swing of a ball joint around the joint frame's Z axis in degrees, applied
+     * when enable-limits is set.
+     * @param value - The Z axis swing limit.
+     */
+    set swingLimitZ(value: number) {
+        this._swingLimitZ = value;
+        if (this.component) {
+            this.component.swingLimitZ = value;
+        }
+    }
+
+    /**
+     * Gets the maximum swing of the joint around the joint frame's Z axis.
+     * @returns The Z axis swing limit.
+     */
+    get swingLimitZ() {
+        return this._swingLimitZ;
+    }
+
+    /**
+     * Sets the maximum twist of a ball joint about its primary axis in degrees, applied when
+     * enable-limits is set.
+     * @param value - The twist limit.
+     */
+    set twistLimit(value: number) {
+        this._twistLimit = value;
+        if (this.component) {
+            this.component.twistLimit = value;
+        }
+    }
+
+    /**
+     * Gets the maximum twist of the joint about its primary axis.
+     * @returns The twist limit.
+     */
+    get twistLimit() {
+        return this._twistLimit;
+    }
+
+    /**
+     * Sets the type of the joint. Can be `fixed`, `ball`, `hinge`, `slider` or `6dof`. Defaults to
+     * `fixed`.
+     * @param value - The joint type.
+     */
+    set type(value: JointType) {
+        this._type = value;
+        if (this.component) {
+            this.component.type = value;
+        }
+    }
+
+    /**
+     * Gets the type of the joint.
+     * @returns The joint type.
+     */
+    get type() {
+        return this._type;
+    }
+
+    static get observedAttributes() {
+        return [
+            ...super.observedAttributes,
+            'angular-damping',
+            'angular-equilibrium',
+            'angular-limits-x',
+            'angular-limits-y',
+            'angular-limits-z',
+            'angular-motion-x',
+            'angular-motion-y',
+            'angular-motion-z',
+            'angular-stiffness',
+            'break-impulse',
+            'enable-collision',
+            'enable-limits',
+            'entity-a',
+            'entity-b',
+            'limits',
+            'linear-damping',
+            'linear-equilibrium',
+            'linear-limits-x',
+            'linear-limits-y',
+            'linear-limits-z',
+            'linear-motion-x',
+            'linear-motion-y',
+            'linear-motion-z',
+            'linear-stiffness',
+            'max-motor-force',
+            'motor-speed',
+            'swing-limit-y',
+            'swing-limit-z',
+            'twist-limit',
+            'type'
+        ];
+    }
+
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
+        super.attributeChangedCallback(name, _oldValue, newValue);
+
+        switch (name) {
+            case 'angular-damping':
+                this.angularDamping = parseVec3(newValue, Vec3.ONE, name);
+                break;
+            case 'angular-equilibrium':
+                this.angularEquilibrium = parseVec3(newValue, Vec3.ZERO, name);
+                break;
+            case 'angular-limits-x':
+                this.angularLimitsX = parseVec2(newValue, Vec2.ZERO, name);
+                break;
+            case 'angular-limits-y':
+                this.angularLimitsY = parseVec2(newValue, Vec2.ZERO, name);
+                break;
+            case 'angular-limits-z':
+                this.angularLimitsZ = parseVec2(newValue, Vec2.ZERO, name);
+                break;
+            case 'angular-motion-x':
+                this.angularMotionX = parseEnum(newValue, ['locked', 'limited', 'free'], 'locked', name);
+                break;
+            case 'angular-motion-y':
+                this.angularMotionY = parseEnum(newValue, ['locked', 'limited', 'free'], 'locked', name);
+                break;
+            case 'angular-motion-z':
+                this.angularMotionZ = parseEnum(newValue, ['locked', 'limited', 'free'], 'locked', name);
+                break;
+            case 'angular-stiffness':
+                this.angularStiffness = parseVec3(newValue, Vec3.ZERO, name);
+                break;
+            case 'break-impulse':
+                this.breakImpulse = parseNumber(newValue, Infinity, name);
+                break;
+            case 'enable-collision':
+                this.enableCollision = parseBool(newValue, false);
+                break;
+            case 'enable-limits':
+                this.enableLimits = parseBool(newValue, false);
+                break;
+            case 'entity-a':
+                this.entityA = newValue ?? '';
+                break;
+            case 'entity-b':
+                this.entityB = newValue ?? '';
+                break;
+            case 'limits':
+                this.limits = parseVec2(newValue, new Vec2(-45, 45), name);
+                break;
+            case 'linear-damping':
+                this.linearDamping = parseVec3(newValue, Vec3.ONE, name);
+                break;
+            case 'linear-equilibrium':
+                this.linearEquilibrium = parseVec3(newValue, Vec3.ZERO, name);
+                break;
+            case 'linear-limits-x':
+                this.linearLimitsX = parseVec2(newValue, Vec2.ZERO, name);
+                break;
+            case 'linear-limits-y':
+                this.linearLimitsY = parseVec2(newValue, Vec2.ZERO, name);
+                break;
+            case 'linear-limits-z':
+                this.linearLimitsZ = parseVec2(newValue, Vec2.ZERO, name);
+                break;
+            case 'linear-motion-x':
+                this.linearMotionX = parseEnum(newValue, ['locked', 'limited', 'free'], 'locked', name);
+                break;
+            case 'linear-motion-y':
+                this.linearMotionY = parseEnum(newValue, ['locked', 'limited', 'free'], 'locked', name);
+                break;
+            case 'linear-motion-z':
+                this.linearMotionZ = parseEnum(newValue, ['locked', 'limited', 'free'], 'locked', name);
+                break;
+            case 'linear-stiffness':
+                this.linearStiffness = parseVec3(newValue, Vec3.ZERO, name);
+                break;
+            case 'max-motor-force':
+                this.maxMotorForce = parseNumber(newValue, 0, name);
+                break;
+            case 'motor-speed':
+                this.motorSpeed = parseNumber(newValue, 0, name);
+                break;
+            case 'swing-limit-y':
+                this.swingLimitY = parseNumber(newValue, 45, name);
+                break;
+            case 'swing-limit-z':
+                this.swingLimitZ = parseNumber(newValue, 45, name);
+                break;
+            case 'twist-limit':
+                this.twistLimit = parseNumber(newValue, 20, name);
+                break;
+            case 'type':
+                this.type = parseEnum(newValue, ['fixed', 'ball', 'hinge', 'slider', '6dof'], 'fixed', name);
+                break;
+        }
+    }
+}
+
+customElements.define('pc-joint', JointComponentElement);
+
+export { JointComponentElement };

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { CameraComponentElement } from './components/camera-component';
 import { CollisionComponentElement } from './components/collision-component';
 import { ComponentElement } from './components/component';
 import { ElementComponentElement } from './components/element-component';
+import { JointComponentElement } from './components/joint-component';
 import { LayoutChildComponentElement } from './components/layoutchild-component';
 import { LayoutGroupComponentElement } from './components/layoutgroup-component';
 import { LightComponentElement } from './components/light-component';
@@ -50,6 +51,7 @@ import type {
 
 declare global {
     interface HTMLElementEventMap {
+        break: CustomEvent;
         scriptattributeschange: ScriptAttributesChangeEvent;
         scriptenablechange: ScriptEnableChangeEvent;
         scriptnamechange: ScriptNameChangeEvent;
@@ -64,6 +66,7 @@ declare global {
         'pc-element': ElementComponentElement;
         'pc-entity': EntityElement;
         'pc-gsplat': GSplatComponentElement;
+        'pc-joint': JointComponentElement;
         'pc-layoutchild': LayoutChildComponentElement;
         'pc-layoutgroup': LayoutGroupComponentElement;
         'pc-light': LightComponentElement;
@@ -98,6 +101,7 @@ export {
     CollisionComponentElement,
     ComponentElement,
     ElementComponentElement,
+    JointComponentElement,
     LayoutChildComponentElement,
     LayoutGroupComponentElement,
     ParticleSystemComponentElement,

--- a/test/elements/attribute-removal.test.ts
+++ b/test/elements/attribute-removal.test.ts
@@ -30,6 +30,8 @@ describe('attribute removal', () => {
         ['pc-element', 'texture-asset', 'textureAsset', ''],
         ['pc-element', 'text', 'text', ''],
         ['pc-gsplat', 'asset', 'asset', ''],
+        ['pc-joint', 'entity-a', 'entityA', ''],
+        ['pc-joint', 'entity-b', 'entityB', ''],
         ['pc-particles', 'asset', 'asset', ''],
         ['pc-render', 'material', 'material', ''],
         ['pc-scrollbar', 'handle', 'handle', ''],
@@ -64,6 +66,6 @@ describe('attribute removal', () => {
     it('covers every unparsed string attribute in the library', () => {
         // If a new `this.x = newValue ?? ''` branch is added without a case above, this fails.
         // Counted rather than enumerated, so it stays a one-line update rather than a second table.
-        expect(cases).toHaveLength(21);
+        expect(cases).toHaveLength(23);
     });
 });

--- a/test/integration/components/joint-component.test.ts
+++ b/test/integration/components/joint-component.test.ts
@@ -1,0 +1,258 @@
+import type { JointComponent } from 'playcanvas';
+import { Vec2, Vec3 } from 'playcanvas';
+import { describe, expect, it } from 'vitest';
+
+import type { JointComponentElement } from '../../../src/components/joint-component';
+import { bootApp } from '../../helpers/app';
+import { useGuard } from '../../helpers/guard';
+
+/**
+ * Two rigid bodies for the joint to reference. Without Ammo the bodies never simulate and the
+ * joint never creates a constraint, but every property still round-trips through the engine
+ * component - which is exactly the surface these tests pin.
+ */
+const BODIES = `
+    <pc-entity id="anchor-id" name="anchor"><pc-rigidbody></pc-rigidbody></pc-entity>
+    <pc-entity id="bob-id" name="bob">
+        <pc-collision></pc-collision>
+        <pc-rigidbody type="dynamic"></pc-rigidbody>
+    </pc-entity>
+`;
+
+const scene = (jointAttributes = '') =>
+    `${BODIES}<pc-entity name="frame"><pc-joint ${jointAttributes}></pc-joint></pc-entity>`;
+
+/** Reads an engine component property named by a table row. */
+const engineValue = (component: JointComponent, property: string) =>
+    (component as unknown as Record<string, unknown>)[property];
+
+/**
+ * One row per attribute (the entity references have their own suite): the attribute, the engine
+ * property behind it, a non-default value, what the engine must report for it, and the engine
+ * default that removal must restore. Ordered by `observedAttributes` - the source of truth.
+ */
+const cases: [attribute: string, property: string, value: string, expected: unknown, restored: unknown][] = [
+    ['angular-damping', 'angularDamping', '0.1 0.2 0.3', new Vec3(0.1, 0.2, 0.3), new Vec3(1, 1, 1)],
+    ['angular-equilibrium', 'angularEquilibrium', '1 2 3', new Vec3(1, 2, 3), new Vec3()],
+    ['angular-limits-x', 'angularLimitsX', '-10 10', new Vec2(-10, 10), new Vec2()],
+    ['angular-limits-y', 'angularLimitsY', '-20 20', new Vec2(-20, 20), new Vec2()],
+    ['angular-limits-z', 'angularLimitsZ', '-30 30', new Vec2(-30, 30), new Vec2()],
+    ['angular-motion-x', 'angularMotionX', 'free', 'free', 'locked'],
+    ['angular-motion-y', 'angularMotionY', 'limited', 'limited', 'locked'],
+    ['angular-motion-z', 'angularMotionZ', 'free', 'free', 'locked'],
+    ['angular-stiffness', 'angularStiffness', '4 5 6', new Vec3(4, 5, 6), new Vec3()],
+    ['break-impulse', 'breakImpulse', '8', 8, Infinity],
+    ['enable-collision', 'enableCollision', '', true, false],
+    ['enable-limits', 'enableLimits', '', true, false],
+    ['limits', 'limits', '0 110', new Vec2(0, 110), new Vec2(-45, 45)],
+    ['linear-damping', 'linearDamping', '0.4 0.5 0.6', new Vec3(0.4, 0.5, 0.6), new Vec3(1, 1, 1)],
+    ['linear-equilibrium', 'linearEquilibrium', '7 8 9', new Vec3(7, 8, 9), new Vec3()],
+    ['linear-limits-x', 'linearLimitsX', '-1 1', new Vec2(-1, 1), new Vec2()],
+    ['linear-limits-y', 'linearLimitsY', '-2 2', new Vec2(-2, 2), new Vec2()],
+    ['linear-limits-z', 'linearLimitsZ', '-3 3', new Vec2(-3, 3), new Vec2()],
+    ['linear-motion-x', 'linearMotionX', 'limited', 'limited', 'locked'],
+    ['linear-motion-y', 'linearMotionY', 'free', 'free', 'locked'],
+    ['linear-motion-z', 'linearMotionZ', 'limited', 'limited', 'locked'],
+    ['linear-stiffness', 'linearStiffness', '10 20 30', new Vec3(10, 20, 30), new Vec3()],
+    ['max-motor-force', 'maxMotorForce', '50', 50, 0],
+    ['motor-speed', 'motorSpeed', '90', 90, 0],
+    ['swing-limit-y', 'swingLimitY', '35', 35, 45],
+    ['swing-limit-z', 'swingLimitZ', '25', 25, 45],
+    ['twist-limit', 'twistLimit', '10', 10, 20],
+    ['type', 'type', 'hinge', 'hinge', 'fixed']
+];
+
+describe('<pc-joint>', () => {
+    const { warnings } = useGuard();
+
+    describe('#component', () => {
+        it('creates the joint component with the engine defaults', async () => {
+            const { get } = await bootApp(scene());
+            const component = get<JointComponentElement>('pc-joint').component;
+
+            expect(component).toBeDefined();
+
+            // No Ammo in this tier, so the constraint is never created - properties are all
+            // that exists, which is what makes the joint testable headlessly
+            expect(component.constraint).toBeNull();
+            expect(component.isBroken).toBe(false);
+            expect(component.entityA).toBeNull();
+            expect(component.entityB).toBeNull();
+
+            for (const [attribute, property, , , restored] of cases) {
+                expect.soft(engineValue(component, property), attribute).toEqual(restored);
+            }
+        });
+    });
+
+    describe('attributes', () => {
+        it('applies every declarative attribute through the initial component data', async () => {
+            const markup = cases
+                .map(([attribute, , value]) => (value === '' ? attribute : `${attribute}="${value}"`))
+                .join(' ');
+            const { get } = await bootApp(scene(markup));
+            const component = get<JointComponentElement>('pc-joint').component;
+
+            for (const [attribute, property, , expected] of cases) {
+                expect.soft(engineValue(component, property), attribute).toEqual(expected);
+            }
+        });
+
+        it('writes attribute changes through to the component', async () => {
+            const { get } = await bootApp(scene());
+            const joint = get<JointComponentElement>('pc-joint');
+
+            for (const [attribute, property, value, expected] of cases) {
+                joint.setAttribute(attribute, value);
+                expect.soft(engineValue(joint.component, property), attribute).toEqual(expected);
+            }
+        });
+
+        it('restores the engine default when an attribute is removed', async () => {
+            const { get } = await bootApp(scene());
+            const joint = get<JointComponentElement>('pc-joint');
+
+            for (const [attribute, property, value, , restored] of cases) {
+                joint.setAttribute(attribute, value);
+                joint.removeAttribute(attribute);
+                expect.soft(engineValue(joint.component, property), attribute).toEqual(restored);
+            }
+        });
+
+        it('falls back to the default and warns once per invalid value', async () => {
+            const { get } = await bootApp(
+                scene(
+                    'type="banana" break-impulse="soft" limits="1" linear-stiffness="x y z" linear-motion-y="wobbly"'
+                )
+            );
+            const component = get<JointComponentElement>('pc-joint').component;
+
+            warnings.expect(
+                "Invalid value 'banana' for attribute 'type'. Valid values: fixed, ball, hinge, slider, 6dof. Using 'fixed'."
+            );
+            warnings.expect(
+                "Invalid value 'soft' for attribute 'break-impulse'. Expected a finite number. Using 'Infinity'."
+            );
+            warnings.expect(
+                "Invalid value '1' for attribute 'limits'. Expected 2 space-separated numbers. Using '[-45, 45]'."
+            );
+            warnings.expect(
+                "Invalid value 'x y z' for attribute 'linear-stiffness'. Expected 3 space-separated numbers. Using '[0, 0, 0]'."
+            );
+            warnings.expect(
+                "Invalid value 'wobbly' for attribute 'linear-motion-y'. Valid values: locked, limited, free. Using 'locked'."
+            );
+
+            expect(component.type).toBe('fixed');
+            expect(component.breakImpulse).toBe(Infinity);
+            expect(component.limits).toEqual(new Vec2(-45, 45));
+            expect(component.linearStiffness).toEqual(new Vec3());
+            expect(component.linearMotionY).toBe('locked');
+        });
+
+        it('accepts 6dof as a runtime type change and restores fixed on removal', async () => {
+            const { get } = await bootApp(scene('type="hinge"'));
+            const joint = get<JointComponentElement>('pc-joint');
+
+            expect(joint.component.type).toBe('hinge');
+
+            joint.setAttribute('type', '6dof');
+            expect(joint.component.type).toBe('6dof');
+
+            joint.removeAttribute('type');
+            expect(joint.component.type).toBe('fixed');
+        });
+    });
+
+    describe('[entity-a] and [entity-b]', () => {
+        it('resolves references by entity name and by CSS selector to live entities', async () => {
+            const { app, get } = await bootApp(scene('entity-a="bob" entity-b="#anchor-id"'));
+            const component = get<JointComponentElement>('pc-joint').component;
+
+            expect(component.entityA).toBe(app.root.findByName('bob'));
+            expect(component.entityB).toBe(app.root.findByName('anchor'));
+        });
+
+        it('resolves references to entities declared later in the document', async () => {
+            const { app, get } = await bootApp(
+                `<pc-entity name="frame"><pc-joint entity-a="bob" entity-b="anchor"></pc-joint></pc-entity>${BODIES}`
+            );
+            const component = get<JointComponentElement>('pc-joint').component;
+
+            expect(component.entityA).toBe(app.root.findByName('bob'));
+            expect(component.entityB).toBe(app.root.findByName('anchor'));
+        });
+
+        it('retargets a body when the attribute changes at runtime', async () => {
+            const { app, get } = await bootApp(
+                `${scene('entity-a="bob" entity-b="anchor"')}
+                <pc-entity id="post-id" name="post"><pc-rigidbody></pc-rigidbody></pc-entity>`
+            );
+            const joint = get<JointComponentElement>('pc-joint');
+
+            joint.setAttribute('entity-b', 'post-id');
+
+            expect(joint.component.entityB).toBe(app.root.findByName('post'));
+        });
+
+        it('pins the first body to a world point when entity-b is removed', async () => {
+            const { get } = await bootApp(scene('entity-a="bob" entity-b="anchor"'));
+            const joint = get<JointComponentElement>('pc-joint');
+
+            joint.removeAttribute('entity-b');
+
+            expect(joint.entityB).toBe('');
+            expect(joint.component.entityB).toBeNull();
+        });
+
+        it('detaches the first body when entity-a is removed', async () => {
+            const { get } = await bootApp(scene('entity-a="bob" entity-b="anchor"'));
+            const joint = get<JointComponentElement>('pc-joint');
+
+            joint.removeAttribute('entity-a');
+
+            expect(joint.entityA).toBe('');
+            expect(joint.component.entityA).toBeNull();
+        });
+
+        it('leaves an unresolvable reference null without warning', async () => {
+            const { get } = await bootApp(scene('entity-a="#nope"'));
+            const joint = get<JointComponentElement>('pc-joint');
+
+            // No warning claimed here: getEntity resolves references quietly, and the guard
+            // fails the test if anything warns
+            expect(joint.entityA).toBe('#nope');
+            expect(joint.component.entityA).toBeNull();
+        });
+    });
+
+    describe('break event', () => {
+        it('forwards the engine break event as a bubbling DOM event', async () => {
+            const { container, get } = await bootApp(scene('entity-a="bob" entity-b="anchor"'));
+            const joint = get<JointComponentElement>('pc-joint');
+
+            const events: Event[] = [];
+            container.addEventListener('break', event => events.push(event));
+
+            joint.component.fire('break');
+
+            expect(events).toHaveLength(1);
+            expect(events[0]).toBeInstanceOf(CustomEvent);
+            expect(events[0].bubbles).toBe(true);
+            expect(events[0].target).toBe(joint);
+        });
+
+        it('dispatches once per engine event', async () => {
+            const { get } = await bootApp(scene());
+            const joint = get<JointComponentElement>('pc-joint');
+
+            const events: Event[] = [];
+            joint.addEventListener('break', event => events.push(event));
+
+            joint.component.fire('break');
+            joint.component.fire('break');
+
+            expect(events).toHaveLength(2);
+        });
+    });
+});

--- a/typedoc.json
+++ b/typedoc.json
@@ -65,6 +65,7 @@
             "ElementComponent": "https://api.playcanvas.com/engine/classes/ElementComponent.html",
             "Entity": "https://api.playcanvas.com/engine/classes/Entity.html",
             "GSplatComponent": "https://api.playcanvas.com/engine/classes/GSplatComponent.html",
+            "JointComponent": "https://api.playcanvas.com/engine/classes/JointComponent.html",
             "LightComponent": "https://api.playcanvas.com/engine/classes/LightComponent.html",
             "ParticleSystemComponent": "https://api.playcanvas.com/engine/classes/ParticleSystemComponent.html",
             "RenderComponent": "https://api.playcanvas.com/engine/classes/RenderComponent.html",

--- a/utils/cem/tags.mjs
+++ b/utils/cem/tags.mjs
@@ -11,17 +11,17 @@
 /** Every tag the library registers. Kept explicit so adding or removing an element is deliberate. */
 export const TAGS = [
     'pc-app', 'pc-asset', 'pc-button', 'pc-camera', 'pc-collision', 'pc-element', 'pc-entity',
-    'pc-gsplat', 'pc-layoutchild', 'pc-layoutgroup', 'pc-light', 'pc-listener', 'pc-material',
-    'pc-model', 'pc-module', 'pc-node', 'pc-particles', 'pc-render', 'pc-rigidbody', 'pc-scene',
-    'pc-screen', 'pc-script', 'pc-scripts', 'pc-scrollbar', 'pc-scrollview', 'pc-sky', 'pc-sound',
-    'pc-sounds'
+    'pc-gsplat', 'pc-joint', 'pc-layoutchild', 'pc-layoutgroup', 'pc-light', 'pc-listener',
+    'pc-material', 'pc-model', 'pc-module', 'pc-node', 'pc-particles', 'pc-render', 'pc-rigidbody',
+    'pc-scene', 'pc-screen', 'pc-script', 'pc-scripts', 'pc-scrollbar', 'pc-scrollview', 'pc-sky',
+    'pc-sound', 'pc-sounds'
 ];
 
 /** The tags whose elements extend `ComponentElement`, and so inherit its `enabled` attribute. */
 export const COMPONENT_TAGS = [
-    'pc-button', 'pc-camera', 'pc-collision', 'pc-element', 'pc-gsplat', 'pc-layoutchild',
-    'pc-layoutgroup', 'pc-light', 'pc-listener', 'pc-particles', 'pc-render', 'pc-rigidbody',
-    'pc-screen', 'pc-scripts', 'pc-scrollbar', 'pc-scrollview', 'pc-sounds'
+    'pc-button', 'pc-camera', 'pc-collision', 'pc-element', 'pc-gsplat', 'pc-joint',
+    'pc-layoutchild', 'pc-layoutgroup', 'pc-light', 'pc-listener', 'pc-particles', 'pc-render',
+    'pc-rigidbody', 'pc-screen', 'pc-scripts', 'pc-scrollbar', 'pc-scrollview', 'pc-sounds'
 ];
 
 /** `pc-material` extends `HTMLElement`, so it never becomes ready. */

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -186,9 +186,17 @@ if (manifest) {
         check(Boolean(attribute('pc-camera', name)), `pc-camera is missing the '${name}' attribute`);
     }
 
-    // The only default in the library that is not a value a user would ever type: Infinity means
-    // "no cap", which renderDefault has a dedicated branch for.
+    // The two defaults in the library that are not values a user would ever type: Infinity means
+    // "no cap" / "unbreakable", which renderDefault has a dedicated branch for.
     expectAttribute('pc-app', 'max-pixel-ratio', { type: 'number', default: 'Infinity', fieldName: 'maxPixelRatio' });
+    expectAttribute('pc-joint', 'break-impulse', { type: 'number', default: 'Infinity', fieldName: 'breakImpulse' });
+
+    // pc-joint's remaining shapes: enums from inline arrays, a Vec2 default with negative
+    // components, and string entity references
+    expectEnum('pc-joint', 'type', 5, 'fixed');
+    expectEnum('pc-joint', 'linear-motion-y', 3, 'locked');
+    expectAttribute('pc-joint', 'limits', { type: 'string', default: '-45 45', fieldName: 'limits' });
+    expectAttribute('pc-joint', 'entity-a', { type: 'string', fieldName: 'entityA' });
 
     // Attributes read with getAttribute, so declared with @attribute
     for (const name of ['name', 'glue', 'wasm', 'fallback']) {
@@ -236,6 +244,8 @@ if (manifest) {
     for (const name of ['scriptattributeschange', 'scriptenablechange', 'scriptnamechange']) {
         check(events('pc-script').includes(name), `pc-script is missing the '${name}' event`);
     }
+
+    check(events('pc-joint').includes('break'), "pc-joint is missing the 'break' event");
 
     const pointerEvents = ['pointerenter', 'pointerleave', 'pointermove', 'pointerdown', 'pointerup'];
     for (const name of pointerEvents) {


### PR DESCRIPTION
Adds a `<pc-joint>` element wrapping the engine's `JointComponent` (public `@alpha` since v2.20.0, so the full `^2.20.1` peer range has it), completing the physics trio alongside `pc-rigidbody` and `pc-collision`.

### What's in the element

- The full 30-property surface as attributes — `type`, `entity-a`/`entity-b`, `enable-collision`, `break-impulse`, the hinge/slider limits and motor set, the ball swing/twist limits, and the complete 6dof motion/limits/spring set — with defaults taken verbatim from the engine. Follows the `pc-rigidbody` template exactly (backing fields, write-through accessors, uniform `attributeChangedCallback` switch).
- `entity-a`/`entity-b` resolve via the shared `getEntity` helper. Unlike the scrollview reference setters, these write `null` through on removal deliberately: clearing `entity-b` means "pin the first body to a world point" and clearing `entity-a` detaches the joint, so removal has to reach the engine.
- The engine's `break` event is re-dispatched as a bubbling, composed DOM `CustomEvent` (declared in `HTMLElementEventMap`). The subscription is wired in `initComponent` with an `off`/`on` pair because a host readiness cycle can re-run it against the same surviving component instance.
- `isBroken`, `constraint` and `refreshFrames()` are reachable via `.component` rather than mirrored onto the element.

### Registration and tooling

`src/index.ts` (import, event map, tag map, export), `utils/cem/tags.mjs` (both golden lists), `typedoc.json` (JointComponent symbol link), and new `validate.mjs` spot checks pinning the pipeline shapes this element adds: an `Infinity` default on `break-impulse` (the comment beside `max-pixel-ratio` is reworded now that it is no longer unique), a negative-component Vec2 default (`-45 45`), both inline-array enums, a string entity reference, and the `break` event. No `EXTRA_MEMBERS` entry needed, and no `src/app.ts` change — `JointComponentSystem` was already registered.

### Tests

- New `test/integration/components/joint-component.test.ts` (first file in the mirrored `components/` subdir): engine defaults, declarative and runtime round-trips for every attribute, removal semantics, exact parse-warning claims, entity-reference resolution (name and selector, forward references, retargeting, pin-to-world on removal, quiet unresolved refs), and break-event forwarding. Constraint creation defers until bodies are simulation-ready, so everything round-trips headlessly without Ammo. Tests avoid `entityA === entityB` states — the engine's debug-build warning there is build-resolution-sensitive.
- `test/elements/attribute-removal.test.ts` gains the two entity-reference rows (count 21 → 23).

### Example

`examples/physics-joints.html` ("Physics Joints", under Physics): five declarative stations over a shared ground — a breakable weld demonstrating `break-impulse` and the `break` event (fixed), a hanging chain with swing/twist limits (ball), a swinging arm with rotation limits (hinge), a block sliding a tilted rail into its travel stop (slider), and a vertical spring suspension (6dof).

### Verification

`npm run build` (CEM validated, 29 elements), `npm run lint`, `npm run type-check`, `npm test` (763 passing) all green. Also verified live with Ammo: all seven constraints create, and after 10 simulated seconds every station behaves as designed — the weld snaps and fires exactly one bubbling `break` CustomEvent, the chain hangs in its cones, the arm rests at its -100° stop, the slider block sits at its +1.8 m stop (measured (4.1, 2.98) vs predicted (4.1, 2.98)), and the 6dof box oscillates about its spring sag point.

### Reviewer notes

- `npm run fmt` fails on ~119 pre-existing files repo-wide (not a CI gate), so no formatting changes are included; the new files follow ESLint house style.
- `npm run docs` emits two new warnings for the unexported `JointType`/`MotionMode` aliases — the same pre-existing pattern as the asset.ts and material.ts aliases.
- Related engine issues filed while building this: playcanvas/engine#9168 (`Entity#joint` accessor missing from the declarations — the element sidesteps it via the `addComponent` return) and playcanvas/engine#9169 (joint limits/equilibrium zero-point and sign conventions are undocumented — the example's 6dof station is designed sign-proof as a result).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
