### PR TITLE
Add pc-anim and pc-anim-clip for declarative animation

### DIFF
--- a/examples/glb-animation.html
+++ b/examples/glb-animation.html
@@ -58,7 +58,9 @@
                 </pc-entity>
                 <!-- T-Rex -->
                 <pc-entity name="t-rex" scale="3 3 3">
-                    <pc-model asset="t-rex"></pc-model>
+                    <pc-model asset="t-rex">
+                        <pc-anim></pc-anim>
+                    </pc-model>
                 </pc-entity>
                 <!-- Shadow Catcher -->
                 <pc-entity name="shadow-catcher">

--- a/src/components/anim-clip.ts
+++ b/src/components/anim-clip.ts
@@ -1,0 +1,395 @@
+import type { Asset, EventHandle } from 'playcanvas';
+import { AnimTrack } from 'playcanvas';
+
+import { AssetElement, useAsset } from '../asset';
+import { AsyncElement } from '../async-element';
+import { ModelElement } from '../model';
+import { parseBool, parseNumber } from '../parse';
+
+import type { ContainerWithAnimations } from './anim-component';
+import { AnimComponentElement } from './anim-component';
+
+/**
+ * The AnimClipElement interface provides properties and methods for manipulating
+ * {@link https://developer.playcanvas.com/user-manual/web-components/tags/pc-anim-clip/ | `<pc-anim-clip>`}
+ * elements. The AnimClipElement interface also inherits the properties and methods of the
+ * {@link HTMLElement} interface.
+ *
+ * A clip declares one named animation on its parent `<pc-anim>`. `name` is both the clip's name
+ * and the track looked up in the clip's source: an explicit `asset` (a `container`, an
+ * `animation` `.glb`, or an `animclip` JSON), or, without one, the container of the `<pc-model>`
+ * enclosing the parent `<pc-anim>`. A source holding a single track supplies it whatever it is
+ * named; in a multi-track source the track named `name` is chosen, falling back to the first
+ * with a warning. The element becomes ready once its resolved track is assigned.
+ *
+ * @category Components
+ */
+class AnimClipElement extends AsyncElement {
+    /**
+     * The `<pc-anim>` this clip was adopted by, captured when the parent adopts the clip and on
+     * connection.
+     *
+     * `disconnectedCallback` cannot rediscover it: by the time the element is disconnected its
+     * `parentElement` is already `null`, so a lookup would both fail to find the component and
+     * emit a misleading "must be a direct child" warning for what is an ordinary removal.
+     */
+    private _animElement: AnimComponentElement | null = null;
+
+    private _asset = '';
+
+    /**
+     * Incremented on every connect and disconnect, and captured by connectedCallback on entry —
+     * a resume from an await abandons itself if the value has moved on, so a stale callback can
+     * neither act on a torn-down tree nor register its clip alongside a re-inserted element's
+     * own callback.
+     */
+    private _connectionGeneration = 0;
+
+    private _errorHandle: EventHandle | null = null;
+
+    /**
+     * Incremented on every track resolution and on disconnect, and captured by a resolution when
+     * it starts. A resolution that resumes from an await or an asset callback abandons itself if
+     * the value has moved on, so a superseded resolution cannot hand a stale track to the parent.
+     */
+    private _loadGeneration = 0;
+
+    /**
+     * The pending asset subscriptions of the current resolution, if it is waiting for its asset.
+     * Held so that whatever supersedes the resolution can detach the handlers from the asset,
+     * rather than leave them registered until the asset settles (or forever, if it never does).
+     */
+    private _loadHandle: EventHandle | null = null;
+
+    private _loop = true;
+
+    private _name = '';
+
+    private _speed = 1;
+
+    /**
+     * The source complaint already made — the asset id it was made for, or `''` for the
+     * no-asset-no-model case — so re-resolutions (host cycles, model reloads) do not repeat it.
+     */
+    private _warnedSource: string | null = null;
+
+    /**
+     * Whether the owning `<pc-anim>` already rejected this clip's name — its sweeps re-run on
+     * host cycles and must not repeat the complaint.
+     */
+    private _warnedInvalid = false;
+
+    /**
+     * The clip's resolved track. `null` until resolution completes, during which the owning
+     * `<pc-anim>` assigns the engine's placeholder track in its stead.
+     *
+     * @internal
+     */
+    _track: AnimTrack | null = null;
+
+    async connectedCallback() {
+        const generation = ++this._connectionGeneration;
+
+        const animElement = this.animElement;
+        await animElement?.ready();
+
+        // The element may have been removed (perhaps re-inserted, which runs a callback of its
+        // own), or its parent torn down, while we were waiting. A <pc-app> disconnects before
+        // its children, so by the time we resume the component can already be gone - see the
+        // matching guard in disconnectedCallback below.
+        const component = animElement ? animElement.component : null;
+        if (generation !== this._connectionGeneration || !animElement || !component) {
+            return;
+        }
+
+        this._animElement = animElement;
+        animElement._registerClip(this);
+    }
+
+    disconnectedCallback() {
+        // Invalidate any connectedCallback or track resolution still suspended on an await
+        this._connectionGeneration++;
+        this._loadGeneration++;
+        this._detachLoadHandlers();
+
+        // Uses the cached parent rather than a fresh lookup, since parentElement is already null
+        // by now. The component itself is null if the whole <pc-app> is being torn down —
+        // parents disconnect first and have already removed the component.
+        this._animElement?._unregisterClip(this);
+        this._animElement = null;
+        this._track = null;
+        this._resetReady();
+    }
+
+    protected get animElement(): AnimComponentElement | null {
+        const animElement = this.parentElement as AnimComponentElement;
+
+        if (!(animElement instanceof AnimComponentElement)) {
+            const label = this._name ? ` '${this._name}'` : '';
+            console.warn(`pc-anim-clip${label} must be a direct child of a pc-anim element`);
+            return null;
+        }
+
+        return animElement;
+    }
+
+    private _detachLoadHandlers() {
+        this._loadHandle?.off();
+        this._loadHandle = null;
+        this._errorHandle?.off();
+        this._errorHandle = null;
+    }
+
+    /**
+     * Reports a name-validation failure from the owning `<pc-anim>`, once per name value.
+     *
+     * @param message - The complaint.
+     * @internal
+     */
+    _markInvalid(message: string) {
+        if (this._warnedInvalid) {
+            return;
+        }
+        this._warnedInvalid = true;
+        console.warn(message);
+    }
+
+    /**
+     * Resolves the clip's track from its source and hands it to the owning `<pc-anim>`. Called
+     * by the parent whenever the clip is (re)adopted, and again when the source changes; a newer
+     * resolution supersedes one still in flight. The element becomes ready once the resolved
+     * track is assigned.
+     *
+     * @param animElement - The owning `<pc-anim>`.
+     * @internal
+     */
+    async _resolveTrack(animElement: AnimComponentElement) {
+        this._animElement = animElement;
+
+        const generation = ++this._loadGeneration;
+        this._detachLoadHandlers();
+
+        if (this._asset) {
+            const asset = useAsset(this._asset);
+            if (!asset) {
+                this._warnSource(`pc-anim-clip '${this._name}' could not find asset '${this._asset}' - clip not assigned`);
+                return;
+            }
+            if (asset.loaded) {
+                this._extractTrack(asset, `asset '${this._asset}'`);
+                return;
+            }
+            // Whichever of load/error fires first detaches the other. The generation is
+            // re-checked even though a superseded handler is detached: the detach relies on how
+            // the engine's event emitter treats removal, while the check holds on its own.
+            this._loadHandle = asset.once('load', () => {
+                this._detachLoadHandlers();
+                if (generation !== this._loadGeneration) {
+                    return;
+                }
+                this._extractTrack(asset, `asset '${this._asset}'`);
+            });
+            this._errorHandle = asset.once('error', () => {
+                this._detachLoadHandlers();
+                if (generation !== this._loadGeneration) {
+                    return;
+                }
+                this._warnSource(`pc-anim-clip '${this._name}' - asset '${this._asset}' failed to load - clip not assigned`);
+            });
+            return;
+        }
+
+        const model = animElement.parentElement;
+        if (!(model instanceof ModelElement)) {
+            this._warnSource(`pc-anim-clip '${this._name}' has no asset and no enclosing pc-model - clip not assigned`);
+            return;
+        }
+
+        await model.ready();
+        if (generation !== this._loadGeneration) {
+            return;
+        }
+
+        const asset = AssetElement.get(model.asset);
+        if (!asset?.resource) {
+            // The model's load failed; it already reported the error
+            return;
+        }
+        this._extractTrack(asset, `model '${model.asset}'`);
+    }
+
+    /**
+     * Complains about the clip's source, once per source value — resolutions re-run on host
+     * cycles and model reloads, and must not repeat the complaint.
+     */
+    private _warnSource(message: string) {
+        if (this._warnedSource === this._asset) {
+            return;
+        }
+        this._warnedSource = this._asset;
+        console.warn(message);
+    }
+
+    /**
+     * Picks the clip's track out of a loaded source asset: the track named `name`, or a lone
+     * track whatever it is named, or the first of several with a warning.
+     *
+     * @param asset - The loaded source asset.
+     * @param source - How warnings name the source.
+     */
+    private _extractTrack(asset: Asset, source: string) {
+        const label = `pc-anim-clip '${this._name}'`;
+
+        // Widened: the engine registers an 'animclip' handler but omits the type from the
+        // Asset.type union
+        const type: string = asset.type;
+
+        let candidates: unknown[];
+        switch (type) {
+            case 'container':
+                candidates = (asset.resource as ContainerWithAnimations).animations.map(
+                    (animationAsset) => animationAsset.resource
+                );
+                break;
+            case 'animation':
+                candidates = asset.resources;
+                break;
+            case 'animclip':
+                candidates = [asset.resource];
+                break;
+            default:
+                this._warnSource(`${label} - ${source} has type '${asset.type}', expected 'container', 'animation' or 'animclip' - clip not assigned`);
+                return;
+        }
+
+        // A JSON 'animation' asset parses to the engine's legacy Animation class, which the anim
+        // system rejects - only real AnimTracks qualify
+        const tracks = candidates.filter((candidate): candidate is AnimTrack => candidate instanceof AnimTrack);
+        if (tracks.length === 0) {
+            this._warnSource(`${label} - ${source} contains no usable animation track - clip not assigned`);
+            return;
+        }
+
+        let track = tracks.find((candidate) => candidate.name === this._name);
+        if (!track) {
+            track = tracks[0];
+            if (tracks.length > 1) {
+                console.warn(
+                    `${label} - no track named '${this._name}' in ${source} - using '${track.name}' (available: ${tracks.map((candidate) => candidate.name).join(', ')})`
+                );
+            }
+        }
+
+        this._track = track;
+        if (this._animElement?._onClipResolved(this)) {
+            this._onReady();
+        }
+    }
+
+    /**
+     * Sets the id of the `pc-asset` supplying the clip's track: a `container`, an `animation`
+     * `.glb`, or an `animclip` JSON. When empty, the track comes from the container of the
+     * `<pc-model>` enclosing the parent `<pc-anim>`.
+     * @param value - The asset id.
+     */
+    set asset(value: string) {
+        this._asset = value;
+        this._warnedSource = null;
+        if (this._animElement) {
+            this._resetReady();
+            this._track = null;
+            this._resolveTrack(this._animElement);
+        }
+    }
+
+    /**
+     * Gets the id of the `pc-asset` supplying the clip's track.
+     * @returns The asset id.
+     */
+    get asset() {
+        return this._asset;
+    }
+
+    /**
+     * Sets whether the clip loops. A non-looping clip holds its last pose when it ends — the
+     * engine reports no completion. Defaults to `true`.
+     * @param value - Whether the clip loops.
+     */
+    set loop(value: boolean) {
+        this._loop = value;
+        this._animElement?._onClipParamsChanged(this);
+    }
+
+    /**
+     * Gets whether the clip loops.
+     * @returns Whether the clip loops.
+     */
+    get loop() {
+        return this._loop;
+    }
+
+    /**
+     * Sets the name of the clip: the name it is played by, and the track looked up in the
+     * clip's source. Names must be unique within a `<pc-anim>` and must not contain `.`.
+     * @param value - The clip name.
+     */
+    set name(value: string) {
+        this._name = value;
+        this._warnedInvalid = false;
+        if (this._animElement) {
+            this._resetReady();
+            this._animElement._refreshClips();
+        }
+    }
+
+    /**
+     * Gets the name of the clip.
+     * @returns The clip name.
+     */
+    get name() {
+        return this._name;
+    }
+
+    /**
+     * Sets the playback speed of the clip, where negative values play it backwards. Applies
+     * immediately, preserving the playhead. Defaults to 1.
+     * @param value - The playback speed.
+     */
+    set speed(value: number) {
+        this._speed = value;
+        this._animElement?._onClipParamsChanged(this);
+    }
+
+    /**
+     * Gets the playback speed of the clip.
+     * @returns The playback speed.
+     */
+    get speed() {
+        return this._speed;
+    }
+
+    static get observedAttributes() {
+        return ['asset', 'loop', 'name', 'speed'];
+    }
+
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
+        switch (name) {
+            case 'asset':
+                this.asset = newValue ?? '';
+                break;
+            case 'loop':
+                this.loop = parseBool(newValue, true);
+                break;
+            case 'name':
+                this.name = newValue ?? '';
+                break;
+            case 'speed':
+                this.speed = parseNumber(newValue, 1, name);
+                break;
+        }
+    }
+}
+
+customElements.define('pc-anim-clip', AnimClipElement);
+
+export { AnimClipElement };

