### PR TITLE
Give pc-model a stable host entity it creates and fronts

### DIFF
--- a/examples/assets/scripts/baked-ao.mjs
+++ b/examples/assets/scripts/baked-ao.mjs
@@ -102,7 +102,9 @@ export class BakedAo extends Script {
         // castShadowsLightmap defaults to true for them.
         const models = Array.from(document.querySelectorAll('pc-model'));
         const request = () => {
-            if (models.every((model) => model.entity)) {
+            // contentEntity, not entity: the host entity exists from boot, while the content is
+            // what the bake needs in the scene.
+            if (models.every((model) => model.contentEntity)) {
                 this._scheduleBake();
             }
         };

--- a/src/app.ts
+++ b/src/app.ts
@@ -66,8 +66,8 @@ import {
 
 import type { AssetElement } from './asset';
 import { AsyncElement } from './async-element';
-import type { EntityElement } from './entity';
 import type { EntityBaseElement } from './entity-base';
+import type { EntityOwnerElement } from './entity-owner';
 import { LoadingBar } from './loading-bar';
 import type { MaterialElement } from './material';
 import type { ModuleElement } from './module';
@@ -75,6 +75,13 @@ import { parseBool, parseEnum, parseNumber } from './parse';
 
 /** The pointer event types the application synthesizes on `<pc-entity>` elements via picking. */
 const pointerEventTypes = ['pointermove', 'pointerdown', 'pointerup', 'pointerenter', 'pointerleave'] as const;
+
+/**
+ * The event types whose listeners make an element a hover target. Hover resolution walks past
+ * elements listening for none of them, so a silent element never swallows an ancestor's
+ * enter/leave pair.
+ */
+const hoverEventTypes = ['pointerenter', 'pointerleave', 'pointermove'] as const;
 
 /**
  * Gives `pc-app` the sizing contract of a replaced element (`<video>`, `<img>`): a block-level
@@ -163,9 +170,9 @@ class AppElement extends AsyncElement {
 
     /**
      * The elements backing this application's entities, keyed by the entity itself. Registered
-     * by EntityElement at creation (and NodeElement at binding) and removed when an entity is
-     * destroyed or unbound, this joins engine scene nodes back to their owning elements by
-     * identity - never by name.
+     * by entity-owning elements at creation (pc-entity, and pc-model for its host) and by
+     * NodeElement at binding, and removed when an entity is destroyed or unbound, this joins
+     * engine scene nodes back to their owning elements by identity - never by name.
      */
     private _entityElements = new Map<GraphNode, EntityBaseElement>();
 
@@ -462,15 +469,16 @@ class AppElement extends AsyncElement {
             materialElement._createMaterial();
         });
 
-        // Create all entities
-        const entityElements = this.querySelectorAll<EntityElement>('pc-entity');
-        Array.from(entityElements).forEach((entityElement) => {
-            entityElement._createEntity(app);
+        // Create all entities. pc-model joins the sweep because it owns a host entity of its
+        // own; its instantiated content arrives later, beneath that host.
+        const ownerElements = this.querySelectorAll<EntityOwnerElement>('pc-entity, pc-model');
+        Array.from(ownerElements).forEach((ownerElement) => {
+            ownerElement._createEntity(app);
         });
 
         // Build hierarchy
-        entityElements.forEach((entityElement) => {
-            entityElement._buildHierarchy(app);
+        ownerElements.forEach((ownerElement) => {
+            ownerElement._buildHierarchy(app);
         });
 
         // Building the hierarchy dispatched each entity's ready event synchronously, and a
@@ -602,9 +610,9 @@ class AppElement extends AsyncElement {
         // created from onpointer* attributes when their elements were first upgraded, or
         // listeners carried over from before a re-boot)
         pointerEventTypes.forEach((type) => {
-            const anyListeners = Array.from(this.querySelectorAll<EntityBaseElement>('pc-entity, pc-node')).some(
-                (entity) => entity._hasListeners(type)
-            );
+            const anyListeners = Array.from(
+                this.querySelectorAll<EntityBaseElement>('pc-entity, pc-model, pc-node')
+            ).some((entity) => entity._hasListeners(type));
             if (anyListeners) {
                 this._onPointerListenerAdded(type);
             }
@@ -659,10 +667,10 @@ class AppElement extends AsyncElement {
     }
 
     /**
-     * Returns the `<pc-entity>` or `<pc-node>` element whose backing entity is `entity`, or
-     * `null` if the entity is not fronted by an element of this application - for example, an
-     * unbound node inside a model's instantiated hierarchy, or an entity created through the
-     * engine API.
+     * Returns the `<pc-entity>`, `<pc-model>` or `<pc-node>` element whose backing entity is
+     * `entity`, or `null` if the entity is not fronted by an element of this application - for
+     * example, an unbound node inside a model's instantiated hierarchy, or an entity created
+     * through the engine API.
      *
      * @param entity - The entity to look up.
      * @returns The element fronting the entity, or `null`.
@@ -672,18 +680,19 @@ class AppElement extends AsyncElement {
     }
 
     /**
-     * Resolves the element that owns a picked node: the nearest node up the parent chain -
-     * starting with the node itself - that is fronted by a `<pc-entity>` or `<pc-node>` of this
-     * application. A hit inside a model's instantiated hierarchy therefore resolves to the
-     * nearest bound `<pc-node>`, or failing that the element hosting the model.
+     * Resolves the element that owns hover for a picked node: the nearest node up the parent
+     * chain - starting with the node itself - whose element listens for any of the hover event
+     * types. Skipping silent elements matches {@link _elementWithListener}, so a registered
+     * element with no hover listeners (a `<pc-model>` host, a plain child entity) is transparent
+     * to hover rather than swallowing a listening ancestor's enter/leave pair.
      *
      * @param node - The picked node, or `null`.
-     * @returns The owning element, or `null`.
+     * @returns The hover-owning element, or `null`.
      */
-    private _elementFromNode(node: GraphNode | null): EntityBaseElement | null {
+    private _hoverTarget(node: GraphNode | null): EntityBaseElement | null {
         while (node !== null) {
             const element = this._entityElements.get(node);
-            if (element) {
+            if (element && hoverEventTypes.some((type) => element._hasListeners(type))) {
                 return element;
             }
             node = node.parent;
@@ -831,9 +840,10 @@ class AppElement extends AsyncElement {
         const node = await this._pickNode(event);
         if (token !== this._pickToken || !this._picker) return;
 
-        // The hovered element is the nearest one up the node's parent chain, listening or not -
-        // dispatch is gated per event type below
-        const newHoverEntity = this._elementFromNode(node);
+        // The hovered element is the nearest one up the node's parent chain with a hover
+        // listener - the nearest-listener rule down/up use. Dispatch is still gated per event
+        // type below: having any hover listener selects the target, each event needs its own.
+        const newHoverEntity = this._hoverTarget(node);
 
         // Handle enter/leave events
         if (this._hoveredEntity !== newHoverEntity) {
@@ -898,9 +908,9 @@ class AppElement extends AsyncElement {
     }
 
     private _onPointerListenerRemoved(type: string) {
-        const hasListeners = Array.from(this.querySelectorAll<EntityBaseElement>('pc-entity, pc-node')).some((entity) =>
-            entity._hasListeners(type)
-        );
+        const hasListeners = Array.from(
+            this.querySelectorAll<EntityBaseElement>('pc-entity, pc-model, pc-node')
+        ).some((entity) => entity._hasListeners(type));
 
         if (!hasListeners && this._canvas) {
             this._hasPointerListeners[type] = false;

--- a/src/components/anim-component.ts
+++ b/src/components/anim-component.ts
@@ -1,4 +1,4 @@
-import type { AnimComponent, Asset, ContainerResource } from 'playcanvas';
+import type { AnimComponent, Asset, ContainerResource, Entity } from 'playcanvas';
 import { ANIM_CONTROL_STATES, AnimTrack } from 'playcanvas';
 
 import { AssetElement } from '../asset';
@@ -72,6 +72,12 @@ class AnimComponentElement extends ComponentElement {
     private _clip = '';
 
     /**
+     * The binding root this element last assigned through {@link _applyRootBone}, distinguishing
+     * its own writes from a `rootBone` assigned through the engine API — which is left alone.
+     */
+    private _managedRootBone: Entity | null = null;
+
+    /**
      * The element the model-readiness listener is attached to, held so disconnection can detach
      * it after `closestEntity` no longer resolves.
      */
@@ -142,17 +148,33 @@ class AnimComponentElement extends ComponentElement {
     }
 
     /**
-     * Points the component's binding root at the skeleton source's host entity. The host wraps
-     * the instantiated content, so left at its default — the component's own entity — the engine
-     * binder mis-resolves curves that target the asset's root node: its fallback treats the
-     * graph as the asset root once the root is no longer a direct child. The write is skipped
-     * while unchanged, because the engine setter itself triggers a rebind.
+     * Keeps the component's binding root pointing at the skeleton source's host entity. The host
+     * wraps the instantiated content, so left at its default — the component's own entity — the
+     * engine binder mis-resolves curves that target the asset's root node: its fallback treats
+     * the graph as the asset root once the root is no longer a direct child.
+     *
+     * Authoritative in both directions for values this element assigned: a source appearing pins
+     * its host, and a source dissolving (the model gone, or a second model making the skeleton
+     * ambiguous) clears the pin rather than leaving it on a stale host. A root assigned through
+     * the engine API is never overwritten — the user's choice outranks the managed default.
+     * Writes are skipped while unchanged, because the engine setter itself triggers a rebind.
      */
     private _applyRootBone() {
-        const host = this._skeletonSource()?.entity ?? null;
-        if (host && this.component.rootBone !== host) {
-            this.component.rootBone = host;
+        const component = this.component;
+
+        // A non-null root this element did not assign came through the engine API. A fresh
+        // component starts at null, which is always reclaimable.
+        if (component.rootBone !== null && component.rootBone !== this._managedRootBone) {
+            return;
         }
+
+        const host = this._skeletonSource()?.entity ?? null;
+        if (component.rootBone !== host) {
+            // The engine setter accepts null - restoring the component's own entity as the
+            // binding graph - but its declared type does not
+            component.rootBone = host as Entity;
+        }
+        this._managedRootBone = host;
     }
 
     /** @ignore */
@@ -196,6 +218,7 @@ class AnimComponentElement extends ComponentElement {
         this._sourceGeneration++;
         this._assignedClips.clear();
         this._autoAssigned = false;
+        this._managedRootBone = null;
 
         super.disconnectedCallback();
     }
@@ -386,6 +409,10 @@ class AnimComponentElement extends ComponentElement {
         if (!component) {
             return;
         }
+        // A clip-set change is also a chance for the skeleton source to have changed shape (a
+        // clip child appearing or leaving can accompany a model coming or going) - re-derive the
+        // binding root before the reassignment binds against it.
+        this._applyRootBone();
         const layer = component.baseLayer;
         const restore = layer ? {
             state: layer.activeState,

--- a/src/components/anim-component.ts
+++ b/src/components/anim-component.ts
@@ -112,6 +112,9 @@ class AnimComponentElement extends ComponentElement {
         if (!(event.target instanceof ModelElement) || !this.component) {
             return;
         }
+        // A model cycle can replace the skeleton source's host entity (a rebuild under a
+        // retargeting pc-node), so the binding root is re-asserted before anything rebinds.
+        this._applyRootBone();
         if (event.target === this.parentElement) {
             const implicit = this._autoAssigned ||
                 [...this._assignedClips.values()].some(clip => !clip.asset);
@@ -122,6 +125,35 @@ class AnimComponentElement extends ComponentElement {
         }
         this.component.rebind();
     };
+
+    /**
+     * The model whose host entity scopes this component's curve binding: the parent `pc-model`,
+     * or the sole `pc-model` among the parent's direct children (the arrangement where clips
+     * live in a library asset beside the skeleton). `null` when there is no such model, or more
+     * than one — an ambiguous skeleton is left to the engine's name-based resolution.
+     */
+    private _skeletonSource(): ModelElement | null {
+        const parent = this.parentElement;
+        if (parent instanceof ModelElement) {
+            return parent;
+        }
+        const models = parent ? parent.querySelectorAll(':scope > pc-model') : null;
+        return models?.length === 1 && models[0] instanceof ModelElement ? models[0] : null;
+    }
+
+    /**
+     * Points the component's binding root at the skeleton source's host entity. The host wraps
+     * the instantiated content, so left at its default — the component's own entity — the engine
+     * binder mis-resolves curves that target the asset's root node: its fallback treats the
+     * graph as the asset root once the root is no longer a direct child. The write is skipped
+     * while unchanged, because the engine setter itself triggers a rebind.
+     */
+    private _applyRootBone() {
+        const host = this._skeletonSource()?.entity ?? null;
+        if (host && this.component.rootBone !== host) {
+            this.component.rootBone = host;
+        }
+    }
 
     /** @ignore */
     constructor() {
@@ -151,6 +183,7 @@ class AnimComponentElement extends ComponentElement {
             this._modelListenerTarget = host;
         }
 
+        this._applyRootBone();
         this._applyClips();
     }
 

--- a/src/entity-base.ts
+++ b/src/entity-base.ts
@@ -17,11 +17,12 @@ export const POINTER_ATTRIBUTES = [
 ] as const;
 
 /**
- * The base class for elements that front an engine {@link Entity}: `<pc-entity>`, which creates
- * one, and `<pc-node>`, which binds to one inside a model's instantiated hierarchy. It carries
- * what both need — the `entity` contract, registration with the owning application (which joins
- * picked scene nodes back to elements by identity, never by name), and the pointer listener
- * bookkeeping that lets the application lazily attach its canvas handlers.
+ * The base class for elements that front an engine {@link Entity}: `<pc-entity>` and
+ * `<pc-model>`, which create one, and `<pc-node>`, which binds to one inside a model's
+ * instantiated hierarchy. It carries what all of them need — the `entity` contract, registration
+ * with the owning application (which joins picked scene nodes back to elements by identity,
+ * never by name), and the pointer listener bookkeeping that lets the application lazily attach
+ * its canvas handlers.
  */
 class EntityBaseElement extends AsyncElement {
     protected _entity: Entity | null = null;

--- a/src/entity-owner.ts
+++ b/src/entity-owner.ts
@@ -150,6 +150,14 @@ class EntityOwnerElement extends EntityBaseElement {
             return;
         }
 
+        // An owner that exists but is not yet parented is itself deferred behind an unresolved
+        // node further up. Building beneath it would announce readiness for an entity that is
+        // not in the scene graph; stay unbuilt with it - the node's bind sweeps the whole
+        // subtree, ancestors before descendants.
+        if (closestEntity instanceof EntityOwnerElement && !closestEntity._built) {
+            return;
+        }
+
         this._built = true;
 
         if (closestEntity?.entity) {

--- a/src/entity-owner.ts
+++ b/src/entity-owner.ts
@@ -1,0 +1,290 @@
+import type { AppBase } from 'playcanvas';
+import { Entity, Vec3 } from 'playcanvas';
+
+import { EntityBaseElement } from './entity-base';
+
+/**
+ * Creates and parents the entities of every descendant entity-owning element of `root`, in two
+ * passes so that no parent's existence depends on document order. Called wherever a subtree could
+ * not build itself: an element inserted into an application that is already running, and a
+ * `<pc-node>` whose children waited for it to bind.
+ *
+ * Descendants that are not yet custom elements are skipped, because there is nothing useful to do
+ * for them and reaching for `_createEntity` would throw. A subtree cloned from a `<template>`
+ * arrives entirely unupgraded — template content lives in an inert document, where custom element
+ * definitions are never looked up — and appending the clone upgrades its elements in tree order,
+ * an element before its descendants. So a sweep from an element's own `connectedCallback` sees
+ * plain `HTMLElement`s below it. Each becomes an entity-owning element moments later and its own
+ * `connectedCallback` creates and parents it, by which time the ancestor it parents under has its
+ * entity — the same guarantee tree order gives this sweep.
+ *
+ * @param root - The element whose descendant entities to build.
+ * @param app - The application to create the entities in.
+ * @internal
+ */
+export const buildDescendantEntities = (root: Element, app: AppBase) => {
+    const children = Array.from(root.querySelectorAll('pc-entity, pc-model')).filter(
+        (child): child is EntityOwnerElement => child instanceof EntityOwnerElement
+    );
+    children.forEach((child) => child._createEntity(app));
+    children.forEach((child) => child._buildHierarchy(app));
+};
+
+/**
+ * The base class for elements that create and own their backing entity: `<pc-entity>` and
+ * `<pc-model>`, whose host entity carries the same authored properties. It carries the cached
+ * property state, entity creation and parenting, and the reset that follows the entity's
+ * destruction. `<pc-node>` sits outside this class: it borrows an entity a model instantiated,
+ * and its properties are nullable overrides rather than owned values.
+ */
+class EntityOwnerElement extends EntityBaseElement {
+    /**
+     * Whether the entity is enabled.
+     */
+    private _enabled = true;
+
+    /**
+     * The name of the entity.
+     */
+    private _name = 'Untitled';
+
+    /**
+     * The position of the entity.
+     */
+    private _position = new Vec3();
+
+    /**
+     * The rotation of the entity.
+     */
+    private _rotation = new Vec3();
+
+    /**
+     * The scale of the entity.
+     */
+    private _scale = new Vec3(1, 1, 1);
+
+    /**
+     * The tags of the entity.
+     */
+    private _tags: string[] = [];
+
+    /**
+     * Whether the hierarchy has been built for this entity — set once {@link _buildHierarchy} has
+     * parented it. Read by subclasses that gate work on the entity being in the scene graph.
+     */
+    protected _built = false;
+
+    /**
+     * Creates the backing entity. Called by the containing `<pc-app>` element during its boot
+     * sweep, and on connection for elements inserted while the application is already running.
+     *
+     * @param app - The application to create the entity in.
+     * @internal
+     */
+    _createEntity(app: AppBase) {
+        // Guard against double creation. When a subtree is inserted at runtime (e.g. cloning a
+        // `<template>`), an ancestor's connectedCallback eagerly creates descendant entities; the
+        // descendants' own connectedCallbacks would otherwise create them a second time.
+        if (this._entity) {
+            return;
+        }
+
+        // Seed from the cached fields rather than re-reading the attributes. Every observed
+        // attribute is routed through its property setter by attributeChangedCallback, so the field
+        // already holds the parsed attribute value - and it also holds anything assigned through the
+        // property API before the app booted, which reading the attribute back would discard.
+        const entity = new Entity(this._name, app);
+        this._entity = entity;
+
+        entity.enabled = this._enabled;
+        entity.setLocalPosition(this._position);
+        entity.setLocalEulerAngles(this._rotation);
+        entity.setLocalScale(this._scale);
+
+        if (this._tags.length > 0) {
+            entity.tags.add(this._tags);
+        }
+
+        // Register with the owning application and hook the entity's destruction. The engine
+        // fires 'destroy' for every entity in a destroyed subtree, so the element learns of its
+        // entity's death no matter who causes it: this element, an ancestor, the whole
+        // application, or a user script calling entity.destroy().
+        this._registerEntity(entity);
+        entity.once('destroy', this._onEntityDestroy, this);
+    }
+
+    /**
+     * Handles the destruction of the backing entity. Resets the element so a later re-insertion
+     * starts clean: `_built` must be cleared alongside `_entity`, or _buildHierarchy would bail
+     * and a re-created entity would never be parented. Readiness is re-armed for the same
+     * reason — with the entity gone, a resolved ready promise would resume its awaiters against
+     * a null `entity`.
+     *
+     * @param entity - The entity that was destroyed.
+     */
+    protected _onEntityDestroy(entity: Entity) {
+        this._unregisterEntity(entity);
+        this._entity = null;
+        this._built = false;
+        this._resetReady();
+    }
+
+    /**
+     * Parents the backing entity: under the entity of the nearest ancestor `<pc-entity>` or
+     * `<pc-node>` when there is one, and under the application root otherwise. Called by the
+     * containing `<pc-app>` element once a sweep has created every entity, so a parent's
+     * existence never depends on document order.
+     *
+     * @param app - The application whose root adopts parentless entities.
+     * @internal
+     */
+    _buildHierarchy(app: AppBase) {
+        if (!this.entity || this._built) return;
+
+        const closestEntity = this.closestEntity;
+
+        // A host element without an entity is an unresolved `<pc-node>`: building now would
+        // mis-anchor this entity to the application root while the host is still resolving.
+        // Stay unbuilt - the host drives this subtree itself once it binds.
+        if (closestEntity && !closestEntity.entity) {
+            return;
+        }
+
+        this._built = true;
+
+        if (closestEntity?.entity) {
+            closestEntity.entity.addChild(this.entity);
+        } else {
+            app.root.addChild(this.entity);
+        }
+
+        this._onBuilt();
+    }
+
+    /**
+     * Called by {@link _buildHierarchy} once the backing entity has been parented — exactly once
+     * per build cycle. The default announces readiness, which is what a parented `<pc-entity>`
+     * means; `<pc-model>` overrides it to start loading content instead, because its readiness
+     * tracks the content settling rather than the host entering the scene graph.
+     */
+    protected _onBuilt() {
+        this._onReady();
+    }
+
+    /**
+     * Sets the enabled state of the entity.
+     * @param value - Whether the entity is enabled.
+     */
+    set enabled(value) {
+        this._enabled = value;
+        if (this.entity) {
+            this.entity.enabled = value;
+        }
+    }
+
+    /**
+     * Gets the enabled state of the entity.
+     * @returns Whether the entity is enabled.
+     */
+    get enabled() {
+        return this._enabled;
+    }
+
+    /**
+     * Sets the name of the entity.
+     * @param value - The name of the entity.
+     */
+    set name(value) {
+        this._name = value;
+        if (this.entity) {
+            this.entity.name = value;
+        }
+    }
+
+    /**
+     * Gets the name of the entity.
+     * @returns The name of the entity.
+     */
+    get name() {
+        return this._name;
+    }
+
+    /**
+     * Sets the position of the entity.
+     * @param value - The position of the entity.
+     */
+    set position(value) {
+        this._position = value;
+        if (this.entity) {
+            this.entity.setLocalPosition(this._position);
+        }
+    }
+
+    /**
+     * Gets the position of the entity.
+     * @returns The position of the entity.
+     */
+    get position() {
+        return this._position;
+    }
+
+    /**
+     * Sets the rotation of the entity.
+     * @param value - The rotation of the entity.
+     */
+    set rotation(value) {
+        this._rotation = value;
+        if (this.entity) {
+            this.entity.setLocalEulerAngles(this._rotation);
+        }
+    }
+
+    /**
+     * Gets the rotation of the entity.
+     * @returns The rotation of the entity.
+     */
+    get rotation() {
+        return this._rotation;
+    }
+
+    /**
+     * Sets the scale of the entity.
+     * @param value - The scale of the entity.
+     */
+    set scale(value) {
+        this._scale = value;
+        if (this.entity) {
+            this.entity.setLocalScale(this._scale);
+        }
+    }
+
+    /**
+     * Gets the scale of the entity.
+     * @returns The scale of the entity.
+     */
+    get scale() {
+        return this._scale;
+    }
+
+    /**
+     * Sets the tags of the entity.
+     * @param value - The tags of the entity.
+     */
+    set tags(value) {
+        this._tags = value;
+        if (this.entity) {
+            this.entity.tags.clear();
+            this.entity.tags.add(this._tags);
+        }
+    }
+
+    /**
+     * Gets the tags of the entity.
+     * @returns The tags of the entity.
+     */
+    get tags() {
+        return this._tags;
+    }
+}
+
+export { EntityOwnerElement };

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -1,35 +1,8 @@
-import type { AppBase } from 'playcanvas';
-import { Entity, Vec3 } from 'playcanvas';
+import { Vec3 } from 'playcanvas';
 
-import { EntityBaseElement, POINTER_ATTRIBUTES } from './entity-base';
+import { POINTER_ATTRIBUTES } from './entity-base';
+import { buildDescendantEntities, EntityOwnerElement } from './entity-owner';
 import { parseBool, parseTags, parseVec3 } from './parse';
-
-/**
- * Creates and parents the entities of every descendant `<pc-entity>` of `root`, in two passes so
- * that no parent's existence depends on document order. Called wherever a subtree could not build
- * itself: an element inserted into an application that is already running, and a `<pc-node>` whose
- * children waited for it to bind.
- *
- * Descendants that are not yet custom elements are skipped, because there is nothing useful to do
- * for them and reaching for `_createEntity` would throw. A subtree cloned from a `<template>`
- * arrives entirely unupgraded — template content lives in an inert document, where custom element
- * definitions are never looked up — and appending the clone upgrades its elements in tree order,
- * an element before its descendants. So a sweep from an element's own `connectedCallback` sees
- * plain `HTMLElement`s below it. Each becomes an `EntityElement` moments later and its own
- * `connectedCallback` creates and parents it, by which time the ancestor it parents under has its
- * entity — the same guarantee tree order gives this sweep.
- *
- * @param root - The element whose descendant entities to build.
- * @param app - The application to create the entities in.
- * @internal
- */
-export const buildDescendantEntities = (root: Element, app: AppBase) => {
-    const children = Array.from(root.querySelectorAll('pc-entity')).filter(
-        (child): child is EntityElement => child instanceof EntityElement
-    );
-    children.forEach((child) => child._createEntity(app));
-    children.forEach((child) => child._buildHierarchy(app));
-};
 
 /**
  * The EntityElement interface provides properties and methods for manipulating
@@ -42,6 +15,12 @@ export const buildDescendantEntities = (root: Element, app: AppBase) => {
  * them, registered either with {@link addEventListener} or with the matching inline `onpointer*`
  * attribute.
  *
+ * @attribute {boolean} enabled - The enabled state of the entity.
+ * @attribute {string} name - The name of the entity.
+ * @attribute {string} position - The position of the entity.
+ * @attribute {string} rotation - The rotation of the entity.
+ * @attribute {string} scale - The scale of the entity.
+ * @attribute {string} tags - The tags of the entity.
  * @attribute {string} onpointerenter - Script to run when the pointer moves onto the entity.
  * @attribute {string} onpointerleave - Script to run when the pointer moves off the entity.
  * @attribute {string} onpointermove - Script to run when the pointer moves over the entity.
@@ -55,129 +34,7 @@ export const buildDescendantEntities = (root: Element, app: AppBase) => {
  * @fires {PointerEvent} pointerdown - Fired when a pointer button is pressed over the entity.
  * @fires {PointerEvent} pointerup - Fired when a pointer button is released over the entity.
  */
-class EntityElement extends EntityBaseElement {
-    /**
-     * Whether the entity is enabled.
-     */
-    private _enabled = true;
-
-    /**
-     * The name of the entity.
-     */
-    private _name = 'Untitled';
-
-    /**
-     * The position of the entity.
-     */
-    private _position = new Vec3();
-
-    /**
-     * The rotation of the entity.
-     */
-    private _rotation = new Vec3();
-
-    /**
-     * The scale of the entity.
-     */
-    private _scale = new Vec3(1, 1, 1);
-
-    /**
-     * The tags of the entity.
-     */
-    private _tags: string[] = [];
-
-    /**
-     * Whether the hierarchy has been built for this entity.
-     */
-    private _built = false;
-
-    /**
-     * Creates the backing entity. Called by the containing `<pc-app>` element during its boot
-     * sweep, and on connection for elements inserted while the application is already running.
-     *
-     * @param app - The application to create the entity in.
-     * @internal
-     */
-    _createEntity(app: AppBase) {
-        // Guard against double creation. When a subtree is inserted at runtime (e.g. cloning a
-        // `<template>`), an ancestor's connectedCallback eagerly creates descendant entities; the
-        // descendants' own connectedCallbacks would otherwise create them a second time.
-        if (this._entity) {
-            return;
-        }
-
-        // Seed from the cached fields rather than re-reading the attributes. Every observed
-        // attribute is routed through its property setter by attributeChangedCallback, so the field
-        // already holds the parsed attribute value - and it also holds anything assigned through the
-        // property API before the app booted, which reading the attribute back would discard.
-        const entity = new Entity(this._name, app);
-        this._entity = entity;
-
-        entity.enabled = this._enabled;
-        entity.setLocalPosition(this._position);
-        entity.setLocalEulerAngles(this._rotation);
-        entity.setLocalScale(this._scale);
-
-        if (this._tags.length > 0) {
-            entity.tags.add(this._tags);
-        }
-
-        // Register with the owning application and hook the entity's destruction. The engine
-        // fires 'destroy' for every entity in a destroyed subtree, so the element learns of its
-        // entity's death no matter who causes it: this element, an ancestor, the whole
-        // application, or a user script calling entity.destroy().
-        this._registerEntity(entity);
-        entity.once('destroy', this._onEntityDestroy, this);
-    }
-
-    /**
-     * Handles the destruction of the backing entity. Resets the element so a later re-insertion
-     * starts clean: `_built` must be cleared alongside `_entity`, or _buildHierarchy would bail
-     * and a re-created entity would never be parented. Readiness is re-armed for the same
-     * reason — with the entity gone, a resolved ready promise would resume its awaiters against
-     * a null `entity`.
-     *
-     * @param entity - The entity that was destroyed.
-     */
-    private _onEntityDestroy(entity: Entity) {
-        this._unregisterEntity(entity);
-        this._entity = null;
-        this._built = false;
-        this._resetReady();
-    }
-
-    /**
-     * Parents the backing entity: under the entity of the nearest ancestor `<pc-entity>` or
-     * `<pc-node>` when there is one, and under the application root otherwise. Called by the
-     * containing `<pc-app>` element once a sweep has created every entity, so a parent's
-     * existence never depends on document order.
-     *
-     * @param app - The application whose root adopts parentless entities.
-     * @internal
-     */
-    _buildHierarchy(app: AppBase) {
-        if (!this.entity || this._built) return;
-
-        const closestEntity = this.closestEntity;
-
-        // A host element without an entity is an unresolved `<pc-node>`: building now would
-        // mis-anchor this entity to the application root while the host is still resolving.
-        // Stay unbuilt - the host drives this subtree itself once it binds.
-        if (closestEntity && !closestEntity.entity) {
-            return;
-        }
-
-        this._built = true;
-
-        if (closestEntity?.entity) {
-            closestEntity.entity.addChild(this.entity);
-        } else {
-            app.root.addChild(this.entity);
-        }
-
-        this._onReady();
-    }
-
+class EntityElement extends EntityOwnerElement {
     connectedCallback() {
         // Wait for app to be ready
         const closestApp = this.closestApp;
@@ -209,121 +66,6 @@ class EntityElement extends EntityBaseElement {
         // element before the descendants' own disconnectedCallbacks run. Their entities are null
         // by then, making this call a no-op for them.
         this._entity?.destroy();
-    }
-
-    /**
-     * Sets the enabled state of the entity.
-     * @param value - Whether the entity is enabled.
-     */
-    set enabled(value) {
-        this._enabled = value;
-        if (this.entity) {
-            this.entity.enabled = value;
-        }
-    }
-
-    /**
-     * Gets the enabled state of the entity.
-     * @returns Whether the entity is enabled.
-     */
-    get enabled() {
-        return this._enabled;
-    }
-
-    /**
-     * Sets the name of the entity.
-     * @param value - The name of the entity.
-     */
-    set name(value) {
-        this._name = value;
-        if (this.entity) {
-            this.entity.name = value;
-        }
-    }
-
-    /**
-     * Gets the name of the entity.
-     * @returns The name of the entity.
-     */
-    get name() {
-        return this._name;
-    }
-
-    /**
-     * Sets the position of the entity.
-     * @param value - The position of the entity.
-     */
-    set position(value) {
-        this._position = value;
-        if (this.entity) {
-            this.entity.setLocalPosition(this._position);
-        }
-    }
-
-    /**
-     * Gets the position of the entity.
-     * @returns The position of the entity.
-     */
-    get position() {
-        return this._position;
-    }
-
-    /**
-     * Sets the rotation of the entity.
-     * @param value - The rotation of the entity.
-     */
-    set rotation(value) {
-        this._rotation = value;
-        if (this.entity) {
-            this.entity.setLocalEulerAngles(this._rotation);
-        }
-    }
-
-    /**
-     * Gets the rotation of the entity.
-     * @returns The rotation of the entity.
-     */
-    get rotation() {
-        return this._rotation;
-    }
-
-    /**
-     * Sets the scale of the entity.
-     * @param value - The scale of the entity.
-     */
-    set scale(value) {
-        this._scale = value;
-        if (this.entity) {
-            this.entity.setLocalScale(this._scale);
-        }
-    }
-
-    /**
-     * Gets the scale of the entity.
-     * @returns The scale of the entity.
-     */
-    get scale() {
-        return this._scale;
-    }
-
-    /**
-     * Sets the tags of the entity.
-     * @param value - The tags of the entity.
-     */
-    set tags(value) {
-        this._tags = value;
-        if (this.entity) {
-            this.entity.tags.clear();
-            this.entity.tags.add(this._tags);
-        }
-    }
-
-    /**
-     * Gets the tags of the entity.
-     * @returns The tags of the entity.
-     */
-    get tags() {
-        return this._tags;
     }
 
     static get observedAttributes() {

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -55,8 +55,11 @@ class EntityElement extends EntityOwnerElement {
             this._createEntity(app);
             this._buildHierarchy(app);
 
-            // Handle any child entities that might exist
-            buildDescendantEntities(this, app);
+            // Handle any child entities that might exist. A build that deferred (an unresolved
+            // pc-node above) defers the whole subtree with it - the node's bind sweeps it.
+            if (this._built) {
+                buildDescendantEntities(this, app);
+            }
         }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,11 +9,12 @@
 
 /* eslint-disable import-x/order */
 
-// Note that order matters here (e.g. pc-entity must be defined before components)
+// Note that order matters here (e.g. pc-entity and pc-model must be defined before components)
 import { AsyncElement, whenReady } from './async-element';
 import { ModuleElement } from './module';
 import { AppElement } from './app';
 import { EntityElement } from './entity';
+import { ModelElement } from './model';
 import { AssetElement } from './asset';
 import { AnimComponentElement } from './components/anim-component';
 import { AnimClipElement } from './components/anim-clip';
@@ -39,8 +40,8 @@ import { SoundComponentElement } from './components/sound-component';
 import { SoundSlotElement } from './components/sound-slot';
 import { GSplatComponentElement } from './components/gsplat-component';
 import { EntityBaseElement } from './entity-base';
+import { EntityOwnerElement } from './entity-owner';
 import { MaterialElement } from './material';
-import { ModelElement } from './model';
 import { NodeElement } from './node';
 import { SceneElement } from './scene';
 import { SkyElement } from './sky';
@@ -124,6 +125,7 @@ export {
     SoundSlotElement,
     GSplatComponentElement,
     EntityBaseElement,
+    EntityOwnerElement,
     MaterialElement,
     ModelElement,
     NodeElement,

--- a/src/model.ts
+++ b/src/model.ts
@@ -263,7 +263,11 @@ class ModelElement extends EntityOwnerElement {
             this._createEntity(app);
             this._buildHierarchy(app);
 
-            buildDescendantEntities(this, app);
+            // A build that deferred (an unresolved pc-node above) defers the whole subtree with
+            // it - the node's bind sweeps it.
+            if (this._built) {
+                buildDescendantEntities(this, app);
+            }
         }
     }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,7 +1,10 @@
 import type { ContainerResource, Entity, EventHandle } from 'playcanvas';
+import { Vec3 } from 'playcanvas';
 
 import { useAsset } from './asset';
-import { AsyncElement } from './async-element';
+import { POINTER_ATTRIBUTES } from './entity-base';
+import { buildDescendantEntities, EntityOwnerElement } from './entity-owner';
+import { parseBool, parseTags, parseVec3 } from './parse';
 
 /**
  * One material assignment of a {@link HierarchyNode} with a render component: a mesh instance's
@@ -104,14 +107,42 @@ const formatHierarchy = (root: HierarchyNode, counts: ReadonlyMap<string, number
  * The ModelElement interface also inherits the properties and methods of the
  * {@link HTMLElement} interface.
  *
- * The element becomes ready once its container asset has loaded and the instantiated hierarchy has
- * been added to the scene — `entity` is non-null by then. A failed load also settles readiness,
- * with `entity` remaining `null`: readiness means the load settled, not that it succeeded — listen
- * for `error`, or check `entity`, to tell the outcomes apart. Changing `asset` re-arms readiness
- * and instantiates anew, so a `ready()` obtained after the change resolves against the new
- * hierarchy. A `pc-model` outside a `pc-app`, or referencing an unknown asset id, warns and never
- * becomes ready.
+ * The element creates and fronts a stable host entity: `entity` is that host, created when the
+ * application builds its hierarchy and kept across `asset` changes, so the element's transform
+ * and tags are instance placement that composes with whatever transform the asset authored on
+ * its root. The instantiated content is parented beneath the host and exposed as
+ * {@link contentEntity}.
  *
+ * The element becomes ready once its current asset selection has settled: the container asset
+ * has loaded and its content root has been parented beneath the host, the load has failed
+ * (`contentEntity` stays `null` — listen for `error`, or check `contentEntity`, to tell the
+ * outcomes apart), or no asset is assigned at all. Changing `asset` re-arms readiness and
+ * instantiates anew, so a `ready()` obtained after the change resolves against the new content.
+ * A `pc-model` outside a `pc-app`, or referencing an unknown asset id, warns and never becomes
+ * ready.
+ *
+ * The pointer events below are dispatched by the containing `<pc-app>` element when the pointer
+ * intersects the model's geometry, exactly as for `<pc-entity>` — a hit on a content node that no
+ * `pc-node` fronts resolves to this element.
+ *
+ * @attribute {boolean} enabled - The enabled state of the model.
+ * @attribute {string} name - The name of the model.
+ * @attribute {string} position - The position of the model.
+ * @attribute {string} rotation - The rotation of the model.
+ * @attribute {string} scale - The scale of the model.
+ * @attribute {string} tags - The tags of the model.
+ * @attribute {string} onpointerenter - Script to run when the pointer moves onto the model.
+ * @attribute {string} onpointerleave - Script to run when the pointer moves off the model.
+ * @attribute {string} onpointermove - Script to run when the pointer moves over the model.
+ * @attribute {string} onpointerdown - Script to run when a pointer button is pressed over the
+ * model.
+ * @attribute {string} onpointerup - Script to run when a pointer button is released over the
+ * model.
+ * @fires {PointerEvent} pointerenter - Fired when the pointer moves onto the model.
+ * @fires {PointerEvent} pointerleave - Fired when the pointer moves off the model.
+ * @fires {PointerEvent} pointermove - Fired when the pointer moves over the model.
+ * @fires {PointerEvent} pointerdown - Fired when a pointer button is pressed over the model.
+ * @fires {PointerEvent} pointerup - Fired when a pointer button is released over the model.
  * @fires {Event} load - Fired each time a container asset finishes instantiating, including
  * re-instantiation after `asset` changes. Does not bubble — listen on this element, or use a
  * capture-phase listener on an ancestor.
@@ -119,16 +150,16 @@ const formatHierarchy = (root: HierarchyNode, counts: ReadonlyMap<string, number
  * error in `message`. Does not bubble. The element still becomes ready — readiness means the load
  * settled, not that it succeeded.
  */
-class ModelElement extends AsyncElement {
+class ModelElement extends EntityOwnerElement {
     private _asset = '';
 
-    private _entity: Entity | null = null;
+    private _contentEntity: Entity | null = null;
 
     /**
-     * Incremented on every new load and on disconnect, and captured by a load when it starts. A
-     * load that resumes from an await or a load callback abandons itself if the value has moved
-     * on, so a superseded load can neither instantiate a second entity nor parent one that has
-     * since been destroyed.
+     * Incremented on every new load, on disconnect, and when the host entity dies, and captured
+     * by a load when it starts. A load that resumes from an await or a load callback abandons
+     * itself if the value has moved on, so a superseded load can neither instantiate a second
+     * content root nor parent one under a host a newer cycle has already replaced.
      */
     private _loadGeneration = 0;
 
@@ -142,12 +173,13 @@ class ModelElement extends AsyncElement {
     private _errorHandle: EventHandle | null = null;
 
     /**
-     * The root entity of the instantiated model. `null` until the container asset has loaded
-     * and been instantiated, and again once the element has been removed from the document.
-     * @returns The model's root entity, or `null`.
+     * The root entity of the instantiated model content, parented beneath the host entity.
+     * `null` until the container asset has loaded and been instantiated, after a failed load,
+     * and again once the element has been removed from the document.
+     * @returns The content root entity, or `null`.
      */
-    get entity(): Entity | null {
-        return this._entity;
+    get contentEntity(): Entity | null {
+        return this._contentEntity;
     }
 
     /**
@@ -160,12 +192,13 @@ class ModelElement extends AsyncElement {
      * is the printable form.
      *
      * The snapshot is plain data, computed afresh each call: it does not follow later changes
-     * to the hierarchy, and mutating it changes nothing.
+     * to the hierarchy, and mutating it changes nothing. It covers the instantiated content
+     * only — the host entity the element fronts is not part of the asset's node tree.
      *
      * @returns The root of the instantiated node tree, or `null`.
      */
     hierarchy(): HierarchyNode | null {
-        const root = this._entity;
+        const root = this._contentEntity;
         if (!root) {
             return null;
         }
@@ -214,19 +247,55 @@ class ModelElement extends AsyncElement {
         // A model outside an application is inert and never becomes ready, so awaiting it hangs.
         // Warn rather than fail silently, naming the parent it requires, as every other misplaced
         // element does.
-        if (!this.closestApp) {
+        const closestApp = this.closestApp;
+        if (!closestApp) {
             const label = this._asset ? ` '${this._asset}'` : '';
             console.warn(`pc-model${label} must be a descendant of pc-app - model not created`);
             return;
         }
-        this._loadModel();
+
+        // If the app is already running, create the host immediately; during a boot, the app's
+        // own sweep does it. Either way, _onBuilt starts the content load once the host is
+        // parented.
+        if (closestApp._hierarchyReady) {
+            const app = closestApp.app!;
+
+            this._createEntity(app);
+            this._buildHierarchy(app);
+
+            buildDescendantEntities(this, app);
+        }
     }
 
     disconnectedCallback() {
+        // Destroying the host destroys the instantiated content with it, and the destroy hook
+        // resets the element. The generation guard comes first so a load suspended on an await
+        // cannot resume against the torn-down element.
         this._loadGeneration++;
         this._detachLoadHandlers();
-        this._unloadModel();
-        this._resetReady();
+        this._entity?.destroy();
+    }
+
+    /**
+     * Starts (or restarts) the content load once the host has been parented. Readiness is not
+     * announced here — it tracks the content settling, not the host entering the scene graph.
+     */
+    protected override _onBuilt() {
+        this._loadContent();
+    }
+
+    /**
+     * Extends the owner reset for the content: the engine's destroy cascade has already taken
+     * the content root down with the host subtree, so only the reference and the in-flight load
+     * are dropped here. The next build re-creates the host and re-instantiates the content.
+     *
+     * @param entity - The host entity that was destroyed.
+     */
+    protected override _onEntityDestroy(entity: Entity) {
+        this._loadGeneration++;
+        this._detachLoadHandlers();
+        this._contentEntity = null;
+        super._onEntityDestroy(entity);
     }
 
     private _detachLoadHandlers() {
@@ -237,9 +306,9 @@ class ModelElement extends AsyncElement {
     }
 
     /**
-     * Resolves readiness and dispatches the `load` event. Called once the instantiated hierarchy
-     * has been parented — readiness means "in the scene graph", matching `pc-entity`, so a ready
-     * model's entity always has world transforms.
+     * Resolves readiness and dispatches the `load` event. Called once the instantiated content
+     * has been parented beneath the host — the host itself is already in the scene graph by
+     * then, so a ready model's content always has world transforms.
      */
     private _announceLoad() {
         this._onReady();
@@ -247,46 +316,29 @@ class ModelElement extends AsyncElement {
     }
 
     private _instantiate(container: ContainerResource) {
-        const generation = this._loadGeneration;
-
-        const entity = container.instantiateRenderEntity();
-        this._entity = entity;
-
-        // The parent's readiness re-arms when it is torn down, so these can resume in a later
-        // connection cycle. The entity is captured above and the generation re-checked, so a
-        // stale resume cannot parent an entity a newer cycle has already destroyed.
-        const parentEntityElement = this.closestEntity;
-        if (parentEntityElement) {
-            parentEntityElement.ready().then(() => {
-                if (generation !== this._loadGeneration) {
-                    return;
-                }
-                parentEntityElement.entity!.addChild(entity);
-                this._announceLoad();
-            });
-        } else {
-            const appElement = this.closestApp;
-            if (appElement) {
-                appElement.ready().then(() => {
-                    if (generation !== this._loadGeneration) {
-                        return;
-                    }
-                    appElement.app!.root.addChild(entity);
-                    this._announceLoad();
-                });
-            }
-        }
+        const content = container.instantiateRenderEntity();
+        this._contentEntity = content;
+        this._entity!.addChild(content);
+        this._announceLoad();
     }
 
-    private async _loadModel() {
-        this._unloadModel();
+    private _destroyContent() {
+        this._contentEntity?.destroy();
+        this._contentEntity = null;
+    }
+
+    private async _loadContent() {
+        // The old content goes down synchronously, so a reader that checks after an asset change
+        // never sees the outgoing hierarchy. The host survives - components and child entities
+        // attached to it carry over to the new content.
+        this._destroyContent();
 
         // Supersede any load already in flight - only the newest load may instantiate
         const generation = ++this._loadGeneration;
         this._detachLoadHandlers();
 
         // Re-arm readiness so a waiter obtained after an asset change resolves against the new
-        // hierarchy. A no-op on first connection, where readiness is still pending.
+        // content. A no-op on first connection, where readiness is still pending.
         this._resetReady();
 
         const appElement = this.closestApp;
@@ -302,14 +354,25 @@ class ModelElement extends AsyncElement {
             return;
         }
 
+        // The host may not be parented yet - a model under a pc-node that has not bound, reached
+        // through the asset setter. Nothing settles here: _onBuilt re-runs this load once the
+        // host builds.
+        if (!this._entity || !this._built) {
+            return;
+        }
+
+        if (this._asset === '') {
+            // No asset assigned is a settled selection: the element is a usable host (components
+            // attach, waiters resolve) with no content. Assigning an asset later re-arms.
+            this._onReady();
+            return;
+        }
+
         const asset = useAsset(this._asset);
         if (!asset) {
-            // An empty id is a legitimate transient (the asset may be assigned later); a
-            // non-empty one that resolves to nothing is a dead end - say so rather than staying
+            // A non-empty id that resolves to nothing is a dead end - say so rather than staying
             // silently pending.
-            if (this._asset) {
-                console.warn(`pc-model could not find asset '${this._asset}' - model not created`);
-            }
+            console.warn(`pc-model could not find asset '${this._asset}' - model not created`);
             return;
         }
 
@@ -331,7 +394,7 @@ class ModelElement extends AsyncElement {
                 if (generation !== this._loadGeneration) {
                     return;
                 }
-                // A failed load settles readiness with a null entity, mirroring pc-asset:
+                // A failed load settles readiness with a null contentEntity, mirroring pc-asset:
                 // readiness means the load settled, not that it succeeded.
                 this.dispatchEvent(
                     new ErrorEvent('error', {
@@ -343,11 +406,6 @@ class ModelElement extends AsyncElement {
         }
     }
 
-    private _unloadModel() {
-        this._entity?.destroy();
-        this._entity = null;
-    }
-
     /**
      * Sets the id of the `pc-asset` to use for the model.
      * @param value - The asset ID.
@@ -355,7 +413,7 @@ class ModelElement extends AsyncElement {
     set asset(value: string) {
         this._asset = value;
         if (this.isConnected) {
-            this._loadModel();
+            this._loadContent();
         }
     }
 
@@ -368,13 +426,38 @@ class ModelElement extends AsyncElement {
     }
 
     static get observedAttributes() {
-        return ['asset'];
+        return ['asset', 'enabled', 'name', 'position', 'rotation', 'scale', 'tags', ...POINTER_ATTRIBUTES];
     }
 
     attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         switch (name) {
             case 'asset':
                 this.asset = newValue ?? '';
+                break;
+            case 'enabled':
+                this.enabled = parseBool(newValue, true);
+                break;
+            case 'name':
+                this.name = newValue ?? 'Untitled';
+                break;
+            case 'position':
+                this.position = parseVec3(newValue, Vec3.ZERO, name);
+                break;
+            case 'rotation':
+                this.rotation = parseVec3(newValue, Vec3.ZERO, name);
+                break;
+            case 'scale':
+                this.scale = parseVec3(newValue, Vec3.ONE, name);
+                break;
+            case 'tags':
+                this.tags = parseTags(newValue);
+                break;
+            case 'onpointerenter':
+            case 'onpointerleave':
+            case 'onpointerdown':
+            case 'onpointerup':
+            case 'onpointermove':
+                this._updateInlineHandler(name, newValue);
                 break;
         }
     }

--- a/src/node.ts
+++ b/src/node.ts
@@ -2,9 +2,9 @@ import type { Entity, EventHandle, GraphNode, Material, MeshInstance, Quat, Rend
 import { Vec3 } from 'playcanvas';
 
 import { ComponentElement } from './components/component';
-import { buildDescendantEntities } from './entity';
-import type { EntityElement } from './entity';
 import { EntityBaseElement, POINTER_ATTRIBUTES } from './entity-base';
+import { buildDescendantEntities } from './entity-owner';
+import type { EntityOwnerElement } from './entity-owner';
 import { MaterialElement } from './material';
 import { ModelElement } from './model';
 import { parseBool, parseTags, parseVec3 } from './parse';
@@ -318,7 +318,10 @@ class NodeElement extends EntityBaseElement {
      * is retained untouched — a redundant edit must not flicker overrides through a revert.
      */
     private _rebind() {
-        const hostEntity = this._host?.entity ?? null;
+        // A model fronts a host entity of its own; the names this element resolves are the
+        // asset's, so the search starts at the instantiated content root, not the wrapper.
+        const host = this._host;
+        const hostEntity = (host instanceof ModelElement ? host.contentEntity : host?.entity) ?? null;
 
         if (!hostEntity || !this._name) {
             // Host not instantiated (or nothing to look up yet): return to pending. An assigned
@@ -435,8 +438,9 @@ class NodeElement extends EntityBaseElement {
         this._revertOverrides();
 
         // Attachment points anchor to the bound node, so they cannot outlive the binding. Each
-        // destroyed entity resets its element, which the next _buildChildren re-creates.
-        this.querySelectorAll<EntityElement>('pc-entity').forEach((child) => {
+        // destroyed entity resets its element, which the next _buildChildren re-creates - a
+        // model host among them re-instantiates its content when it rebuilds.
+        this.querySelectorAll<EntityOwnerElement>('pc-entity, pc-model').forEach((child) => {
             if (child.closestEntity === this) {
                 child.entity?.destroy();
             }

--- a/test/elements/attribute-removal.test.ts
+++ b/test/elements/attribute-removal.test.ts
@@ -47,9 +47,11 @@ describe('attribute removal', () => {
         ['pc-model', 'asset', 'asset', ''],
         ['pc-sky', 'asset', 'asset', ''],
 
-        // The odd one out: pc-entity's backing field starts at the engine's default entity name,
-        // so restoring '' would leave a nameless entity that no name lookup could find.
-        ['pc-entity', 'name', 'name', 'Untitled']
+        // The odd ones out: the entity-owning elements' backing fields start at the engine's
+        // default entity name, so restoring '' would leave a nameless entity that no name lookup
+        // could find.
+        ['pc-entity', 'name', 'name', 'Untitled'],
+        ['pc-model', 'name', 'name', 'Untitled']
     ];
 
     it.for(cases)('%s[%s] restores its default on removal', ([tag, attribute, property, restored]) => {
@@ -69,6 +71,6 @@ describe('attribute removal', () => {
     it('covers every unparsed string attribute in the library', () => {
         // If a new `this.x = newValue ?? ''` branch is added without a case above, this fails.
         // Counted rather than enumerated, so it stays a one-line update rather than a second table.
-        expect(cases).toHaveLength(26);
+        expect(cases).toHaveLength(27);
     });
 });

--- a/test/elements/model.test.ts
+++ b/test/elements/model.test.ts
@@ -1,0 +1,92 @@
+import { Vec3 } from 'playcanvas';
+import { describe, expect, it } from 'vitest';
+
+import type { ModelElement } from '../../src/model';
+import { useGuard } from '../helpers/guard';
+
+/**
+ * Element-level behaviour, with no <pc-app> and therefore no engine. Every setter caches to a
+ * private field and only writes through when the host entity exists, so attribute handling is
+ * fully observable on a disconnected element. The host-entity attributes mirror <pc-entity>'s;
+ * the cases here pin that the shared machinery really is wired into this element.
+ */
+describe('<pc-model>', () => {
+    const { warnings } = useGuard();
+
+    const create = () => document.createElement('pc-model') as ModelElement;
+
+    describe('[asset]', () => {
+        it('caches an assignment made while disconnected', () => {
+            const element = create();
+            element.asset = 'm';
+            expect(element.asset).toBe('m');
+            expect(element.contentEntity, 'no engine, so nothing instantiates').toBeNull();
+        });
+    });
+
+    describe('[enabled]', () => {
+        it('parses the attribute and restores the default on removal', () => {
+            const element = create();
+            element.setAttribute('enabled', 'false');
+            expect(element.enabled).toBe(false);
+
+            element.removeAttribute('enabled');
+            expect(element.enabled).toBe(true);
+        });
+    });
+
+    describe('[name]', () => {
+        it('restores the default entity name on removal', () => {
+            const element = create();
+            expect(element.name).toBe('Untitled');
+
+            element.setAttribute('name', 'prop');
+            expect(element.name).toBe('prop');
+
+            element.removeAttribute('name');
+            expect(element.name).toBe('Untitled');
+        });
+    });
+
+    describe('[position]', () => {
+        it('round-trips a valid value and restores the default on removal', () => {
+            const element = create();
+            element.setAttribute('position', '1 2 3');
+            expect(element.position).toEqual(new Vec3(1, 2, 3));
+
+            element.removeAttribute('position');
+            expect(element.position).toEqual(Vec3.ZERO);
+        });
+
+        it('warns and falls back for a malformed value', () => {
+            const element = create();
+            element.setAttribute('position', '1 2');
+            expect(element.position).toEqual(Vec3.ZERO);
+            warnings.expect("Invalid value '1 2' for attribute 'position'. Expected 3 space-separated numbers.");
+        });
+    });
+
+    describe('[scale]', () => {
+        it('defaults to one rather than zero', () => {
+            const element = create();
+            expect(element.scale).toEqual(Vec3.ONE);
+
+            element.setAttribute('scale', '2 2 2');
+            expect(element.scale).toEqual(new Vec3(2, 2, 2));
+
+            element.removeAttribute('scale');
+            expect(element.scale).toEqual(Vec3.ONE);
+        });
+    });
+
+    describe('[tags]', () => {
+        it('parses a comma-separated list and restores the default on removal', () => {
+            const element = create();
+            element.setAttribute('tags', 'alpha, beta ,gamma');
+            expect(element.tags).toEqual(['alpha', 'beta', 'gamma']);
+
+            expect(() => element.removeAttribute('tags')).not.toThrow();
+            expect(element.tags).toEqual([]);
+        });
+    });
+});

--- a/test/elements/registration.test.ts
+++ b/test/elements/registration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { AsyncElement, ComponentElement } from '../../src/index';
-import { COMPONENT_TAGS, READY_TAGS, TAGS } from '../helpers/tags';
+import { AsyncElement, ComponentElement, EntityBaseElement } from '../../src/index';
+import { COMPONENT_TAGS, ENTITY_TAGS, READY_TAGS, TAGS } from '../helpers/tags';
 
 /**
  * The runtime twin of validate.mjs's manifest checks. It catches a case the manifest cannot see: an
@@ -33,6 +33,16 @@ describe('customElements registration', () => {
 
     it.for(COMPONENT_TAGS)('%s extends ComponentElement', (tag) => {
         expect(document.createElement(tag)).toBeInstanceOf(ComponentElement);
+    });
+
+    it.for(ENTITY_TAGS)('%s extends EntityBaseElement, so it fronts an entity', (tag) => {
+        expect(document.createElement(tag)).toBeInstanceOf(EntityBaseElement);
+    });
+
+    it.for(ENTITY_TAGS)('%s observes the onpointer* attributes', (tag) => {
+        const observed = (customElements.get(tag) as unknown as { observedAttributes?: string[] })?.observedAttributes;
+        expect(observed).toContain('onpointerdown');
+        expect(observed).toContain('onpointerenter');
     });
 
     it.for(COMPONENT_TAGS)('%s inherits the enabled attribute from ComponentElement', (tag) => {

--- a/test/helpers/tags.ts
+++ b/test/helpers/tags.ts
@@ -7,4 +7,4 @@
  * for a `.mts` specifier, which would not exist at runtime - hence the single exception here rather
  * than one at every call site.
  */
-export { COMPONENT_TAGS, READY_TAGS, TAGS } from '../../utils/cem/tags.mjs';
+export { COMPONENT_TAGS, ENTITY_TAGS, READY_TAGS, TAGS } from '../../utils/cem/tags.mjs';

--- a/test/integration/components/anim-component.test.ts
+++ b/test/integration/components/anim-component.test.ts
@@ -256,6 +256,51 @@ describe('<pc-anim>', () => {
             expect(bonePosition(app).x).toBeGreaterThan(0);
         });
 
+        it('clears the managed binding root when a second model makes the skeleton ambiguous', async () => {
+            const { get } = await bootApp(`
+                ${WALK_RUN_IDLE}
+                <pc-asset id="m2" type="container" src="${animatedSrc('Jump')}"></pc-asset>
+                <pc-entity name="holder">
+                    <pc-model asset="m"></pc-model>
+                    <pc-anim>
+                        <pc-anim-clip name="Run" asset="m"></pc-anim-clip>
+                    </pc-anim>
+                </pc-entity>
+            `);
+            const anim = get<AnimComponentElement>('pc-anim');
+            const model = get<ModelElement>('pc-model');
+            expect(anim.component.rootBone, 'the sole sibling model pins the root').toBe(model.entity);
+
+            // A second sibling model leaves no single skeleton to pin - the stale pin must not
+            // survive, or curves would keep binding against whichever model happened to be first.
+            const second = document.createElement('pc-model');
+            second.setAttribute('asset', 'm2');
+            model.parentElement!.appendChild(second);
+            await readyWithin(second);
+
+            expect(anim.component.rootBone, 'the ambiguous source clears the pin').toBeNull();
+        });
+
+        it('leaves a binding root assigned through the engine API alone', async () => {
+            const { app, get } = await bootApp(`
+                ${WALK_RUN_IDLE}
+                <pc-asset id="m2" type="container" src="${animatedSrc('Jump')}"></pc-asset>
+                <pc-entity name="holder"><pc-model asset="m"><pc-anim></pc-anim></pc-model></pc-entity>
+            `);
+            const anim = get<AnimComponentElement>('pc-anim');
+            const model = get<ModelElement>('pc-model');
+            await vi.waitFor(() => expect(anim.clips).toEqual(['Walk', 'Run', 'Idle']));
+            expect(anim.component.rootBone).toBe(model.entity);
+
+            const custom = app.root.findByName('holder') as Entity;
+            anim.component.rootBone = custom;
+
+            model.setAttribute('asset', 'm2');
+            await vi.waitFor(() => expect(anim.clips).toEqual(['Jump']));
+
+            expect(anim.component.rootBone, "the user's choice outranks the managed default").toBe(custom);
+        });
+
         it('resolves animation and animclip typed assets', async () => {
             // A data: URI cannot reach the engine's GLB animation parser (it keys off the .glb
             // extension), so the multi-track 'animation' shape is produced directly: a lazy

--- a/test/integration/entity-map.test.ts
+++ b/test/integration/entity-map.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type { EntityElement } from '../../src/entity';
 import { bootApp } from '../helpers/app';
 import { useGuard } from '../helpers/guard';
+import { readyWithin } from '../helpers/ready';
 
 /**
  * A macrotask turn, so disconnect callbacks and suspended awaits run to completion.
@@ -13,6 +14,16 @@ const settleTask = () =>
     new Promise((resolve) => {
         setTimeout(resolve, 0);
     });
+
+/** The smallest valid glTF, for the pc-model host registration cases. Loads from a data: URI. */
+const MODEL_ASSET_TAG = `<pc-asset id="map-m" type="container" src="data:application/json,${encodeURIComponent(
+    JSON.stringify({
+        asset: { version: '2.0' },
+        scene: 0,
+        scenes: [{ nodes: [0] }],
+        nodes: [{ name: 'map-root' }]
+    })
+)}"></pc-asset>`;
 
 /**
  * The entity map is what joins engine scene nodes back to their owning elements by identity.
@@ -84,6 +95,46 @@ describe('pc-app entity map', () => {
         expect(fresh, 'a fresh entity was created').not.toBeNull();
         expect(fresh).not.toBe(oldEntity);
         expect(appElement.elementFromEntity(fresh!)).toBe(parentElement);
+        expect(uncaught.seen).toEqual([]);
+    });
+
+    it('registers a pc-model host, never its instantiated content', async () => {
+        const { appElement, get } = await bootApp(`${MODEL_ASSET_TAG}<pc-model asset="map-m"></pc-model>`);
+        const model = get('pc-model');
+
+        expect(appElement.elementFromEntity(model.entity!), 'the host resolves to the element').toBe(model);
+        expect(appElement.elementFromEntity(model.contentEntity!),
+            'content nodes stay unregistered, so picks fall through to the host').toBeNull();
+    });
+
+    it('resets a pc-model when a user script destroys its host', async () => {
+        const { appElement, get } = await bootApp(`${MODEL_ASSET_TAG}<pc-model asset="map-m"></pc-model>`);
+        const model = get('pc-model');
+        const host = model.entity!;
+
+        host.destroy();
+
+        expect(appElement.elementFromEntity(host)).toBeNull();
+        expect(model.entity, 'the element no longer references the destroyed host').toBeNull();
+        expect(model.contentEntity, 'the content died with the host subtree').toBeNull();
+    });
+
+    it('registers a fresh host when a pc-model is removed and re-added', async () => {
+        const { appElement, get } = await bootApp(`${MODEL_ASSET_TAG}<pc-model asset="map-m"></pc-model>`);
+        const model = get('pc-model');
+        const container = model.parentElement!;
+        const oldHost = model.entity!;
+
+        model.remove();
+        await settleTask();
+        expect(appElement.elementFromEntity(oldHost), 'the destroyed host is unregistered').toBeNull();
+
+        container.appendChild(model);
+        await readyWithin(model);
+
+        expect(model.entity, 'a fresh host was created').not.toBe(oldHost);
+        expect(appElement.elementFromEntity(model.entity!)).toBe(model);
+        expect(model.contentEntity!.parent, 'the content was re-instantiated beneath it').toBe(model.entity);
         expect(uncaught.seen).toEqual([]);
     });
 });

--- a/test/integration/hierarchy.test.ts
+++ b/test/integration/hierarchy.test.ts
@@ -209,7 +209,7 @@ describe('<pc-model> hierarchy()', () => {
         const { model } = await bootCar();
         expect(model.hierarchy()!.components).toEqual([]);
 
-        model.entity!.addComponent('camera');
+        model.contentEntity!.addComponent('camera');
 
         expect(model.hierarchy()!.components, 'a fresh snapshot sees the new component').toEqual(['camera']);
         expect(uncaught.seen).toEqual([]);
@@ -261,7 +261,7 @@ describe('<pc-model> hierarchy()', () => {
     it('reads the material assignments at call time', async () => {
         const { get } = await bootApp(`${ASSETS}<pc-model asset="body"></pc-model>`);
         const model = get<ModelElement>('pc-model');
-        const meshInstances = model.entity!.render!.meshInstances;
+        const meshInstances = model.contentEntity!.render!.meshInstances;
 
         const replacement = new StandardMaterial();
         replacement.name = 'Resprayed';

--- a/test/integration/lifecycle.test.ts
+++ b/test/integration/lifecycle.test.ts
@@ -9,6 +9,16 @@ import { mount } from '../helpers/dom';
 import { useGuard } from '../helpers/guard';
 import { expectNeverReady, readyWithin } from '../helpers/ready';
 
+/** The smallest valid glTF, for the pc-model re-boot case. Loads from a data: URI. */
+const MODEL_ASSET_TAG = `<pc-asset id="reboot-m" type="container" src="data:application/json,${encodeURIComponent(
+    JSON.stringify({
+        asset: { version: '2.0' },
+        scene: 0,
+        scenes: [{ nodes: [0] }],
+        nodes: [{ name: 'reboot-root' }]
+    })
+)}"></pc-asset>`;
+
 /**
  * <pc-app> boot and teardown state. Removing the element must return it - and everything that
  * keyed off its readiness - to the pre-boot state, so that re-inserting it boots afresh, and so
@@ -138,11 +148,13 @@ describe('<pc-app> lifecycle', () => {
 
     it('re-boots a removed pc-app when it is re-added within the same task', async () => {
         const handle = await bootApp(`
+            ${MODEL_ASSET_TAG}
             <pc-scene fog="linear"></pc-scene>
             <pc-entity name="e">
                 <pc-camera></pc-camera>
                 <pc-sounds><pc-sound name="blip"></pc-sound></pc-sounds>
             </pc-entity>
+            <pc-model asset="reboot-m"></pc-model>
         `);
         const { appElement, app: firstApp, container, get } = handle;
 
@@ -180,6 +192,14 @@ describe('<pc-app> lifecycle', () => {
 
         const soundsComponent = (get('pc-sounds') as { component?: { slots: Record<string, unknown> } }).component;
         expect(Object.keys(soundsComponent!.slots), 'the sound slot is back').toContain('blip');
+
+        // ...the model's host was recreated in the new application, re-registered, and its
+        // content re-instantiated beneath it...
+        const modelElement = get('pc-model');
+        expect(modelElement.entity, 'the model host is back').toBeTruthy();
+        expect(modelElement.entity!.parent).toBe(app!.root);
+        expect(appElement.elementFromEntity(modelElement.entity!), 'and re-registered').toBe(modelElement);
+        expect(modelElement.contentEntity!.parent, 'with re-instantiated content').toBe(modelElement.entity);
 
         // ...and the scene element announced the new scene, with its settings re-applied.
         const sceneElement = get<SceneElement>('pc-scene');

--- a/test/integration/material-overrides.test.ts
+++ b/test/integration/material-overrides.test.ts
@@ -108,7 +108,7 @@ describe('<pc-node> material-overrides', () => {
             smokedGlass: booted.get<MaterialElement>('pc-material[id="smoked-glass"]').material!
         };
         /** The body render component's mesh instances, read fresh from the current hierarchy. */
-        const meshInstances = () => model.entity!.render!.meshInstances;
+        const meshInstances = () => model.contentEntity!.render!.meshInstances;
         return { ...booted, model, node, replacements, meshInstances };
     };
 
@@ -358,7 +358,7 @@ describe('<pc-node> material-overrides', () => {
                 'candy-red'
             );
             expect(decoration.isConnected).toBe(true);
-            expect(booted.get<ModelElement>('pc-model').entity).toBeTruthy();
+            expect(booted.get<ModelElement>('pc-model').contentEntity).toBeTruthy();
             expect(uncaught.seen).toEqual([]);
         });
 

--- a/test/integration/model.test.ts
+++ b/test/integration/model.test.ts
@@ -1,3 +1,4 @@
+import { Vec3 } from 'playcanvas';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { AppElement } from '../../src/app';
@@ -36,9 +37,9 @@ describe('<pc-model>', () => {
     });
 
     it('abandons a load whose element is removed while it waits', async () => {
-        // _loadModel parks on the app's ready promise, which is already resolved here - so the
+        // _loadContent parks on the app's ready promise, which is already resolved here - so the
         // load resumes one microtask after connect. A same-task removal lands in that window,
-        // and the resumed load must not instantiate an entity for an element that is gone.
+        // and the resumed load must not instantiate content for an element that is gone.
         const { appElement, get } = await bootApp(ASSET_TAG);
 
         expect(get('pc-asset').asset!.loaded, 'the container asset really loaded').toBe(true);
@@ -50,7 +51,8 @@ describe('<pc-model>', () => {
 
         await settleTask();
 
-        expect(model.entity, 'no entity was instantiated for the removed element').toBeNull();
+        expect(model.entity, 'the host died with the removal').toBeNull();
+        expect(model.contentEntity, 'no content was instantiated for the removed element').toBeNull();
         expect(uncaught.seen).toEqual([]);
     });
 
@@ -76,7 +78,7 @@ describe('<pc-model>', () => {
         await vi.waitFor(() => expect(asset.loaded).toBe(true));
         await settleTask();
 
-        expect(model.entity, 'nothing was instantiated for the removed element').toBeNull();
+        expect(model.contentEntity, 'nothing was instantiated for the removed element').toBeNull();
         expect(uncaught.seen).toEqual([]);
     });
 
@@ -119,12 +121,12 @@ describe('<pc-model>', () => {
         appElement.app!.autoRender = false;
 
         expect(instantiations, 'the superseded load did not instantiate').toBe(1);
-        expect(handle.get('pc-model').entity, 'the surviving load produced the entity').toBeTruthy();
+        expect(handle.get('pc-model').contentEntity, 'the surviving load produced the content').toBeTruthy();
         expect(uncaught.seen).toEqual([]);
     });
 
     describe('readiness', () => {
-        it('resolves ready only once the model is instantiated and parented', async () => {
+        it('resolves ready only once the content is instantiated and parented', async () => {
             const { appElement } = await bootApp(ASSET_TAG.replace('>', ' lazy>'));
 
             const model = document.createElement('pc-model');
@@ -136,29 +138,36 @@ describe('<pc-model>', () => {
                 ready = true;
             });
 
+            // The host exists from the moment of connection - readiness tracks the content, not
+            // the host entering the scene graph.
+            expect(model.entity, 'the host is created on connection').not.toBeNull();
+
             // Let the connect continuations run: the app-ready resume on the first hop, the asset
             // subscription on the second. The data: fetch needs a macrotask, so the load cannot
             // have completed yet.
             await Promise.resolve();
             await Promise.resolve();
             expect(ready, 'not ready before the asset has loaded').toBe(false);
-            expect(model.entity, 'no entity before the asset has loaded').toBeNull();
+            expect(model.contentEntity, 'no content before the asset has loaded').toBeNull();
 
             await readyWithin(model);
-            expect(model.entity, 'ready implies an instantiated entity').not.toBeNull();
-            expect(model.entity!.parent, 'ready implies the entity is parented').toBe(appElement.app!.root);
+            expect(model.contentEntity, 'ready implies instantiated content').not.toBeNull();
+            expect(model.contentEntity!.parent, 'ready implies the content is parented beneath the host').toBe(model.entity);
+            expect(model.entity!.parent, 'the host is parented under the application root').toBe(appElement.app!.root);
             expect(uncaught.seen).toEqual([]);
         });
 
-        it('stays pending without warning while no asset is assigned', async () => {
+        it('becomes ready with no content while no asset is assigned', async () => {
             const { appElement } = await bootApp();
 
             const model = document.createElement('pc-model');
             appElement.appendChild(model);
 
-            // An unassigned asset is a legitimate transient (the property may be set later), so
-            // the element waits silently - the guard fails this test if anything warns.
-            await expectNeverReady(model);
+            // An empty selection is settled: the element is a usable host with nothing to load.
+            // No warning either - the guard fails this test if anything warns.
+            await readyWithin(model);
+            expect(model.entity, 'the host exists without an asset').not.toBeNull();
+            expect(model.contentEntity, 'there is no content to instantiate').toBeNull();
         });
 
         it('warns and never becomes ready when no asset matches the id', async () => {
@@ -187,17 +196,17 @@ describe('<pc-model>', () => {
 
             const model = document.createElement('pc-model');
             model.setAttribute('asset', 'm');
-            const seen: { entity: unknown; bubbles: boolean }[] = [];
+            const seen: { content: unknown; bubbles: boolean }[] = [];
             model.addEventListener('load', (event) => {
-                seen.push({ entity: model.entity, bubbles: event.bubbles });
+                seen.push({ content: model.contentEntity, bubbles: event.bubbles });
             });
             appElement.appendChild(model);
 
             await readyWithin(model);
             expect(seen).toHaveLength(1);
-            expect(seen[0].entity, 'the entity is set by the time load fires').toBe(model.entity);
+            expect(seen[0].content, 'the content is set by the time load fires').toBe(model.contentEntity);
             expect(seen[0].bubbles, 'load does not bubble, mirroring pc-asset').toBe(false);
-            expect(model.entity).not.toBeNull();
+            expect(model.contentEntity).not.toBeNull();
             expect(uncaught.seen).toEqual([]);
         });
 
@@ -213,7 +222,8 @@ describe('<pc-model>', () => {
             appElement.appendChild(model);
 
             await readyWithin(model);
-            expect(model.entity, 'readiness means the load settled, not that it succeeded').toBeNull();
+            expect(model.contentEntity, 'readiness means the load settled, not that it succeeded').toBeNull();
+            expect(model.entity, 'the host survives a failed load').not.toBeNull();
             expect(seen).toHaveLength(1);
             expect(seen[0].message, 'the engine error is forwarded').not.toBe('');
             expect(seen[0].bubbles).toBe(false);
@@ -225,11 +235,12 @@ describe('<pc-model>', () => {
     });
 
     describe('[asset]', () => {
-        it('re-instantiates and re-arms readiness when the asset changes', async () => {
+        it('re-instantiates content beneath the surviving host when the asset changes', async () => {
             const { appElement, get } = await bootApp(`${ASSET_TAG}${ASSET_TAG_B}<pc-model asset="m"></pc-model>`);
             const model = get('pc-model');
 
-            const first = model.entity!;
+            const host = model.entity!;
+            const first = model.contentEntity!;
             expect(first.findByName('model-root'), 'the first model is instantiated').not.toBeNull();
 
             let loads = 0;
@@ -238,16 +249,51 @@ describe('<pc-model>', () => {
             });
 
             model.setAttribute('asset', 'm2');
-            expect(model.entity, 'the old hierarchy is torn down synchronously').toBeNull();
+            expect(model.contentEntity, 'the old content is torn down synchronously').toBeNull();
+            expect(model.entity, 'the host survives the change').toBe(host);
 
             await readyWithin(model);
-            const second = model.entity!;
-            expect(second, 'a new hierarchy was instantiated').not.toBe(first);
-            expect(second.findByName('model-root-b'), 'the new hierarchy comes from the new asset').not.toBeNull();
-            expect(second.parent, 'the new hierarchy is parented').toBe(appElement.app!.root);
-            expect(first.parent, 'the old hierarchy left the scene').toBeNull();
+            const second = model.contentEntity!;
+            expect(second, 'new content was instantiated').not.toBe(first);
+            expect(second.findByName('model-root-b'), 'the new content comes from the new asset').not.toBeNull();
+            expect(second.parent, 'the new content is parented beneath the host').toBe(host);
+            expect(host.parent, 'the host never left the scene').toBe(appElement.app!.root);
+            expect(first.parent, 'the old content left the scene').toBeNull();
             expect(loads, 'each instantiation fires load').toBe(1);
             expect(uncaught.seen).toEqual([]);
+        });
+    });
+
+    describe('host entity', () => {
+        it('registers the host so picks and lookups resolve to this element', async () => {
+            const { appElement, get } = await bootApp(`${ASSET_TAG}<pc-model asset="m"></pc-model>`);
+            const model = get('pc-model');
+
+            expect(appElement.elementFromEntity(model.entity!), 'the identity map points back here').toBe(model);
+            expect(appElement.elementFromEntity(model.contentEntity!),
+                'the content root itself is not fronted by any element').toBeNull();
+        });
+
+        it('applies authored properties to the host and writes changes through', async () => {
+            const { get } = await bootApp(
+                `${ASSET_TAG}<pc-model asset="m" name="prop" position="1 2 3" scale="2 2 2" tags="a, b"></pc-model>`
+            );
+            const model = get('pc-model');
+            const host = model.entity!;
+
+            expect(host.name).toBe('prop');
+            expect(host.getLocalPosition().equals(new Vec3(1, 2, 3))).toBe(true);
+            expect(host.getLocalScale().equals(new Vec3(2, 2, 2))).toBe(true);
+            expect(host.tags.list().sort()).toEqual(['a', 'b']);
+
+            model.position = new Vec3(4, 5, 6);
+            model.enabled = false;
+            expect(host.getLocalPosition().equals(new Vec3(4, 5, 6))).toBe(true);
+            expect(host.enabled).toBe(false);
+
+            // The authored transform composes with the host's rather than being overwritten by it:
+            // the content root keeps its own local transform beneath the placed host.
+            expect(model.contentEntity!.parent).toBe(host);
         });
     });
 });

--- a/test/integration/node.test.ts
+++ b/test/integration/node.test.ts
@@ -72,6 +72,37 @@ describe('<pc-node>', () => {
     };
 
     describe('binding', () => {
+        it('defers a nested entity subtree entirely until the binding resolves', async () => {
+            // Every level below an unresolved node must stay out of the scene graph - including
+            // descendants of an owner that itself deferred, which must neither parent beneath the
+            // owner's floating entity nor announce readiness from outside the graph.
+            const { model } = await bootCar('');
+
+            const node = document.createElement('pc-node');
+            node.setAttribute('name', 'Nowhere');
+            const outer = document.createElement('pc-entity');
+            outer.setAttribute('name', 'outer');
+            const inner = document.createElement('pc-entity');
+            inner.setAttribute('name', 'inner');
+            outer.appendChild(inner);
+            node.appendChild(outer);
+            model.appendChild(node);
+
+            warnings.expect("pc-node 'Nowhere' not found in model 'car'");
+            expect(node.state).toBe('missing');
+            expect(outer.entity!.parent, 'the deferred owner is unparented').toBeNull();
+            expect(inner.entity?.parent ?? null, 'and so is everything beneath it').toBeNull();
+            await expectNeverReady(inner);
+
+            node.setAttribute('name', 'Head');
+
+            expect(node.state).toBe('bound');
+            expect(outer.entity!.parent, 'the bind parents the whole chain').toBe(node.entity);
+            expect(inner.entity!.parent).toBe(outer.entity);
+            await readyWithin(inner);
+            expect(uncaught.seen).toEqual([]);
+        });
+
         it('binds a uniquely named node and registers it as a pick target', async () => {
             const { appElement, get } = await bootCar('<pc-node name="Head"></pc-node>');
             const node = get<NodeElement>('pc-node');

--- a/test/integration/pointer.test.ts
+++ b/test/integration/pointer.test.ts
@@ -83,6 +83,17 @@ const flush = () =>
         setTimeout(resolve, 0);
     });
 
+/**
+ * The smallest valid glTF - no meshes, one named node - for the tests that need a real model
+ * host between a picked content node and a listening wrapper. Loads from a data: URI, so no I/O.
+ */
+const CONTAINER_SRC = `data:application/json,${encodeURIComponent(JSON.stringify({
+    asset: { version: '2.0' },
+    scene: 0,
+    scenes: [{ nodes: [0] }],
+    nodes: [{ name: 'content-root' }]
+}))}`;
+
 describe('pc-app pointer picking', () => {
     useGuard();
 
@@ -149,8 +160,7 @@ describe('pc-app pointer picking', () => {
 
     it('walks up to the nearest ancestor that has a pc-entity', async () => {
         // A picked GLB gives back its own internal nodes - Object_8 and friends - which no
-        // element created, so the walk to the model's host entity is what makes a model pickable
-        // at all.
+        // element created, so the walk up the parent chain is what makes a model pickable at all.
         const { appElement, canvas, entity, spies } = await bootTarget();
         const inner = modelNode('Object_8', modelNode('GLTF_SceneRootNode', entity));
         stubPicker(appElement, [[hit(inner)]]);
@@ -159,6 +169,69 @@ describe('pc-app pointer picking', () => {
         await flush();
 
         expect(spies.pointerenter).toHaveBeenCalledTimes(1);
+    });
+
+    it('hover walks past a registered element with no hover listeners', async () => {
+        // Hover resolution is listener-aware, like down/up: a registered but silent element (a
+        // pc-model host, a plain child entity) is transparent, so crossing between its geometry
+        // and the listening ancestor's produces no spurious leave/enter pair on the ancestor.
+        const handle = await bootApp(`
+            <pc-entity name="camera"><pc-camera></pc-camera></pc-entity>
+            <pc-entity name="outer"><pc-entity name="silent"></pc-entity></pc-entity>
+        `);
+        const outer = handle.get<EntityElement>('pc-entity[name="outer"]');
+        const silent = handle.get<EntityElement>('pc-entity[name="silent"]');
+        const spies = { pointerenter: vi.fn(), pointerleave: vi.fn() };
+        Object.entries(spies).forEach(([type, spy]) => outer.addEventListener(type, spy));
+        const canvas = handle.appElement.querySelector('canvas')!;
+
+        stubPicker(handle.appElement, [[hit(silent.entity!)], [hit(outer.entity!)], []]);
+
+        canvas.dispatchEvent(move(400, 300));
+        await flush();
+        expect(spies.pointerenter, 'the hit on the silent child resolves to the listener').toHaveBeenCalledTimes(1);
+
+        canvas.dispatchEvent(move(410, 300));
+        await flush();
+        expect(spies.pointerleave, 'moving to the ancestor itself is not a crossing').not.toHaveBeenCalled();
+        expect(spies.pointerenter).toHaveBeenCalledTimes(1);
+
+        canvas.dispatchEvent(move(10, 10));
+        await flush();
+        expect(spies.pointerleave, 'leaving the subtree fires exactly one leave').toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves a hit inside a model through the silent host to the listening wrapper', async () => {
+        // The tweening-example shape: hover handlers on a wrapper entity around a bare pc-model.
+        // The model's registered host entity sits between the content and the wrapper, and must
+        // not swallow the wrapper's hover - unless the model itself listens, in which case it is
+        // the nearer owner.
+        const handle = await bootApp(`
+            <pc-asset id="m" type="container" src="${CONTAINER_SRC}"></pc-asset>
+            <pc-entity name="camera"><pc-camera></pc-camera></pc-entity>
+            <pc-entity name="wrapper"><pc-model asset="m"></pc-model></pc-entity>
+        `);
+        const wrapper = handle.get<EntityElement>('pc-entity[name="wrapper"]');
+        const model = handle.get('pc-model');
+        const wrapperEnter = vi.fn();
+        wrapper.addEventListener('pointerenter', wrapperEnter);
+        const canvas = handle.appElement.querySelector('canvas')!;
+
+        stubPicker(handle.appElement, [[hit(model.contentEntity!)], [], [hit(model.contentEntity!)]]);
+
+        canvas.dispatchEvent(move(400, 300));
+        await flush();
+        expect(wrapperEnter, 'the silent host is transparent to hover').toHaveBeenCalledTimes(1);
+
+        canvas.dispatchEvent(move(10, 10));
+        await flush();
+
+        const modelEnter = vi.fn();
+        model.addEventListener('pointerenter', modelEnter);
+        canvas.dispatchEvent(move(400, 300));
+        await flush();
+        expect(modelEnter, 'a listening model is the nearer hover owner').toHaveBeenCalledTimes(1);
+        expect(wrapperEnter).toHaveBeenCalledTimes(1);
     });
 
     it('dispatches pointerleave once the pointer moves off the entity', async () => {

--- a/test/integration/teardown.test.ts
+++ b/test/integration/teardown.test.ts
@@ -4,6 +4,17 @@ import type { AppElement } from '../../src/app';
 import type { EntityElement } from '../../src/entity';
 import { bootApp } from '../helpers/app';
 import { useGuard } from '../helpers/guard';
+import { readyWithin } from '../helpers/ready';
+
+/** The smallest valid glTF, for the pc-model teardown cases. Loads from a data: URI. */
+const MODEL_ASSET_TAG = `<pc-asset id="teardown-m" type="container" src="data:application/json,${encodeURIComponent(
+    JSON.stringify({
+        asset: { version: '2.0' },
+        scene: 0,
+        scenes: [{ nodes: [0] }],
+        nodes: [{ name: 'teardown-root' }]
+    })
+)}"></pc-asset>`;
 
 /**
  * Teardown is where this library is most fragile, because a <pc-app> disconnects BEFORE its
@@ -42,6 +53,7 @@ describe('teardown', () => {
     it('tears down a full tree of component elements without throwing', async () => {
         // Every element type that carries a teardown guard, in one tree.
         const { unmount } = await bootApp(`
+            ${MODEL_ASSET_TAG}
             <pc-scene></pc-scene>
             <pc-entity name="camera"><pc-camera></pc-camera></pc-entity>
             <pc-entity name="light"><pc-light type="directional"></pc-light></pc-entity>
@@ -49,6 +61,7 @@ describe('teardown', () => {
                 <pc-render type="box"></pc-render>
                 <pc-sounds><pc-sound name="blip"></pc-sound></pc-sounds>
             </pc-entity>
+            <pc-model asset="teardown-m"></pc-model>
         `);
 
         unmount();
@@ -165,6 +178,34 @@ describe('teardown', () => {
         expect(childEntity, 'the child is attached to the hierarchy').toBeTruthy();
         expect(childElement.entity, "and is the element's own entity").toBe(childEntity);
         expect(childEntity?.parent, 'parented under the parent entity, not the root').toBe(parentEntity);
+    });
+
+    it('rebuilds a pc-model inside a removed and re-added pc-entity subtree', async () => {
+        // The model's host dies with the ancestor's destroy cascade, resetting the element
+        // through its destroy hook. Re-adding the ancestor rebuilds descendants through
+        // buildDescendantEntities, which must include model hosts - and a rebuilt host must
+        // re-instantiate its content from the still-loaded asset.
+        const { app, get, all } = await bootApp(`
+            ${MODEL_ASSET_TAG}
+            <pc-entity name="parent"><pc-model asset="teardown-m"></pc-model></pc-entity>
+        `);
+        const parentElement = all<EntityElement>('pc-entity')[0];
+        const container = parentElement.parentElement as AppElement;
+        const model = get('pc-model');
+        const oldHost = model.entity!;
+
+        parentElement.remove();
+        await settleTask();
+        expect(model.entity, 'the host died with the subtree').toBeNull();
+        expect(model.contentEntity, 'the content died with the host').toBeNull();
+
+        container.appendChild(parentElement);
+        await readyWithin(model);
+
+        expect(model.entity, 'a fresh host was created').not.toBe(oldHost);
+        expect(model.entity!.parent, 'parented under the recreated parent entity').toBe(app.root.findByName('parent'));
+        expect(model.contentEntity!.parent, 'the content was re-instantiated beneath the host').toBe(model.entity);
+        expect(uncaught.seen).toEqual([]);
     });
 
     it('restores every level when a three-deep pc-entity subtree is removed and re-added', async () => {

--- a/test/integration/template-clone.test.ts
+++ b/test/integration/template-clone.test.ts
@@ -5,6 +5,7 @@ import type { AppElement } from '../../src/app';
 import type { AssetElement } from '../../src/asset';
 import type { EntityElement } from '../../src/entity';
 import type { MaterialElement } from '../../src/material';
+import type { ModelElement } from '../../src/model';
 import type { ModuleElement } from '../../src/module';
 import type { NodeElement } from '../../src/node';
 import { bootApp, settle } from '../helpers/app';
@@ -154,6 +155,33 @@ describe('a <template>-cloned subtree', () => {
         expect(marker.entity, 'the attachment entity was created').toBeTruthy();
         expect(marker.entity!.parent, 'and parented under the bound node').toBe(node.entity);
         expect(marker.entity!.getLocalPosition().equals(new Vec3(0, 1, 0))).toBe(true);
+
+        expect(uncaught.seen).toEqual([]);
+    });
+
+    it('builds a cloned <pc-model> appended to a running app', async () => {
+        const { get, container } = await bootApp(`
+            <pc-asset id="stage" type="container" src="${STAGE_SRC}"></pc-asset>
+            <pc-entity name="Content"></pc-entity>
+            <template id="prop">
+                <pc-model asset="stage" position="1 2 3"></pc-model>
+            </template>
+        `);
+        const content = get<EntityElement>('pc-entity[name="Content"]');
+        const template = get<HTMLTemplateElement>('template');
+
+        content.appendChild(template.content.cloneNode(true));
+
+        // The host is built synchronously on upgrade, like a cloned pc-entity; the content
+        // instantiates asynchronously behind the element's readiness.
+        const model = content.querySelector<ModelElement>(':scope > pc-model')!;
+        expect(model.entity, 'the cloned host was created').toBeTruthy();
+        expect(model.entity!.parent, 'and parented under the entity it was appended to').toBe(content.entity);
+        expect(model.entity!.getLocalPosition().equals(new Vec3(1, 2, 3)), 'position="1 2 3" applied').toBe(true);
+
+        await settle(container);
+        expect(model.contentEntity, 'the content was instantiated').toBeTruthy();
+        expect(model.contentEntity!.parent, 'beneath the host').toBe(model.entity);
 
         expect(uncaught.seen).toEqual([]);
     });

--- a/utils/cem/tags.d.mts
+++ b/utils/cem/tags.d.mts
@@ -2,5 +2,6 @@
 // validate.mjs uses. `allowJs` is deliberately off in tsconfig.test.json: enabling it alongside
 // the inherited `declaration: true` raises TS5053.
 export declare const TAGS: string[];
+export declare const ENTITY_TAGS: string[];
 export declare const COMPONENT_TAGS: string[];
 export declare const READY_TAGS: string[];

--- a/utils/cem/tags.mjs
+++ b/utils/cem/tags.mjs
@@ -17,6 +17,12 @@ export const TAGS = [
     'pc-scrollbar', 'pc-scrollview', 'pc-sky', 'pc-sound', 'pc-sounds'
 ];
 
+/**
+ * The tags whose elements extend `EntityBaseElement`, and so front an engine entity: they are
+ * pick targets and carry the `onpointer*` attributes and pointer events.
+ */
+export const ENTITY_TAGS = ['pc-entity', 'pc-model', 'pc-node'];
+
 /** The tags whose elements extend `ComponentElement`, and so inherit its `enabled` attribute. */
 export const COMPONENT_TAGS = [
     'pc-anim', 'pc-button', 'pc-camera', 'pc-collision', 'pc-element', 'pc-gsplat', 'pc-joint',

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -13,7 +13,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { COMPONENT_TAGS, READY_TAGS, TAGS } from './tags.mjs';
+import { COMPONENT_TAGS, ENTITY_TAGS, READY_TAGS, TAGS } from './tags.mjs';
 
 const dist = fileURLToPath(new URL('../../dist/', import.meta.url));
 
@@ -91,8 +91,16 @@ if (manifest) {
     expectAttribute('pc-camera', 'clear-color', { default: '0.75 0.75 0.75 1' });
     expectAttribute('pc-camera', 'rect', { default: '0 0 1 1' });
     expectAttribute('pc-scene', 'gravity', { default: '0 -9.81 0' });
-    expectAttribute('pc-entity', 'position', { default: '0 0 0' });
+    expectAttribute('pc-entity', 'position', { default: '0 0 0', fieldName: 'position' });
     expectAttribute('pc-entity', 'scale', { default: '1 1 1' });
+    expectAttribute('pc-model', 'position', { default: '0 0 0', fieldName: 'position' });
+    expectAttribute('pc-model', 'scale', { default: '1 1 1' });
+
+    // The entity-owning accessors live on a shared base class, but the attributes plugin can only
+    // read a same-module member's JSDoc - these descriptions exist solely because the leaf classes
+    // re-declare them as @attribute tags, so their loss is pinned here.
+    check(Boolean(attribute('pc-entity', 'position')?.description), 'pc-entity[position] has no description');
+    check(Boolean(attribute('pc-model', 'position')?.description), 'pc-model[position] has no description');
     expectAttribute('pc-button', 'hit-padding', { default: '0 0 0 0' });
     expectAttribute('pc-button', 'hover-tint', { default: '1 1 1' });
     expectAttribute('pc-collision', 'angular-offset', { default: '0 0 0' });
@@ -248,8 +256,10 @@ if (manifest) {
     check(events('pc-joint').includes('break'), "pc-joint is missing the 'break' event");
 
     const pointerEvents = ['pointerenter', 'pointerleave', 'pointermove', 'pointerdown', 'pointerup'];
-    for (const name of pointerEvents) {
-        check(events('pc-entity').includes(name), `pc-entity is missing the '${name}' event`);
+    for (const tag of ENTITY_TAGS) {
+        for (const name of pointerEvents) {
+            check(events(tag).includes(name), `${tag} is missing the '${name}' event`);
+        }
     }
     const strayPointerEvents = pointerEvents.filter(name => events('pc-app').includes(name));
     check(strayPointerEvents.length === 0,
@@ -319,7 +329,7 @@ if (manifest) {
         // roughness and roughnessMap are the alias accessors: their attributes resolve to the
         // gloss fields, so no attribute claims them as its backing member
         ['pc-material', ['get', 'material', 'roughness', 'roughnessMap']],
-        ['pc-model', ['entity', 'hierarchy', ...ASYNC_MEMBERS]],
+        ['pc-model', ['addEventListener', 'contentEntity', 'entity', 'hierarchy', 'removeEventListener', ...ASYNC_MEMBERS]],
         ['pc-module', [...ASYNC_MEMBERS]],
         ['pc-node', ['addEventListener', 'entity', 'path', 'removeEventListener', 'state', ...ASYNC_MEMBERS]],
         ['pc-particles', ['component', 'pause', 'play', 'reset', 'stop', ...ASYNC_MEMBERS]],


### PR DESCRIPTION
Part 1 of 2 for #396: `<pc-model>` becomes an entity-fronting element by creating and fronting a **stable identity host entity**, with the instantiated GLB content parented beneath it. Part 2 (separate PR) widens `closestEntity` so nested components and child entities re-target to the host.

## What changes

- **New `EntityOwnerElement` base** (`src/entity-owner.ts`) between `EntityBaseElement` and `{EntityElement, ModelElement}`: the cached authored properties, `_createEntity`/`_buildHierarchy`, and the destroy-hook reset move there. A new `_onBuilt` hook lets `pc-entity` announce readiness at parenting while `pc-model` starts its content load instead. (`pc-node` stays outside it — its transforms are nullable overrides on a borrowed entity.)
- **`pc-model` creates its host in the boot sweep** (and on runtime insertion), gains full `pc-entity` attribute parity — `enabled`, `name`, `position`, `rotation`, `scale`, `tags`, `onpointer*` — and registers the host for picking, so a hit on a content node that no `pc-node` fronts resolves to the model element. Transforms compose with the authored root TRS rather than overwriting it (the engine returns the *authored* node as the root of a single-scene/single-node GLB — see `createScenes` in the engine's glb-parser).
- **`contentEntity`** exposes the instantiated root. `hierarchy()` and `pc-node` resolution stay scoped to it, so paths, ordinals, and warning texts are unchanged — `node.test.ts` passes without modification, by design.
- **Readiness keeps meaning "the current asset selection settled"**: content parented, or load failed, or — new — no asset assigned at all (an empty selection settles immediately; the element is a usable host with no content). Asset changes still re-arm readiness; the host, its registration, and (after part 2) its components survive the swap.
- **Hover resolution is now listener-aware**, matching `pointerdown`/`pointerup`: registering the silent host would otherwise swallow `pointerenter`/`pointerleave` from a listening ancestor (the `tweening` example's shape). Side effect: a registered but silent element no longer produces an enter/leave flicker against a listening ancestor — DOM-like subtree semantics.
- **`pc-anim` points `rootBone` at the enclosing model's host** (the parent `pc-model`, or the sole `pc-model` among its parent's direct children). The extra hierarchy level exposed an engine binder edge: for curves targeting the asset's root node, `DefaultAnimBinder`'s fallback (`findByPath(entityPath.slice(1))` → `findByPath([])` → the graph itself) treats its graph as the asset root once that root is no longer a direct child, silently mis-binding the curve to the component's own entity. Anchoring the binding root at the host restores the arrangement the binder expects at any depth — and keeps binding semantics identical before and after part 2.

## Breaking changes

- `ModelElement.entity` now returns the **host** — use `contentEntity` for the instantiated root. `entity` is non-null from boot, **including after a failed load**: detect failure via the `error` event or a null `contentEntity`.
- A `pc-model` with no `asset` assigned becomes ready instead of staying pending forever.
- Hover events resolve to the nearest *listening* element (see above).

## Verification

- 833 tests pass (41 files; 21 new), including the two invariant gates: `node.test.ts` unchanged (content-root scoping) and `anim-component.test.ts` unchanged (binding across the new level).
- `npm run build` (publint + CEM manifest validation with new member/attribute pins), `npm run lint`, `npm run type-check` all clean. pc-entity's manifest attribute metadata is value-identical to before the refactor (descriptions now come from `@attribute` tags, since the analyzer cannot derive them across modules).
- Browser-verified against the built `dist`: **glb-animation** (old markup still animates — real GLB skeleton driven through the host level), **tweening** (hover enter/leave through the silent host with real GPU picking), **car-configurator** (lightmap bake runs via the `contentEntity` sentinel; `pc-node` binding + `enabled` override intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
