### PR TITLE
Remove the car configurator's leftover xr entity

### DIFF
--- a/examples/car-configurator.html
+++ b/examples/car-configurator.html
@@ -75,12 +75,6 @@
                         <pc-script-instance name="bakedAo"></pc-script-instance>
                     </pc-script>
                 </pc-entity>
-                <!-- XR -->
-                <pc-entity name="xr">
-                    <pc-script>
-                        <pc-script-instance name="xrControllers"></pc-script-instance>
-                    </pc-script>
-                </pc-entity>
             </pc-scene>
         </pc-app>
         <script type="module" src="js/example.mjs"></script>


### PR DESCRIPTION
### What

Deletes the standalone `xr` entity from `examples/car-configurator.html`, which held a second `xrControllers` script instance:

```html
<!-- XR -->
<pc-entity name="xr">
    <pc-script>
        <pc-script-instance name="xrControllers"></pc-script-instance>
    </pc-script>
</pc-entity>
```

### Why

The entity dates back to when the controllers script lived on its own entity. When the XR scripts were consolidated onto `camera-root` (alongside `xrMenu`, `xrNavigation` and `xrSession`), every other example dropped it — car-configurator was the only file left with `name="xr"`.

It wasn't merely redundant. `XrControllers` is app-scoped, not entity-scoped: it subscribes to the global `app.xr.input` `add`/`remove` events and parents each loaded model with `app.root.addChild(entity)`. Two instances meant two subscribers, so every input source fetched its WebXR input profile twice and produced two overlapping controller entities under the root, each driven by its own `update()`.

### Notes for reviewers

- The `xrControllers` instance on `camera-root` is untouched, so controller models still load in XR — once instead of twice.
- Diff is a clean 6-line deletion; no line-ending churn.
- Behavior change is only observable in an XR session on a headset, so it hasn't been verified on-device here.
