### PR TITLE
Label the pc-wasm section "Wasm Modules" in the examples

### DIFF
--- a/examples/annotations.html
+++ b/examples/annotations.html
@@ -17,7 +17,7 @@
     </head>
     <body>
         <pc-app>
-            <!-- Modules -->
+            <!-- Wasm Modules -->
             <pc-wasm name="Basis" glue="modules/basis/basis.wasm.js" wasm="modules/basis/basis.wasm.wasm" fallback="modules/basis/basis.js"></pc-wasm>
             <pc-wasm name="DracoDecoderModule" glue="modules/draco/draco.wasm.js" wasm="modules/draco/draco.wasm.wasm" fallback="modules/draco/draco.js"></pc-wasm>
             <!-- Assets -->

--- a/examples/basic-physics.html
+++ b/examples/basic-physics.html
@@ -17,7 +17,7 @@
     </head>
     <body>
         <pc-app>
-            <!-- Modules -->
+            <!-- Wasm Modules -->
             <pc-wasm name="Ammo" glue="modules/ammo/ammo.wasm.js" wasm="modules/ammo/ammo.wasm.wasm" fallback="modules/ammo/ammo.js"></pc-wasm>
             <!-- Assets -->
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>

--- a/examples/car-configurator.html
+++ b/examples/car-configurator.html
@@ -17,7 +17,7 @@
     </head>
     <body>
         <pc-app>
-            <!-- Modules -->
+            <!-- Wasm Modules -->
             <pc-wasm name="DracoDecoderModule" glue="modules/draco/draco.wasm.js" wasm="modules/draco/draco.wasm.wasm" fallback="modules/draco/draco.js"></pc-wasm>
             <!-- Assets -->
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>

--- a/examples/first-person-controller.html
+++ b/examples/first-person-controller.html
@@ -17,7 +17,7 @@
     </head>
     <body>
         <pc-app>
-            <!-- Modules -->
+            <!-- Wasm Modules -->
             <pc-wasm name="Ammo" glue="modules/ammo/ammo.wasm.js" wasm="modules/ammo/ammo.wasm.wasm" fallback="modules/ammo/ammo.js"></pc-wasm>
             <pc-wasm name="Basis" glue="modules/basis/basis.wasm.js" wasm="modules/basis/basis.wasm.wasm" fallback="modules/basis/basis.js"></pc-wasm>
             <!-- Assets -->

--- a/examples/physics-cluster.html
+++ b/examples/physics-cluster.html
@@ -17,7 +17,7 @@
     </head>
     <body>
         <pc-app>
-            <!-- Modules -->
+            <!-- Wasm Modules -->
             <pc-wasm name="Ammo" glue="modules/ammo/ammo.wasm.js" wasm="modules/ammo/ammo.wasm.wasm" fallback="modules/ammo/ammo.js"></pc-wasm>
             <!-- Assets -->
             <pc-asset src="assets/skies/octagon-lamps-photo-studio-2k.hdr" id="studio"></pc-asset>

--- a/examples/physics-joints.html
+++ b/examples/physics-joints.html
@@ -17,7 +17,7 @@
     </head>
     <body>
         <pc-app>
-            <!-- Modules -->
+            <!-- Wasm Modules -->
             <pc-wasm name="Ammo" glue="modules/ammo/ammo.wasm.js" wasm="modules/ammo/ammo.wasm.wasm" fallback="modules/ammo/ammo.js"></pc-wasm>
             <!-- Assets -->
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>

--- a/examples/ragdoll.html
+++ b/examples/ragdoll.html
@@ -17,7 +17,7 @@
     </head>
     <body>
         <pc-app>
-            <!-- Modules -->
+            <!-- Wasm Modules -->
             <pc-wasm name="Ammo" glue="modules/ammo/ammo.wasm.js" wasm="modules/ammo/ammo.wasm.wasm" fallback="modules/ammo/ammo.js"></pc-wasm>
             <!-- Assets -->
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>

--- a/examples/solar-system.html
+++ b/examples/solar-system.html
@@ -527,7 +527,7 @@
         <!-- 3D scene (transparent canvas over the starfield). The page has its own themed
              loader, so the built-in loading bar is disabled -->
         <pc-app loading-bar="false">
-            <!-- Modules -->
+            <!-- Wasm Modules -->
             <pc-wasm name="Basis" glue="modules/basis/basis.wasm.js" wasm="modules/basis/basis.wasm.wasm" fallback="modules/basis/basis.js"></pc-wasm>
             <!-- Assets -->
             <pc-asset src="assets/scripts/solar-system.mjs"></pc-asset>

--- a/examples/video-texture.html
+++ b/examples/video-texture.html
@@ -17,7 +17,7 @@
     </head>
     <body>
         <pc-app>
-            <!-- Modules -->
+            <!-- Wasm Modules -->
             <pc-wasm name="Basis" glue="modules/basis/basis.wasm.js" wasm="modules/basis/basis.wasm.wasm" fallback="modules/basis/basis.js"></pc-wasm>
             <pc-wasm name="DracoDecoderModule" glue="modules/draco/draco.wasm.js" wasm="modules/draco/draco.wasm.wasm" fallback="modules/draco/draco.js"></pc-wasm>
             <!-- Assets -->


### PR DESCRIPTION
### What

Renames the `<!-- Modules -->` section comment to `<!-- Wasm Modules -->` in the nine examples that have one. Comment-only change — nine single-line edits, no markup or behavior touched.

`annotations`, `basic-physics`, `car-configurator`, `first-person-controller`, `physics-cluster`, `physics-joints`, `ragdoll`, `solar-system`, `video-texture`

### Why

In every case the comment labels a block of `<pc-wasm>` elements, but bare "Modules" reads ambiguously in files that also pull in ES modules via the import map and `<pc-asset src="....mjs">`. Naming the technology matches the tag directly beneath the comment and lines up with the sibling labels (`<!-- Assets -->`, `<!-- Materials -->`, `<!-- Scene -->`).

### Notes for reviewers

One naming call worth a look: the JSDoc in `src/wasm.ts` spells this out in prose — "the name of the WebAssembly module to configure", "the module's WebAssembly binary" — and reserves `Wasm` for identifiers (`WasmElement`, `WasmModule`). So `WebAssembly Modules` would match the docs, while `Wasm Modules` matches the `pc-wasm` tag it sits above. Happy to switch if the docs spelling is preferred.