--- a/src/components/anim-component.ts
+++ b/src/components/anim-component.ts
@@ -17,12 +17,15 @@ type ContainerWithAnimations = ContainerResource & { animations: Asset[] };
 
 /**
  * A playback snapshot captured before a clip-set rebuild and restored afterwards, so a rebuild
- * whose active clip survives it is seamless.
+ * whose active clip survives it is seamless. Both playing flags are captured: the component's
+ * gates the system tick, the layer controller's gates the layer, and they legitimately diverge —
+ * {@link AnimComponentElement.pause} clears only the component's.
  */
 type PlaybackState = {
     state: string;
     time: number;
     playing: boolean;
+    layerPlaying: boolean;
 };
 
 /**
@@ -293,8 +296,9 @@ class AnimComponentElement extends ComponentElement {
     /**
      * Applies the active-clip selection: the declared `clip` when it names an assigned state,
      * else a captured pre-rebuild state when it survived, else the engine's default (the first
-     * assigned clip). A restore also reinstates the playhead and both playing flags — the
-     * system tick reads the component's, the layer's controller reads its own.
+     * assigned clip). A restore also reinstates the playhead and both playing flags exactly as
+     * captured — the reassignment that preceded it set both to the `activate` outcome, which is
+     * not necessarily the state the rebuild interrupted.
      */
     private _applySelection(restore?: PlaybackState) {
         const component = this.component;
@@ -322,9 +326,7 @@ class AnimComponentElement extends ComponentElement {
             if (target === restore.state) {
                 layer.activeStateCurrentTime = restore.time;
             }
-            if (restore.playing) {
-                layer.playing = true;
-            }
+            layer.playing = restore.layerPlaying;
             component.playing = restore.playing;
         }
     }
