### PR TITLE
Fix five pieces of example markup that never took effect

### DIFF
--- a/examples/basic-physics.html
+++ b/examples/basic-physics.html
@@ -52,7 +52,7 @@
                     </pc-script>
                 </pc-entity>
                 <!-- Light -->
-                <pc-entity name="light" rotation="45 45 0" cast-shadows>
+                <pc-entity name="light" rotation="45 45 0">
                     <pc-light cast-shadows></pc-light>
                 </pc-entity>
                 <!-- Box 1 -->

--- a/examples/basic-sound.html
+++ b/examples/basic-sound.html
@@ -31,7 +31,7 @@
                     </pc-script>
                 </pc-entity>
                 <!-- Light -->
-                <pc-entity name="light" rotation="45 0 0" intensity="1">
+                <pc-entity name="light" rotation="45 0 0">
                     <pc-light></pc-light>
                 </pc-entity>
                 <!-- Cube -->

--- a/examples/first-person-teleport.html
+++ b/examples/first-person-teleport.html
@@ -31,7 +31,6 @@
             <pc-asset src="assets/splats/statues/narcissus.sog" id="narcissus"></pc-asset>
             <pc-asset src="assets/splats/statues/st-peter.sog" id="st-peter"></pc-asset>
             <pc-asset src="assets/splats/statues/trumpet.sog" id="trumpet"></pc-asset>
-            <pc-asset src="assets/skies/sepulchral-chapel-rotunda-4k.webp" id="rotunda"></pc-asset>
             <pc-asset src="assets/textures/dark-tiles.png" id="dark-tiles" anisotropy="16"></pc-asset>
             <pc-material id="ground" diffuse-map="dark-tiles"></pc-material>
             <!-- Scene -->

--- a/examples/splat-flipbook.html
+++ b/examples/splat-flipbook.html
@@ -34,7 +34,7 @@
                 <!-- Camera (with XR support) -->
                 <pc-entity name="camera-root">
                     <pc-entity name="camera" position="-2 1.25 0">
-                        <pc-camera far-clip="1500" fov="50" tone-mapping="aces"></pc-camera>
+                        <pc-camera far-clip="1500" fov="50" tonemap="aces"></pc-camera>
                         <pc-script>
                             <pc-script-instance name="cameraControls"
                                                 enable-fly="false"
@@ -79,15 +79,13 @@
                     <pc-light type="directional"
                         cast-shadows shadow-bias="0.1" normal-offset-bias="0.05"
                         shadow-distance="10" shadow-intensity="0.15"
-                        shadow-resolution="1024" shadow-type="pcf5-16f"
-                    </pc-light>
+                        shadow-resolution="1024" shadow-type="pcf5-16f"></pc-light>
                 </pc-entity>
                 <pc-entity name="light" rotation="55 220 0">
                     <pc-light type="directional"
                         cast-shadows shadow-bias="0.1" normal-offset-bias="0.05"
                         shadow-distance="10" shadow-intensity="0.15"
-                        shadow-resolution="1024" shadow-type="pcf5-16f"
-                    </pc-light>
+                        shadow-resolution="1024" shadow-type="pcf5-16f"></pc-light>
                 </pc-entity>
             </pc-scene>
         </pc-app>


### PR DESCRIPTION
First of three stacked PRs from an audit of `examples/`. Merge order: **this one**, then #404, then #405 (whose new test fails on `main` until this lands).

### What

Five pieces of example markup that never took effect. Each was verified in a browser before and after.

| File | Was | Effect |
| --- | --- | --- |
| `splat-flipbook.html` | `tone-mapping="aces"` on `<pc-camera>` | dropped — camera rendered untonemapped |
| `splat-flipbook.html` | two `<pc-light>` start tags with no closing `>` | invalid HTML, survived on parser recovery |
| `first-person-teleport.html` | a 607 KB sky texture nothing references | preloaded on every visit |
| `basic-sound.html` | `intensity="1"` on `<pc-entity>` | inert |
| `basic-physics.html` | `cast-shadows` on `<pc-entity>` | inert |

### Detail

**`tone-mapping` is not an attribute.** The name is `tonemap` ([camera-component.ts:516](https://github.com/playcanvas/web-components/blob/main/src/components/camera-component.ts#L516)); every other example gets it right. Verified live: `el.tonemap` read `"none"` and `component.toneMapping` was `6` (`TONEMAP_NONE`), not `3` (`TONEMAP_ACES`). Not cosmetic — sampling a 200px centre crop, the untonemapped render clipped highlights at max luma 255 where ACES rolls them off at 234. After the fix `component.toneMapping` is `3`.

**Two unclosed `<pc-light>` tags.** Each ran four attribute lines and went straight to `</pc-light>` with no `>`. Chrome and jsdom recover identically: every intended attribute lands, plus two junk ones named `<` and `pc-light`, and the element is closed implicitly by the following `</pc-entity>`. So the lights worked — this is invalid markup surviving on error recovery, in a file whose purpose is to be copied. After the fix both elements carry 8 attributes and no junk, with `castShadows`, `shadowResolution` and `shadowIntensity` unchanged on the engine components.

**A dead 607 KB preload.** `first-person-teleport.html` declared `sepulchral-chapel-rotunda-4k.webp` as `id="rotunda"`. Nothing referenced it — the page has no `<pc-sky>` at all, and its script never touches assets. Verified before: the request fired, `asset.preload` and `asset.loaded` were both true, `scene.skybox` and `scene.envAtlas` were both null, no material used it. Since a non-lazy `<pc-asset>` gates `<pc-app>` readiness, it delayed the loading bar for nothing. Verified after, from the page's own Resource Timing: zero requests for it and zero for anything under `/skies/`, with the scene still building its 7 splats.

**Two component attributes on the wrong element.** `<pc-entity>` observes neither `intensity` nor `cast-shadows`. Both were no-ops: the light already sat at the default intensity of 1, and the `<pc-light>` one line below carried its own `cast-shadows`. Shadows still cast and physics still runs after removal (3 rigid bodies, Ammo loaded).

### Notes for reviewers

- These are the only two misplaced attributes in all 37 pages — I checked every `pc-*` attribute against each element's resolved `observedAttributes` chain. Script-instance attributes are clean: every one resolves to a real field on the target script.
- The unclosed tags are fixed minimally here (just the `>`); the surrounding indentation is an outlier too, and that is restyled in the follow-up so this diff stays about behaviour.
- Root cause is that nothing in CI reads `examples/*.html`. The third PR in the stack adds that check.