@@ -355,7 +357,8 @@ class AnimComponentElement extends ComponentElement {
         const restore = layer ? {
             state: layer.activeState,
             time: layer.activeStateCurrentTime,
-            playing: component.playing
+            playing: component.playing,
+            layerPlaying: layer.playing
         } : undefined;
         component.removeStateGraph();
         this._applyClips(restore);
@@ -463,6 +466,8 @@ class AnimComponentElement extends ComponentElement {
         if (!component || !layer) {
             return;
         }
+        // layer.play sets the layer controller's playing flag; the component's is the system
+        // gate. Setting both is what makes this a resume regardless of how playback stopped.
         if (name !== undefined) {
             if (!layer.states.includes(name)) {
                 return;
@@ -481,6 +486,9 @@ class AnimComponentElement extends ComponentElement {
         if (!this.component) {
             return;
         }
+        // Only the component flag - the single gate the system tick reads - is cleared. The
+        // layer controller's flag is left as-is so a pause is exactly reversible, whether
+        // resumed through play() (which sets both) or through the component API directly.
         this.component.playing = false;
     }
 

--- a/src/components/anim-component.ts
+++ b/src/components/anim-component.ts
@@ -1,0 +1,641 @@
+import type { AnimComponent, Asset, ContainerResource } from 'playcanvas';
+import { ANIM_CONTROL_STATES, AnimTrack } from 'playcanvas';
+
+import { AssetElement } from '../asset';
+import type { EntityBaseElement } from '../entity-base';
+import { ModelElement } from '../model';
+import { parseBool, parseNumber } from '../parse';
+
+import type { AnimClipElement } from './anim-clip';
+import { ComponentElement } from './component';
+
+/**
+ * A container resource with the `animations` sub-assets the engine documents but does not type:
+ * one `Asset` of type `animation` per glTF animation, each holding an `AnimTrack` resource.
+ */
+type ContainerWithAnimations = ContainerResource & { animations: Asset[] };
+
+/**
+ * A playback snapshot captured before a clip-set rebuild and restored afterwards, so a rebuild
+ * whose active clip survives it is seamless.
+ */
+type PlaybackState = {
+    state: string;
+    time: number;
+    playing: boolean;
+};
+
+/**
+ * The AnimComponentElement interface provides properties and methods for manipulating
+ * {@link https://developer.playcanvas.com/user-manual/web-components/tags/pc-anim/ | `<pc-anim>`} elements.
+ * The AnimComponentElement interface also inherits the properties and methods of the
+ * {@link HTMLElement} interface.
+ *
+ * The element drives animation clips over the host entity's hierarchy. Clips come from
+ * `<pc-anim-clip>` children — or, when the element is a direct child of a `<pc-model>` and
+ * declares no clips, every animation of that model's container asset is assigned, named by track
+ * name, in container order. The first clip plays automatically (opt out with `activate="false"`);
+ * switch clips declaratively through the `clip` attribute, or imperatively through {@link play}
+ * and {@link transition}. Tracks bind to scene nodes by name, so any hierarchy whose node names
+ * match a clip's curves can be animated — a model's skeleton is simply the common case.
+ *
+ * The engine reports no clip completion: a non-looping clip holds its last pose silently. Poll
+ * the underlying {@link AnimComponent} (via {@link component}) for playback state beyond what
+ * this element exposes.
+ *
+ * @category Components
+ */
+class AnimComponentElement extends ComponentElement {
+    /**
+     * Whether playback starts automatically once a clip is assigned.
+     */
+    private _activate = true;
+
+    /**
+     * The clip elements whose states are currently assigned, by clip name. The single writer of
+     * a state: a later clip child re-using an adopted name is rejected as a duplicate.
+     */
+    private _assignedClips = new Map<string, AnimClipElement>();
+
+    /**
+     * Whether the current clip set was auto-assigned from the enclosing model rather than
+     * declared by clip children.
+     */
+    private _autoAssigned = false;
+
+    /**
+     * The name of the active clip.
+     */
+    private _clip = '';
+
+    /**
+     * The element the model-readiness listener is attached to, held so disconnection can detach
+     * it after `closestEntity` no longer resolves.
+     */
+    private _modelListenerTarget: EntityBaseElement | null = null;
+
+    /**
+     * Incremented whenever the clip source changes, and captured by an auto-assign pass on
+     * entry — a pass resuming from an await abandons itself if the value has moved on, so a
+     * superseded pass cannot assign clips alongside declared children or a newer pass.
+     */
+    private _sourceGeneration = 0;
+
+    /**
+     * The playback speed multiplier applied across all clips.
+     */
+    private _speed = 1;
+
+    /**
+     * The cross-fade duration of declarative clip switches, in seconds.
+     */
+    private _transitionTime = 0;
+
+    /**
+     * The unknown clip name already warned about, so a repeated selection of the same missing
+     * name complains once.
+     */
+    private _warnedClip: string | null = null;
+
+    /**
+     * Rebinds when a model under the host announces readiness. The engine resolves each curve
+     * once, at the first tick after assignment, and never retries — and its mesh-instance
+     * broadcast fires before an instantiated hierarchy is parented, so a model that loads after
+     * the clips were assigned would otherwise stay silently unbound. A re-instantiation of the
+     * implicit clip source (the parent `<pc-model>`) means a new container, so the clip set
+     * refreshes instead — unless every clip declares its own asset, where a rebind suffices.
+     */
+    private _onModelReady = (event: Event) => {
+        if (!(event.target instanceof ModelElement) || !this.component) {
+            return;
+        }
+        if (event.target === this.parentElement) {
+            const implicit = this._autoAssigned ||
+                [...this._assignedClips.values()].some(clip => !clip.asset);
+            if (implicit) {
+                this._refreshClips();
+                return;
+            }
+        }
+        this.component.rebind();
+    };
+
+    /** @ignore */
+    constructor() {
+        super('anim');
+    }
+
+    protected getInitialComponentData() {
+        // The engine assigns creation data in key order and `activate` gates playback, so it
+        // must precede any future key that builds layers (e.g. a state graph)
+        return {
+            activate: this._activate,
+            speed: this._speed
+        };
+    }
+
+    protected initComponent() {
+        if (!this.component) {
+            return;
+        }
+
+        // A host readiness cycle can re-run this. An identical re-add is deduped by the DOM;
+        // the explicit swap handles the listener target changing across connections.
+        const host = this.closestEntity;
+        if (host && host !== this._modelListenerTarget) {
+            this._modelListenerTarget?.removeEventListener('ready', this._onModelReady);
+            host.addEventListener('ready', this._onModelReady);
+            this._modelListenerTarget = host;
+        }
+
+        this._applyClips();
+    }
+
+    disconnectedCallback() {
+        this._modelListenerTarget?.removeEventListener('ready', this._onModelReady);
+        this._modelListenerTarget = null;
+
+        // Invalidate any auto-assign still awaiting its model, and drop the adoption
+        // bookkeeping so a reconnection starts clean
+        this._sourceGeneration++;
+        this._assignedClips.clear();
+        this._autoAssigned = false;
+
+        super.disconnectedCallback();
+    }
+
+    /**
+     * The clip children in DOM order. Read afresh each pass — the DOM is the single source of
+     * truth for the declared clip set.
+     */
+    private _clipElements(): AnimClipElement[] {
+        return Array.from(this.querySelectorAll<AnimClipElement>(':scope > pc-anim-clip'));
+    }
+
+    /**
+     * Assigns a clip's state. Until the clip's real track resolves, the engine's own placeholder
+     * track stands in — it keeps the layer playable, so `activate` can start playback and the
+     * declared `clip` selection can apply before any asset has loaded.
+     */
+    private _assignClip(clip: AnimClipElement) {
+        this.component.assignAnimation(clip.name, clip._track ?? AnimTrack.EMPTY, undefined, clip.speed, clip.loop);
+    }
+
+    /**
+     * Validates a clip child and, when valid, assigns its state and starts its track resolution.
+     *
+     * @param clip - The clip element.
+     * @returns Whether the clip was adopted.
+     */
+    private _adoptClip(clip: AnimClipElement): boolean {
+        const name = clip.name;
+        if (!name) {
+            clip._markInvalid('pc-anim-clip must have a name - clip not assigned');
+            return false;
+        }
+        if (name.indexOf('.') !== -1) {
+            clip._markInvalid(`pc-anim-clip '${name}' - '.' in a clip name is reserved for blend tree paths - clip not assigned`);
+            return false;
+        }
+        if (this._assignedClips.has(name)) {
+            clip._markInvalid(`pc-anim-clip '${name}' - an earlier clip already uses this name - clip not assigned`);
+            return false;
+        }
+        this._assignedClips.set(name, clip);
+        this._assignClip(clip);
+        clip._resolveTrack(this);
+        return true;
+    }
+
+    /**
+     * Assigns the current clip set: the declared clip children when there are any, otherwise the
+     * enclosing model's clips. Runs against a fresh component after a host cycle, so the
+     * adoption bookkeeping rebuilds from scratch.
+     */
+    private _applyClips(restore?: PlaybackState) {
+        if (!this.component) {
+            return;
+        }
+
+        this._sourceGeneration++;
+        this._assignedClips.clear();
+        this._autoAssigned = false;
+
+        const clips = this._clipElements();
+        if (clips.length === 0) {
+            this._kickAutoAssign(restore);
+            return;
+        }
+
+        for (const clip of clips) {
+            this._adoptClip(clip);
+        }
+        this._applySelection(restore);
+    }
+
+    /**
+     * Assigns every clip of the enclosing model's container, named by track name, in container
+     * order. Names the engine cannot host — dotted (reserved for blend tree paths) or already
+     * taken — are skipped with a warning naming each.
+     */
+    private async _kickAutoAssign(restore?: PlaybackState) {
+        const generation = this._sourceGeneration;
+
+        const model = this.parentElement;
+        if (!(model instanceof ModelElement)) {
+            // Not inside a model: an empty component, driven through the JS API
+            return;
+        }
+
+        await model.ready();
+
+        // The source may have changed while the model loaded - a declared clip child appearing
+        // flips the element over to declared mode, and wins
+        const component = this.component;
+        if (generation !== this._sourceGeneration || !component || this._clipElements().length > 0) {
+            return;
+        }
+
+        const container = AssetElement.get(model.asset)?.resource as ContainerWithAnimations | undefined;
+        if (!container) {
+            // The load failed; the model already reported it
+            return;
+        }
+
+        const label = this.id ? ` '${this.id}'` : '';
+        if (container.animations.length === 0) {
+            console.warn(`pc-anim${label} - model '${model.asset}' has no animations`);
+            return;
+        }
+
+        const seen = new Set<string>();
+        for (const animationAsset of container.animations) {
+            const track = animationAsset.resource;
+            if (!(track instanceof AnimTrack)) {
+                continue;
+            }
+            if (track.name.indexOf('.') !== -1) {
+                console.warn(`pc-anim${label} - track '${track.name}' - '.' in a clip name is reserved for blend tree paths - track skipped`);
+                continue;
+            }
+            if (seen.has(track.name)) {
+                console.warn(`pc-anim${label} - duplicate track name '${track.name}' - track skipped`);
+                continue;
+            }
+            seen.add(track.name);
+            component.assignAnimation(track.name, track);
+        }
+
+        this._autoAssigned = seen.size > 0;
+        this._applySelection(restore);
+    }
+
+    /**
+     * Applies the active-clip selection: the declared `clip` when it names an assigned state,
+     * else a captured pre-rebuild state when it survived, else the engine's default (the first
+     * assigned clip). A restore also reinstates the playhead and both playing flags — the
+     * system tick reads the component's, the layer's controller reads its own.
+     */
+    private _applySelection(restore?: PlaybackState) {
+        const component = this.component;
+        const layer = component ? component.baseLayer : null;
+        if (!component || !layer) {
+            return;
+        }
+
+        if (this._clip && !layer.states.includes(this._clip)) {
+            this._warnUnknownClip(this._clip);
+        }
+
+        let target: string | null = null;
+        if (this._clip && layer.states.includes(this._clip)) {
+            target = this._clip;
+        } else if (restore && layer.states.includes(restore.state)) {
+            target = restore.state;
+        }
+
+        if (target && layer.activeState !== target) {
+            layer.play(target);
+        }
+
+        if (restore) {
+            if (target === restore.state) {
+                layer.activeStateCurrentTime = restore.time;
+            }
+            if (restore.playing) {
+                layer.playing = true;
+            }
+            component.playing = restore.playing;
+        }
+    }
+
+    private _warnUnknownClip(name: string) {
+        if (this._warnedClip === name) {
+            return;
+        }
+        this._warnedClip = name;
+        const label = this.id ? ` '${this.id}'` : '';
+        console.warn(`pc-anim${label} has no clip named '${name}' - selection unchanged`);
+    }
+
+    /**
+     * Rebuilds the clip set from the DOM, restoring the active clip and playhead when they
+     * survive the rebuild. The engine cannot remove a state from a loaded graph (unassigning
+     * only empties the state's tracks), so removals, renames and source changes drop the whole
+     * graph and reassign.
+     *
+     * @internal
+     */
+    _refreshClips() {
+        const component = this.component;
+        if (!component) {
+            return;
+        }
+        const layer = component.baseLayer;
+        const restore = layer ? {
+            state: layer.activeState,
+            time: layer.activeStateCurrentTime,
+            playing: component.playing
+        } : undefined;
+        component.removeStateGraph();
+        this._applyClips(restore);
+    }
+
+    /**
+     * Adopts a clip child announced by its connectedCallback. The initComponent sweep adopts
+     * children already present, so this is a no-op for those; it serves clips appended later,
+     * and flips an auto-assigned element over to its declared children — declared clips win.
+     *
+     * @param clip - The clip element.
+     * @internal
+     */
+    _registerClip(clip: AnimClipElement) {
+        if (!this.component) {
+            return;
+        }
+        if (this._autoAssigned) {
+            this._refreshClips();
+            return;
+        }
+        if (this._assignedClips.get(clip.name) === clip) {
+            return;
+        }
+        // A clip child appearing supersedes an auto-assign still awaiting its model
+        this._sourceGeneration++;
+        if (this._adoptClip(clip)) {
+            this._applySelection();
+        }
+    }
+
+    /**
+     * Releases a disconnected clip child. Rebuilds the set — a state cannot be removed from a
+     * live graph — and the removal of the last child inside a `<pc-model>` flips the element
+     * back to auto-assigning the model's clips.
+     *
+     * @param clip - The clip element.
+     * @internal
+     */
+    _unregisterClip(clip: AnimClipElement) {
+        if (!this.component) {
+            // The whole subtree is coming down (parents disconnect first) - nothing to rebuild
+            return;
+        }
+        if (this._assignedClips.get(clip.name) !== clip) {
+            // The clip never held a state (invalid or duplicate name)
+            return;
+        }
+        this._refreshClips();
+    }
+
+    /**
+     * Swaps a clip's resolved track in for the placeholder (or for its previous track after an
+     * asset change). A swap of the active clip restarts it: the engine preserves the playhead
+     * through a track replacement, which would land mid-way into unrelated animation.
+     *
+     * @param clip - The clip element.
+     * @returns Whether the clip still owns its state — the resolution may have been superseded
+     * by a rebuild that dropped it.
+     * @internal
+     */
+    _onClipResolved(clip: AnimClipElement): boolean {
+        const component = this.component;
+        if (!component || this._assignedClips.get(clip.name) !== clip) {
+            return false;
+        }
+        this._assignClip(clip);
+        const layer = component.baseLayer;
+        if (layer && layer.activeState === clip.name) {
+            layer.play(clip.name);
+        }
+        return true;
+    }
+
+    /**
+     * Applies a clip's changed speed or loop. The engine bakes both into the playback state it
+     * creates on state entry, so a live change re-enters the state and restores the playhead.
+     *
+     * @param clip - The clip element.
+     * @internal
+     */
+    _onClipParamsChanged(clip: AnimClipElement) {
+        const component = this.component;
+        if (!component || this._assignedClips.get(clip.name) !== clip) {
+            return;
+        }
+        this._assignClip(clip);
+        const layer = component.baseLayer;
+        if (layer && layer.activeState === clip.name) {
+            const time = layer.activeStateCurrentTime;
+            layer.play(clip.name);
+            layer.activeStateCurrentTime = time;
+        }
+    }
+
+    /**
+     * Resumes playback, optionally switching to a named clip first (a hard cut). A name that
+     * matches no clip leaves the selection unchanged.
+     *
+     * @param name - The name of the clip to play. Resumes the current clip when omitted.
+     */
+    play(name?: string) {
+        const component = this.component;
+        const layer = component ? component.baseLayer : null;
+        if (!component || !layer) {
+            return;
+        }
+        if (name !== undefined) {
+            if (!layer.states.includes(name)) {
+                return;
+            }
+            layer.play(name);
+        } else {
+            layer.play();
+        }
+        component.playing = true;
+    }
+
+    /**
+     * Pauses playback, preserving the playhead — {@link play} resumes from where it stopped.
+     */
+    pause() {
+        if (!this.component) {
+            return;
+        }
+        this.component.playing = false;
+    }
+
+    /**
+     * Cross-fades to a named clip and ensures playback is running. A name that matches no clip
+     * leaves the selection unchanged.
+     *
+     * @param name - The name of the clip to fade to.
+     * @param time - The fade duration in seconds. Defaults to the `transition-time` attribute.
+     */
+    transition(name: string, time?: number) {
+        const component = this.component;
+        const layer = component ? component.baseLayer : null;
+        if (!component || !layer || !layer.states.includes(name)) {
+            return;
+        }
+        layer.transition(name, Math.max(0, time ?? this._transitionTime));
+        layer.playing = true;
+        component.playing = true;
+    }
+
+    /**
+     * Gets the underlying PlayCanvas anim component.
+     * @returns The anim component.
+     */
+    get component(): AnimComponent {
+        return super.component as AnimComponent;
+    }
+
+    /**
+     * Gets the names of the assigned clips.
+     * @returns The clip names, in assignment order.
+     */
+    get clips(): string[] {
+        const layer = this.component ? this.component.baseLayer : null;
+        return layer ? layer.states.filter(state => !ANIM_CONTROL_STATES.includes(state)) : [];
+    }
+
+    /**
+     * Sets whether playback starts automatically once a clip is assigned. Defaults to `true`.
+     * Applies when clips are assigned — it does not stop a clip that is already playing.
+     * @param value - Whether playback starts automatically.
+     */
+    set activate(value: boolean) {
+        this._activate = value;
+        if (this.component) {
+            this.component.activate = value;
+        }
+    }
+
+    /**
+     * Gets whether playback starts automatically once a clip is assigned.
+     * @returns Whether playback starts automatically.
+     */
+    get activate() {
+        return this._activate;
+    }
+
+    /**
+     * Sets the name of the active clip. Changing it switches playback, cross-fading over
+     * `transition-time` seconds (a hard cut at 0). An empty value leaves the current clip
+     * playing; a name that matches no clip warns and leaves the selection unchanged.
+     * @param value - The name of the active clip.
+     */
+    set clip(value: string) {
+        this._clip = value;
+        const component = this.component;
+        const layer = component ? component.baseLayer : null;
+        if (!component || !layer || !value) {
+            return;
+        }
+        if (!layer.states.includes(value)) {
+            this._warnUnknownClip(value);
+            return;
+        }
+        if (layer.activeState === value) {
+            return;
+        }
+        if (this._transitionTime > 0) {
+            this.transition(value);
+        } else {
+            this.play(value);
+        }
+    }
+
+    /**
+     * Gets the name of the active clip.
+     * @returns The name of the active clip.
+     */
+    get clip() {
+        return this._clip;
+    }
+
+    /**
+     * Sets the playback speed multiplier applied across all clips, where 0 freezes playback.
+     * Defaults to 1.
+     * @param value - The playback speed multiplier.
+     */
+    set speed(value: number) {
+        this._speed = value;
+        if (this.component) {
+            this.component.speed = value;
+        }
+    }
+
+    /**
+     * Gets the playback speed multiplier applied across all clips.
+     * @returns The playback speed multiplier.
+     */
+    get speed() {
+        return this._speed;
+    }
+
+    /**
+     * Sets the cross-fade duration of clip switches made through the `clip` attribute, in
+     * seconds. Defaults to 0 (a hard cut).
+     * @param value - The cross-fade duration in seconds.
+     */
+    set transitionTime(value: number) {
+        this._transitionTime = value;
+    }
+
+    /**
+     * Gets the cross-fade duration of clip switches made through the `clip` attribute.
+     * @returns The cross-fade duration in seconds.
+     */
+    get transitionTime() {
+        return this._transitionTime;
+    }
+
+    static get observedAttributes() {
+        return [...super.observedAttributes, 'activate', 'clip', 'speed', 'transition-time'];
+    }
+
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
+        super.attributeChangedCallback(name, _oldValue, newValue);
+
+        switch (name) {
+            case 'activate':
+                this.activate = parseBool(newValue, true);
+                break;
+            case 'clip':
+                this.clip = newValue ?? '';
+                break;
+            case 'speed':
+                this.speed = parseNumber(newValue, 1, name);
+                break;
+            case 'transition-time':
+                this.transitionTime = parseNumber(newValue, 0, name);
+                break;
+        }
+    }
+}
+
+customElements.define('pc-anim', AnimComponentElement);
+
+export { AnimComponentElement };
+export type { ContainerWithAnimations };

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ import { ModuleElement } from './module';
 import { AppElement } from './app';
 import { EntityElement } from './entity';
 import { AssetElement } from './asset';
+import { AnimComponentElement } from './components/anim-component';
+import { AnimClipElement } from './components/anim-clip';
 import { ListenerComponentElement } from './components/listener-component';
 import { ButtonComponentElement } from './components/button-component';
 import { CameraComponentElement } from './components/camera-component';
@@ -58,6 +60,8 @@ declare global {
     }
 
     interface HTMLElementTagNameMap {
+        'pc-anim': AnimComponentElement;
+        'pc-anim-clip': AnimClipElement;
         'pc-app': AppElement;
         'pc-asset': AssetElement;
         'pc-button': ButtonComponentElement;
@@ -96,6 +100,8 @@ export {
     AppElement,
     EntityElement,
     AssetElement,
+    AnimComponentElement,
+    AnimClipElement,
     ButtonComponentElement,
     CameraComponentElement,
     CollisionComponentElement,

--- a/src/model.ts
+++ b/src/model.ts
@@ -252,13 +252,6 @@ class ModelElement extends AsyncElement {
         const entity = container.instantiateRenderEntity();
         this._entity = entity;
 
-        // @ts-ignore
-        if (container.animations.length > 0) {
-            entity.addComponent('anim');
-            // @ts-ignore
-            entity.anim.assignAnimation('animation', container.animations[0].resource);
-        }
-
         // The parent's readiness re-arms when it is torn down, so these can resume in a later
         // connection cycle. The entity is captured above and the generation re-checked, so a
         // stale resume cannot parent an entity a newer cycle has already destroyed.

--- a/test/elements/attribute-removal.test.ts
+++ b/test/elements/attribute-removal.test.ts
@@ -21,6 +21,9 @@ describe('attribute removal', () => {
 
     /** tag, attribute, property, and the value removal must restore. */
     const cases: [tag: string, attribute: string, property: string, restored: string][] = [
+        ['pc-anim', 'clip', 'clip', ''],
+        ['pc-anim-clip', 'asset', 'asset', ''],
+        ['pc-anim-clip', 'name', 'name', ''],
         ['pc-button', 'image', 'image', ''],
         ['pc-button', 'hover-sprite-asset', 'hoverSpriteAsset', ''],
         ['pc-button', 'pressed-sprite-asset', 'pressedSpriteAsset', ''],
@@ -66,6 +69,6 @@ describe('attribute removal', () => {
     it('covers every unparsed string attribute in the library', () => {
         // If a new `this.x = newValue ?? ''` branch is added without a case above, this fails.
         // Counted rather than enumerated, so it stays a one-line update rather than a second table.
-        expect(cases).toHaveLength(23);
+        expect(cases).toHaveLength(26);
     });
 });

--- a/test/integration/components/anim-component.test.ts
+++ b/test/integration/components/anim-component.test.ts
@@ -495,6 +495,41 @@ describe('<pc-anim>', () => {
             await vi.waitFor(() => expect(anim.clips).toEqual(['Walk', 'Run', 'Idle']));
         });
 
+        it('preserves a pause and its playhead across a rebuild', async () => {
+            const { app, get, step } = await bootApp(`
+                ${WALK_RUN_IDLE}
+                <pc-entity name="holder"><pc-model asset="m">
+                    <pc-anim>
+                        <pc-anim-clip name="Walk"></pc-anim-clip>
+                        <pc-anim-clip name="Run"></pc-anim-clip>
+                    </pc-anim>
+                </pc-model></pc-entity>
+            `);
+            const anim = get<AnimComponentElement>('pc-anim');
+            // Two steps: the first tick is consumed by the START transition
+            step(0.25);
+            step(0.25);
+            anim.pause();
+            const time = anim.component.baseLayer!.activeStateCurrentTime;
+            expect(time).toBeGreaterThan(0);
+
+            // Rebuild while paused: remove the inactive clip
+            (anim.children[1] as AnimClipElement).remove();
+            await vi.waitFor(() => expect(anim.clips).toEqual(['Walk']));
+
+            expect(anim.component.playing).toBe(false);
+            expect(anim.component.baseLayer!.activeState).toBe('Walk');
+            expect(anim.component.baseLayer!.activeStateCurrentTime).toBeCloseTo(time, 5);
+
+            const held = bonePosition(app).y;
+            step(0.25);
+            expect(bonePosition(app).y).toBe(held);
+
+            anim.play();
+            step(0.25);
+            expect(bonePosition(app).y).toBeGreaterThan(held);
+        });
+
         it('falls back to the next clip when the active one is removed', async () => {
             const { get, step } = await bootApp(`
                 ${WALK_RUN_IDLE}

--- a/test/integration/components/anim-component.test.ts
+++ b/test/integration/components/anim-component.test.ts
@@ -1,0 +1,697 @@
+import type { AppBase, Entity } from 'playcanvas';
+import { AnimTrack } from 'playcanvas';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AssetElement } from '../../../src/asset';
+import type { AnimClipElement } from '../../../src/components/anim-clip';
+import type { AnimComponentElement } from '../../../src/components/anim-component';
+import type { ModelElement } from '../../../src/model';
+import { bootApp } from '../../helpers/app';
+import { useGuard } from '../../helpers/guard';
+import { expectNeverReady, readyWithin } from '../../helpers/ready';
+
+/**
+ * An animated glTF: one node, one 1-second translation channel per clip, built as a data: URI so
+ * no I/O is involved (the buffer goes through btoa: the test tsconfig deliberately carries no
+ * node types, so Buffer is unavailable). Clips move the node along a direction determined by
+ * their index — even clips lift +Y, odd clips push +X — so a pose sample identifies which clip
+ * is driving the node.
+ */
+const times = new Float32Array([0, 1]);
+const lift = new Float32Array([0, 0, 0, 0, 2, 0]);
+const push = new Float32Array([0, 0, 0, 2, 0, 0]);
+const animData = new Float32Array([...times, ...lift, ...push]);
+const animDataBase64 = btoa(String.fromCharCode(...new Uint8Array(animData.buffer)));
+
+const animatedSrc = (...clipNames: string[]) => `data:application/json,${encodeURIComponent(JSON.stringify({
+    asset: { version: '2.0' },
+    scene: 0,
+    scenes: [{ nodes: [0] }],
+    nodes: [{ name: 'bone' }],
+    ...(clipNames.length > 0 ? {
+        animations: clipNames.map((name, index) => ({
+            name,
+            channels: [{ sampler: 0, target: { node: 0, path: 'translation' } }],
+            samplers: [{ input: 0, output: 1 + (index % 2) }]
+        })),
+        accessors: [
+            { bufferView: 0, componentType: 5126, count: 2, type: 'SCALAR', min: [0], max: [1] },
+            { bufferView: 1, componentType: 5126, count: 2, type: 'VEC3' },
+            { bufferView: 2, componentType: 5126, count: 2, type: 'VEC3' }
+        ],
+        bufferViews: [
+            { buffer: 0, byteOffset: 0, byteLength: 8 },
+            { buffer: 0, byteOffset: 8, byteLength: 24 },
+            { buffer: 0, byteOffset: 32, byteLength: 24 }
+        ],
+        buffers: [
+            { uri: `data:application/octet-stream;base64,${animDataBase64}`, byteLength: 56 }
+        ]
+    } : {})
+}))}`;
+
+const WALK_RUN_IDLE = `<pc-asset id="m" type="container" src="${animatedSrc('Walk', 'Run', 'Idle')}"></pc-asset>`;
+
+/** The animated node's local position - the pose the assertions sample. */
+const bonePosition = (app: AppBase) => (app.root.findByName('bone') as Entity).getLocalPosition();
+
+describe('<pc-anim>', () => {
+    const { uncaught, warnings } = useGuard();
+
+    const settleTask = () => new Promise((resolve) => {
+        setTimeout(resolve, 0);
+    });
+
+    describe('#component', () => {
+        it('creates the anim component with the engine defaults', async () => {
+            // A bare pc-anim outside a pc-model is an empty component driven through the JS
+            // API - deliberately silent, like a pc-sounds with no slots
+            const { get } = await bootApp('<pc-entity name="e"><pc-anim></pc-anim></pc-entity>');
+            const anim = get<AnimComponentElement>('pc-anim');
+            const component = anim.component;
+
+            expect(component).toBeDefined();
+            expect(component.activate).toBe(true);
+            expect(component.speed).toBe(1);
+            expect(component.playing).toBe(false);
+            expect(component.baseLayer).toBeNull();
+            expect(anim.clips).toEqual([]);
+        });
+    });
+
+    describe('attributes', () => {
+        it('applies declarative attributes through the initial component data', async () => {
+            const { get } = await bootApp(
+                '<pc-entity name="e"><pc-anim activate="false" speed="2" transition-time="0.5"></pc-anim></pc-entity>'
+            );
+            const anim = get<AnimComponentElement>('pc-anim');
+
+            expect(anim.component.activate).toBe(false);
+            expect(anim.component.speed).toBe(2);
+            expect(anim.transitionTime).toBe(0.5);
+        });
+
+        it('writes attribute changes through to the component', async () => {
+            const { get } = await bootApp('<pc-entity name="e"><pc-anim></pc-anim></pc-entity>');
+            const anim = get<AnimComponentElement>('pc-anim');
+
+            anim.setAttribute('activate', 'false');
+            anim.setAttribute('speed', '3');
+            anim.setAttribute('transition-time', '0.25');
+
+            expect(anim.component.activate).toBe(false);
+            expect(anim.component.speed).toBe(3);
+            expect(anim.transitionTime).toBe(0.25);
+        });
+
+        it('restores the engine default when an attribute is removed', async () => {
+            const { get } = await bootApp('<pc-entity name="e"><pc-anim></pc-anim></pc-entity>');
+            const anim = get<AnimComponentElement>('pc-anim');
+
+            anim.setAttribute('activate', 'false');
+            anim.setAttribute('speed', '3');
+            anim.setAttribute('transition-time', '0.25');
+            anim.setAttribute('clip', '');
+            anim.removeAttribute('activate');
+            anim.removeAttribute('speed');
+            anim.removeAttribute('transition-time');
+            anim.removeAttribute('clip');
+
+            expect(anim.component.activate).toBe(true);
+            expect(anim.component.speed).toBe(1);
+            expect(anim.transitionTime).toBe(0);
+            expect(anim.clip).toBe('');
+        });
+
+        it('falls back to the default and warns once per invalid value', async () => {
+            const { get } = await bootApp(
+                '<pc-entity name="e"><pc-anim speed="fast" transition-time="soon"></pc-anim></pc-entity>'
+            );
+            const anim = get<AnimComponentElement>('pc-anim');
+
+            warnings.expect("Invalid value 'fast' for attribute 'speed'. Expected a finite number. Using '1'.");
+            warnings.expect("Invalid value 'soon' for attribute 'transition-time'. Expected a finite number. Using '0'.");
+
+            expect(anim.component.speed).toBe(1);
+            expect(anim.transitionTime).toBe(0);
+        });
+    });
+
+    describe('auto-assign from the enclosing model', () => {
+        it('assigns every clip of the model, first clip playing', async () => {
+            const { app, get, step } = await bootApp(`
+                ${WALK_RUN_IDLE}
+                <pc-entity name="holder"><pc-model asset="m"><pc-anim></pc-anim></pc-model></pc-entity>
+            `);
+            const anim = get<AnimComponentElement>('pc-anim');
+
+            await vi.waitFor(() => expect(anim.clips).toEqual(['Walk', 'Run', 'Idle']));
+            expect(anim.component.playing).toBe(true);
+
+            expect(bonePosition(app).y).toBe(0);
+            step(0.5);
+            // Walk is container index 0, so it lifts +Y
+            expect(bonePosition(app).y).toBeGreaterThan(0);
+            expect(bonePosition(app).x).toBe(0);
+        });
+
+        it('warns when the enclosing model has no animations', async () => {
+            const { get } = await bootApp(`
+                <pc-asset id="still" type="container" src="${animatedSrc()}"></pc-asset>
+                <pc-entity name="holder"><pc-model asset="still"><pc-anim></pc-anim></pc-model></pc-entity>
+            `);
+            const anim = get<AnimComponentElement>('pc-anim');
+
+            await vi.waitFor(() => warnings.expect("pc-anim - model 'still' has no animations"));
+            expect(anim.clips).toEqual([]);
+        });
+
+        it('re-assigns from the new container when the model asset swaps', async () => {
+            const { app, get, step } = await bootApp(`
+                ${WALK_RUN_IDLE}
+                <pc-asset id="m2" type="container" src="${animatedSrc('Jump')}"></pc-asset>
+                <pc-entity name="holder"><pc-model asset="m"><pc-anim></pc-anim></pc-model></pc-entity>
+            `);
+            const anim = get<AnimComponentElement>('pc-anim');
+            await vi.waitFor(() => expect(anim.clips).toEqual(['Walk', 'Run', 'Idle']));
+
+            get<ModelElement>('pc-model').setAttribute('asset', 'm2');
+
+            await vi.waitFor(() => expect(anim.clips).toEqual(['Jump']));
+            step(0.5);
+            expect(bonePosition(app).y).toBeGreaterThan(0);
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('skips container tracks the engine cannot host, naming each', async () => {
+            const { get } = await bootApp(`
+                <pc-asset id="odd" type="container" src="${animatedSrc('Walk', 'Walk', 'bad.name')}"></pc-asset>
+                <pc-entity name="holder"><pc-model asset="odd"><pc-anim></pc-anim></pc-model></pc-entity>
+            `);
+            const anim = get<AnimComponentElement>('pc-anim');
+
+            await vi.waitFor(() => expect(anim.clips).toEqual(['Walk']));
+            warnings.expect("pc-anim - duplicate track name 'Walk' - track skipped");
+            warnings.expect("pc-anim - track 'bad.name' - '.' in a clip name is reserved for blend tree paths - track skipped");
+        });
+    });
+
+    describe('declared clips', () => {
+        it('assigns only the declared clips, first declared active', async () => {
+            const { app, get, step } = await bootApp(`
+                ${WALK_RUN_IDLE}
+                <pc-entity name="holder"><pc-model asset="m">
+                    <pc-anim>
+                        <pc-anim-clip name="Walk"></pc-anim-clip>
+                        <pc-anim-clip name="Run"></pc-anim-clip>
+                    </pc-anim>
+                </pc-model></pc-entity>
+            `);
+            const anim = get<AnimComponentElement>('pc-anim');
+
+            expect(anim.clips).toEqual(['Walk', 'Run']);
+            expect(anim.component.baseLayer!.activeState === 'Walk' || anim.component.baseLayer!.activeState === 'START').toBe(true);
+
+            step(0.5);
+            // Walk lifts +Y; Run would push +X
+            expect(bonePosition(app).y).toBeGreaterThan(0);
+            expect(bonePosition(app).x).toBe(0);
+        });
+
+        it('plays the clip declared by the clip attribute from boot', async () => {
+            const { app, get, step } = await bootApp(`
+                ${WALK_RUN_IDLE}
+                <pc-entity name="holder"><pc-model asset="m">
+                    <pc-anim clip="Run">
+                        <pc-anim-clip name="Walk"></pc-anim-clip>
+                        <pc-anim-clip name="Run"></pc-anim-clip>
+                    </pc-anim>
+                </pc-model></pc-entity>
+            `);
+            const anim = get<AnimComponentElement>('pc-anim');
+
+            expect(anim.component.baseLayer!.activeState).toBe('Run');
+            step(0.5);
+            // Run is container index 1, so it pushes +X
+            expect(bonePosition(app).x).toBeGreaterThan(0);
+            expect(bonePosition(app).y).toBe(0);
+        });
+
+        it('resolves clips from an explicit asset beside the model', async () => {
+            // The clip references the container itself rather than riding the implicit source -
+            // the arrangement used when clips live in a library asset separate from the skeleton
+            const { app, get, step } = await bootApp(`
+                ${WALK_RUN_IDLE}
+                <pc-entity name="holder">
+                    <pc-model asset="m"></pc-model>
+                    <pc-anim>
+                        <pc-anim-clip name="Run" asset="m"></pc-anim-clip>
+                    </pc-anim>
+                </pc-entity>
+            `);
+            const anim = get<AnimComponentElement>('pc-anim');
+
+            expect(anim.clips).toEqual(['Run']);
+            step(0.5);
+            expect(bonePosition(app).x).toBeGreaterThan(0);
+        });
+
+        it('resolves animation and animclip typed assets', async () => {
+            // A data: URI cannot reach the engine's GLB animation parser (it keys off the .glb
+            // extension), so the multi-track 'animation' shape is produced directly: a lazy
+            // asset populated with real AnimTracks before anything resolves it
+            const { appElement, get } = await bootApp(`
+                <pc-asset id="fly" type="animation" src="unused.json" lazy></pc-asset>
+                <pc-asset id="roll" type="animclip" src="unused.json" lazy></pc-asset>
+                <pc-entity name="e"></pc-entity>
+            `);
+
+            const flyAsset = (document.querySelector('pc-asset[id="fly"]') as AssetElement).asset!;
+            flyAsset.resources = [new AnimTrack('Fly', 1, [], [], []), new AnimTrack('Swim', 1, [], [], [])];
+            flyAsset.loaded = true;
+
+            const rollAsset = (document.querySelector('pc-asset[id="roll"]') as AssetElement).asset!;
+            rollAsset.resource = new AnimTrack('Roll', 1, [], [], []);
+            rollAsset.loaded = true;
+
+            const entity = get('pc-entity');
+            const anim = document.createElement('pc-anim');
+            anim.innerHTML = `
+                <pc-anim-clip name="Swim" asset="fly"></pc-anim-clip>
+                <pc-anim-clip name="Roll" asset="roll"></pc-anim-clip>
+            `;
+            entity.appendChild(anim);
+            await readyWithin(anim);
+            await Promise.all(Array.from(anim.children).map((clip) => readyWithin(clip as AnimClipElement)));
+
+            expect(anim.clips).toEqual(['Swim', 'Roll']);
+            expect(appElement.isConnected).toBe(true);
+        });
+
+        it('falls back to the first track with a warning when no name matches', async () => {
+            const { get } = await bootApp(`
+                ${WALK_RUN_IDLE}
+                <pc-entity name="holder"><pc-model asset="m">
+                    <pc-anim activate="false">
+                        <pc-anim-clip name="Dive"></pc-anim-clip>
+                    </pc-anim>
+                </pc-model></pc-entity>
+            `);
+            const anim = get<AnimComponentElement>('pc-anim');
+
+            warnings.expect(
+                "pc-anim-clip 'Dive' - no track named 'Dive' in model 'm' - using 'Walk' (available: Walk, Run, Idle)"
+            );
+            expect(anim.clips).toEqual(['Dive']);
+        });
+    });
+
+    describe('clip switching', () => {
+        const DECLARED = `
+            ${WALK_RUN_IDLE}
+            <pc-entity name="holder"><pc-model asset="m">
+                <pc-anim>
+                    <pc-anim-clip name="Walk"></pc-anim-clip>
+                    <pc-anim-clip name="Run"></pc-anim-clip>
+                </pc-anim>
+            </pc-model></pc-entity>
+        `;
+
+        it('switches clips with a hard cut when the clip attribute changes', async () => {
+            const { app, get, step } = await bootApp(DECLARED);
+            const anim = get<AnimComponentElement>('pc-anim');
+
+            anim.setAttribute('clip', 'Run');
+
+            expect(anim.component.baseLayer!.activeState).toBe('Run');
+            step(0.5);
+            expect(bonePosition(app).x).toBeGreaterThan(0);
+        });
+
+        it('cross-fades when transition-time is set', async () => {
+            const { get, step } = await bootApp(DECLARED);
+            const anim = get<AnimComponentElement>('pc-anim');
+            step(0.1);
+
+            anim.setAttribute('transition-time', '0.5');
+            anim.setAttribute('clip', 'Run');
+
+            const layer = anim.component.baseLayer!;
+            expect(layer.activeState).toBe('Run');
+            step(0.1);
+            expect(layer.transitioning).toBe(true);
+        });
+
+        it('warns once and keeps the current clip for an unknown name', async () => {
+            const { get } = await bootApp(DECLARED);
+            const anim = get<AnimComponentElement>('pc-anim');
+
+            anim.setAttribute('clip', 'Nope');
+            anim.setAttribute('clip', '');
+            anim.setAttribute('clip', 'Nope');
+
+            warnings.expect("pc-anim has no clip named 'Nope' - selection unchanged");
+            expect(anim.component.baseLayer!.activeState).not.toBe('Nope');
+        });
+
+        it('keeps playing when the clip attribute is removed', async () => {
+            const { get } = await bootApp(DECLARED);
+            const anim = get<AnimComponentElement>('pc-anim');
+            anim.setAttribute('clip', 'Run');
+
+            anim.removeAttribute('clip');
+
+            expect(anim.clip).toBe('');
+            expect(anim.component.playing).toBe(true);
+            expect(anim.component.baseLayer!.activeState).toBe('Run');
+        });
+
+        it('play and pause freeze and resume the pose', async () => {
+            const { app, get, step } = await bootApp(DECLARED);
+            const anim = get<AnimComponentElement>('pc-anim');
+
+            step(0.25);
+            const frozen = bonePosition(app).y;
+            expect(frozen).toBeGreaterThan(0);
+
+            anim.pause();
+            expect(anim.component.playing).toBe(false);
+            step(0.25);
+            expect(bonePosition(app).y).toBe(frozen);
+
+            anim.play();
+            step(0.25);
+            expect(bonePosition(app).y).toBeGreaterThan(frozen);
+        });
+
+        it('play(name) hard-cuts, transition(name) cross-fades, unknown names are ignored', async () => {
+            const { get, step } = await bootApp(DECLARED);
+            const anim = get<AnimComponentElement>('pc-anim');
+            const layer = anim.component.baseLayer!;
+            step(0.1);
+
+            anim.play('Run');
+            expect(layer.activeState).toBe('Run');
+
+            anim.transition('Walk', 0.2);
+            step(0.05);
+            expect(layer.activeState).toBe('Walk');
+            expect(layer.transitioning).toBe(true);
+
+            anim.play('Nope');
+            anim.transition('Nope');
+            expect(layer.activeState).toBe('Walk');
+        });
+
+        it('defers playback until play() when activate is false', async () => {
+            const { app, get, step } = await bootApp(`
+                ${WALK_RUN_IDLE}
+                <pc-entity name="holder"><pc-model asset="m">
+                    <pc-anim activate="false" clip="Run">
+                        <pc-anim-clip name="Walk"></pc-anim-clip>
+                        <pc-anim-clip name="Run"></pc-anim-clip>
+                    </pc-anim>
+                </pc-model></pc-entity>
+            `);
+            const anim = get<AnimComponentElement>('pc-anim');
+
+            expect(anim.component.playing).toBe(false);
+            step(0.5);
+            expect(bonePosition(app).x).toBe(0);
+            expect(bonePosition(app).y).toBe(0);
+
+            anim.play();
+            step(0.5);
+            // The declared selection was pre-positioned while paused, so play() resumes Run
+            expect(bonePosition(app).x).toBeGreaterThan(0);
+            expect(bonePosition(app).y).toBe(0);
+        });
+    });
+
+    describe('dynamic clip changes', () => {
+        const WALK_ONLY = `
+            ${WALK_RUN_IDLE}
+            <pc-entity name="holder"><pc-model asset="m">
+                <pc-anim>
+                    <pc-anim-clip name="Walk"></pc-anim-clip>
+                </pc-anim>
+            </pc-model></pc-entity>
+        `;
+
+        it('appends a clip without interrupting the active one', async () => {
+            const { get, step } = await bootApp(WALK_ONLY);
+            const anim = get<AnimComponentElement>('pc-anim');
+            // The first tick is consumed by the START transition (the engine resets its state
+            // time entering the clip), so the playhead only reads non-zero from the second on
+            step(0.25);
+            step(0.25);
+            const layer = anim.component.baseLayer!;
+            const before = layer.activeStateCurrentTime;
+            expect(before).toBeGreaterThan(0);
+
+            const clip = document.createElement('pc-anim-clip');
+            clip.setAttribute('name', 'Run');
+            anim.appendChild(clip);
+            await readyWithin(clip);
+
+            expect(anim.clips).toEqual(['Walk', 'Run']);
+            expect(layer.activeState).toBe('Walk');
+            expect(layer.activeStateCurrentTime).toBeGreaterThanOrEqual(before);
+        });
+
+        it('replaces an auto-assigned set with declared children', async () => {
+            const { get } = await bootApp(`
+                ${WALK_RUN_IDLE}
+                <pc-entity name="holder"><pc-model asset="m"><pc-anim></pc-anim></pc-model></pc-entity>
+            `);
+            const anim = get<AnimComponentElement>('pc-anim');
+            await vi.waitFor(() => expect(anim.clips).toEqual(['Walk', 'Run', 'Idle']));
+
+            const clip = document.createElement('pc-anim-clip');
+            clip.setAttribute('name', 'Run');
+            anim.appendChild(clip);
+
+            await vi.waitFor(() => expect(anim.clips).toEqual(['Run']));
+        });
+
+        it('rebuilds on removal, flipping back to auto-assign after the last child', async () => {
+            const { get } = await bootApp(`
+                ${WALK_RUN_IDLE}
+                <pc-entity name="holder"><pc-model asset="m">
+                    <pc-anim>
+                        <pc-anim-clip name="Walk"></pc-anim-clip>
+                        <pc-anim-clip name="Run"></pc-anim-clip>
+                    </pc-anim>
+                </pc-model></pc-entity>
+            `);
+            const anim = get<AnimComponentElement>('pc-anim');
+            const [walk, run] = Array.from(anim.children) as AnimClipElement[];
+
+            run.remove();
+            await vi.waitFor(() => expect(anim.clips).toEqual(['Walk']));
+
+            walk.remove();
+            // No declared children left inside a pc-model: the element auto-assigns again
+            await vi.waitFor(() => expect(anim.clips).toEqual(['Walk', 'Run', 'Idle']));
+        });
+
+        it('falls back to the next clip when the active one is removed', async () => {
+            const { get, step } = await bootApp(`
+                ${WALK_RUN_IDLE}
+                <pc-entity name="holder"><pc-model asset="m">
+                    <pc-anim>
+                        <pc-anim-clip name="Walk"></pc-anim-clip>
+                        <pc-anim-clip name="Run"></pc-anim-clip>
+                    </pc-anim>
+                </pc-model></pc-entity>
+            `);
+            const anim = get<AnimComponentElement>('pc-anim');
+            step(0.1);
+            expect(anim.component.baseLayer!.activeState).toBe('Walk');
+
+            (anim.children[0] as AnimClipElement).remove();
+            await vi.waitFor(() => expect(anim.clips).toEqual(['Run']));
+
+            step(0.1);
+            expect(anim.component.baseLayer!.activeState).toBe('Run');
+        });
+
+        it('renames a clip in place', async () => {
+            const { app, get, step } = await bootApp(`
+                <pc-asset id="solo" type="container" src="${animatedSrc('Walk')}"></pc-asset>
+                <pc-entity name="holder"><pc-model asset="solo">
+                    <pc-anim>
+                        <pc-anim-clip name="Walk"></pc-anim-clip>
+                    </pc-anim>
+                </pc-model></pc-entity>
+            `);
+            const anim = get<AnimComponentElement>('pc-anim');
+            const clip = anim.children[0] as AnimClipElement;
+
+            clip.setAttribute('name', 'Trot');
+            await readyWithin(clip);
+
+            // A single-track source supplies its track whatever the clip is named
+            expect(anim.clips).toEqual(['Trot']);
+            step(0.5);
+            expect(bonePosition(app).y).toBeGreaterThan(0);
+        });
+
+        it('applies a speed change live, preserving the playhead', async () => {
+            const { get, step } = await bootApp(WALK_ONLY);
+            const anim = get<AnimComponentElement>('pc-anim');
+            const clip = anim.children[0] as AnimClipElement;
+            const layer = anim.component.baseLayer!;
+            // Two steps: the first tick is consumed by the START transition
+            step(0.25);
+            step(0.25);
+            const before = layer.activeStateCurrentTime;
+            expect(before).toBeGreaterThan(0);
+
+            clip.setAttribute('speed', '2');
+
+            expect(layer.activeStateCurrentTime).toBeCloseTo(before, 5);
+            step(0.25);
+            expect(layer.activeStateCurrentTime).toBeGreaterThan(before);
+        });
+
+        it('clamps and holds the last pose of a non-looping clip', async () => {
+            const { app, get, step } = await bootApp(`
+                <pc-asset id="solo" type="container" src="${animatedSrc('Walk')}"></pc-asset>
+                <pc-entity name="holder"><pc-model asset="solo">
+                    <pc-anim>
+                        <pc-anim-clip name="Walk" loop="false"></pc-anim-clip>
+                    </pc-anim>
+                </pc-model></pc-entity>
+            `);
+            const anim = get<AnimComponentElement>('pc-anim');
+
+            step(2);
+            step(2);
+
+            const layer = anim.component.baseLayer!;
+            expect(layer.activeStateCurrentTime).toBe(layer.activeStateDuration);
+            expect(bonePosition(app).y).toBeCloseTo(2, 5);
+
+            // The engine reports no completion: the state holds and playing stays true
+            expect(anim.component.playing).toBe(true);
+            step(2);
+            expect(bonePosition(app).y).toBeCloseTo(2, 5);
+        });
+    });
+
+    describe('inside pc-node', () => {
+        it('reapplies clips when the hosting node rebinds after a model swap', async () => {
+            const { get } = await bootApp(`
+                ${WALK_RUN_IDLE}
+                <pc-asset id="m2" type="container" src="${animatedSrc('Jump')}"></pc-asset>
+                <pc-entity name="holder"><pc-model asset="m">
+                    <pc-node name="bone">
+                        <pc-anim>
+                            <pc-anim-clip name="Run" asset="m"></pc-anim-clip>
+                        </pc-anim>
+                    </pc-node>
+                </pc-model></pc-entity>
+            `);
+            const anim = get<AnimComponentElement>('pc-anim');
+            expect(anim.clips).toEqual(['Run']);
+            const firstComponent = anim.component;
+
+            get<ModelElement>('pc-model').setAttribute('asset', 'm2');
+
+            // The node rebinds to the new hierarchy, cycling the host: the component is
+            // recreated and the declared clips reapply to it
+            await vi.waitFor(() => {
+                expect(anim.component).toBeDefined();
+                expect(anim.component).not.toBe(firstComponent);
+                expect(anim.clips).toEqual(['Run']);
+            });
+            expect(uncaught.seen).toEqual([]);
+        });
+    });
+
+    describe('clip validation', () => {
+        it('warns and stays unassigned for a clip whose asset id resolves to nothing', async () => {
+            const { get } = await bootApp('<pc-entity name="e"><pc-anim></pc-anim></pc-entity>');
+            const anim = get<AnimComponentElement>('pc-anim');
+
+            const clip = document.createElement('pc-anim-clip');
+            clip.setAttribute('name', 'Walk');
+            clip.setAttribute('asset', 'nope');
+            anim.appendChild(clip);
+            await settleTask();
+
+            warnings.expect("pc-anim-clip 'Walk' could not find asset 'nope' - clip not assigned");
+            await expectNeverReady(clip);
+        });
+
+        it('warns and stays unassigned for a clip with no asset and no enclosing model', async () => {
+            const { get } = await bootApp('<pc-entity name="e"><pc-anim></pc-anim></pc-entity>');
+            const anim = get<AnimComponentElement>('pc-anim');
+
+            const clip = document.createElement('pc-anim-clip');
+            clip.setAttribute('name', 'Walk');
+            anim.appendChild(clip);
+            await settleTask();
+
+            warnings.expect("pc-anim-clip 'Walk' has no asset and no enclosing pc-model - clip not assigned");
+            await expectNeverReady(clip);
+        });
+
+        it('rejects empty, dotted and duplicate clip names', async () => {
+            const { get } = await bootApp(`
+                ${WALK_RUN_IDLE}
+                <pc-entity name="holder"><pc-model asset="m">
+                    <pc-anim>
+                        <pc-anim-clip name="Walk"></pc-anim-clip>
+                    </pc-anim>
+                </pc-model></pc-entity>
+            `);
+            const anim = get<AnimComponentElement>('pc-anim');
+
+            const unnamed = document.createElement('pc-anim-clip');
+            const dotted = document.createElement('pc-anim-clip');
+            dotted.setAttribute('name', 'a.b');
+            const duplicate = document.createElement('pc-anim-clip');
+            duplicate.setAttribute('name', 'Walk');
+            anim.append(unnamed, dotted, duplicate);
+            await settleTask();
+
+            warnings.expect('pc-anim-clip must have a name - clip not assigned');
+            warnings.expect("pc-anim-clip 'a.b' - '.' in a clip name is reserved for blend tree paths - clip not assigned");
+            warnings.expect("pc-anim-clip 'Walk' - an earlier clip already uses this name - clip not assigned");
+            expect(anim.clips).toEqual(['Walk']);
+            await expectNeverReady(duplicate);
+        });
+    });
+
+    describe('teardown', () => {
+        it('does not throw when a clip is added and removed within the same task', async () => {
+            const { get } = await bootApp('<pc-entity name="e"><pc-anim></pc-anim></pc-entity>');
+            const anim = get<AnimComponentElement>('pc-anim');
+
+            const clip = document.createElement('pc-anim-clip');
+            clip.setAttribute('name', 'blip');
+            anim.appendChild(clip);
+            clip.remove();
+
+            await settleTask();
+
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('does not throw when the whole app is removed while a clip is connecting', async () => {
+            const { get, unmount } = await bootApp('<pc-entity name="e"><pc-anim></pc-anim></pc-entity>');
+            const anim = get<AnimComponentElement>('pc-anim');
+
+            const clip = document.createElement('pc-anim-clip');
+            clip.setAttribute('name', 'blip');
+            anim.appendChild(clip);
+            unmount();
+
+            await settleTask();
+
+            expect(uncaught.seen).toEqual([]);
+        });
+    });
+});

--- a/test/integration/misplacement.test.ts
+++ b/test/integration/misplacement.test.ts
@@ -91,6 +91,19 @@ describe('misplaced elements', () => {
         await expectNeverReady(get<AsyncElement>('pc-sound'));
     });
 
+    it('warns and never becomes ready when pc-anim-clip is not a direct child of pc-anim', async () => {
+        const { get } = await bootUnsettled(`
+            <pc-entity name="e">
+                <pc-anim>
+                    <div><pc-anim-clip name="walk"></pc-anim-clip></div>
+                </pc-anim>
+            </pc-entity>
+        `);
+
+        warnings.expect("pc-anim-clip 'walk' must be a direct child of a pc-anim element");
+        await expectNeverReady(get<AsyncElement>('pc-anim-clip'));
+    });
+
     it('warns and never becomes ready for a pc-entity with no pc-app ancestor', async () => {
         const handle = mount('<pc-entity name="stray"></pc-entity>');
         const entity = handle.get<AsyncElement>('pc-entity');

--- a/test/integration/teardown.test.ts
+++ b/test/integration/teardown.test.ts
@@ -64,6 +64,7 @@ describe('teardown', () => {
         const cycle = async () => {
             const { unmount } = await bootApp(`
                 <pc-entity name="e">
+                    <pc-anim></pc-anim>
                     <pc-camera></pc-camera>
                     <pc-sounds><pc-sound name="blip"></pc-sound></pc-sounds>
                 </pc-entity>

--- a/typedoc.json
+++ b/typedoc.json
@@ -56,6 +56,9 @@
     "excludeNotDocumented": true,
     "externalSymbolLinkMappings": {
         "playcanvas": {
+            "AnimComponent": "https://api.playcanvas.com/engine/classes/AnimComponent.html",
+            "AnimComponentLayer": "https://api.playcanvas.com/engine/classes/AnimComponentLayer.html",
+            "AnimTrack": "https://api.playcanvas.com/engine/classes/AnimTrack.html",
             "Application": "https://api.playcanvas.com/engine/classes/Application.html",
             "Asset": "https://api.playcanvas.com/engine/classes/Asset.html",
             "AudioListenerComponent": "https://api.playcanvas.com/engine/classes/AudioListenerComponent.html",

--- a/utils/cem/tags.mjs
+++ b/utils/cem/tags.mjs
@@ -10,16 +10,16 @@
 
 /** Every tag the library registers. Kept explicit so adding or removing an element is deliberate. */
 export const TAGS = [
-    'pc-app', 'pc-asset', 'pc-button', 'pc-camera', 'pc-collision', 'pc-element', 'pc-entity',
-    'pc-gsplat', 'pc-joint', 'pc-layoutchild', 'pc-layoutgroup', 'pc-light', 'pc-listener',
-    'pc-material', 'pc-model', 'pc-module', 'pc-node', 'pc-particles', 'pc-render', 'pc-rigidbody',
-    'pc-scene', 'pc-screen', 'pc-script', 'pc-scripts', 'pc-scrollbar', 'pc-scrollview', 'pc-sky',
-    'pc-sound', 'pc-sounds'
+    'pc-anim', 'pc-anim-clip', 'pc-app', 'pc-asset', 'pc-button', 'pc-camera', 'pc-collision',
+    'pc-element', 'pc-entity', 'pc-gsplat', 'pc-joint', 'pc-layoutchild', 'pc-layoutgroup',
+    'pc-light', 'pc-listener', 'pc-material', 'pc-model', 'pc-module', 'pc-node', 'pc-particles',
+    'pc-render', 'pc-rigidbody', 'pc-scene', 'pc-screen', 'pc-script', 'pc-scripts',
+    'pc-scrollbar', 'pc-scrollview', 'pc-sky', 'pc-sound', 'pc-sounds'
 ];
 
 /** The tags whose elements extend `ComponentElement`, and so inherit its `enabled` attribute. */
 export const COMPONENT_TAGS = [
-    'pc-button', 'pc-camera', 'pc-collision', 'pc-element', 'pc-gsplat', 'pc-joint',
+    'pc-anim', 'pc-button', 'pc-camera', 'pc-collision', 'pc-element', 'pc-gsplat', 'pc-joint',
     'pc-layoutchild', 'pc-layoutgroup', 'pc-light', 'pc-listener', 'pc-particles', 'pc-render',
     'pc-rigidbody', 'pc-screen', 'pc-scripts', 'pc-scrollbar', 'pc-scrollview', 'pc-sounds'
 ];

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -311,6 +311,7 @@ if (manifest) {
     // genuinely new public member belongs in this list.
     const ASYNC_MEMBERS = ['closestApp', 'closestEntity', 'ready'];
     const EXTRA_MEMBERS = new Map([
+        ['pc-anim', ['clips', 'component', 'pause', 'play', 'transition', ...ASYNC_MEMBERS]],
         ['pc-app', ['app', 'elementFromEntity', 'loadProgress', ...ASYNC_MEMBERS]],
         ['pc-asset', ['asset', 'get', ...ASYNC_MEMBERS]],
         ['pc-camera', ['component', 'endXr', 'startXr', 'xrAvailable', ...ASYNC_MEMBERS]],


### PR DESCRIPTION
## What

Adds declarative animation via a new component element pair, and removes the hard-coded auto-play from `pc-model`:

- **`<pc-anim>`** (extends `ComponentElement`, engine `anim` component). Attributes: `clip` (active clip by name; switching cross-fades over `transition-time`, hard cut at 0), `transition-time`, `speed`, `activate`, plus inherited `enabled`. JS surface: `play(name?)`, `pause()`, `transition(name, time?)`, `clips`, narrowed `component`.
- **`<pc-anim-clip>`** (extends `AsyncElement`). Attributes: `name` (state name and track-lookup key), `asset` (a `container`, `animation` `.glb`, or `animclip` JSON asset), `speed`, `loop`. Without `asset`, tracks come from the container of the `pc-model` enclosing the parent `pc-anim`. A single-track source supplies its track whatever it is named; a multi-track source matches by name, falling back to the first with a warning.
- A **bare `<pc-anim>` inside a `pc-model`** auto-assigns every clip of the model's container in order (first clip plays). Declared children replace the auto-assigned set; removing the last child flips back.

```html
<pc-entity name="t-rex" scale="3 3 3">
    <pc-model asset="t-rex">
        <pc-anim></pc-anim>
    </pc-model>
</pc-entity>
```

## Why

Animation was previously a hidden default: any GLB with clips silently got an anim component playing `animations[0]`, with no way to opt out, pick a clip, pause, or control speed. That default is a behavior users can depend on, so replacing it is breaking and belongs before 1.0. `pc-anim` is a general component element (hosts on `pc-entity`/`pc-node` like every other), so clip libraries beside a model, sub-hierarchy animation inside `pc-node`, and hand-authored hierarchies all work — the `pc-model` relationship is only a clip-sourcing default.

## Breaking change

`<pc-model>` no longer auto-plays the first clip of an animated GLB. Migration is one line: nest `<pc-anim></pc-anim>` inside the `pc-model` (see the updated GLB Animation example).

## Reviewer notes — engine facts that shaped the implementation

- **The engine cannot remove a state** from a loaded graph (`removeNodeAnimations` only empties `state.animations`), so clip removal/rename/source-swap rebuild via `removeStateGraph()` and reassign, capturing and restoring the active clip, playhead and playing flags.
- **Clip states are pre-assigned with `AnimTrack.EMPTY`** (the engine's own placeholder idiom) until real tracks resolve. This pins the START target to the first declared clip regardless of asset load order and makes the declared `clip` selection race-free; real tracks hot-swap in on load, restarting the state if it is active.
- **Curve binding is lazy and one-shot** (first update tick, never retried), and the engine's `meshInstancesChange` broadcast fires before `instantiateRenderEntity`'s hierarchy is parented — so `pc-anim` listens for bubbling `ready` from descendant models and calls `rebind()` (or refreshes the clip set when the implicit source itself re-instantiated).
- **Two independent playing flags** gate playback (`component.playing` and the layer controller's); the element's `play()`/`transition()` set both.
- **No completion events exist** in the engine — a non-looping clip clamps and holds silently. Documented on the element; forwarding authored AnimEvents as DOM events is possible follow-up work.
- State-graph mode (`state-graph` attribute, graph-authored transitions/parameters) is deliberately out of scope for this PR and planned as a follow-up; the clip-child vocabulary is designed so graph mode drops in without churn.

One test-visible engine quirk: the first anim tick is consumed by the START transition (`_timeInState` resets while the evaluator still advances the clip), so tests sampling `activeStateCurrentTime` step twice.

## Verification

- 807/807 tests pass (34 new cases in `test/integration/components/anim-component.test.ts` using an animated data-URI glTF fixture that asserts real pose movement under jsdom, plus rows in the misplacement/attribute-removal/teardown suites, including the #310 shapes).
- `npm run build` (CEM manifest validated at 31 elements), `npm run lint`, `npm run type-check` (both tsconfigs) and `npm run publint` all green.
- Verified live in the browser on `examples/glb-animation.html`: clips auto-assign and animate the t-rex; removing the `pc-anim` element removes the component and freezes the pose; re-adding it resumes; console clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
