### PR TITLE
Bring the outlier examples into line with the house conventions

### DIFF
--- a/examples/2d-screen.html
+++ b/examples/2d-screen.html
@@ -32,7 +32,7 @@
                     <pc-entity name="text" position="0 40 0">
                         <pc-element type="text" font-asset="arial" text="This is Arial"></pc-element>
                     </pc-entity>
-                    <pc-entity name="text2" position="0 0 0">
+                    <pc-entity name="text2">
                         <pc-element type="text" font-asset="courier" text="This is Courier"></pc-element>
                     </pc-entity>
                     <pc-entity name="text3" position="0 -40 0">

--- a/examples/3d-text.html
+++ b/examples/3d-text.html
@@ -27,8 +27,8 @@
             <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-navigation.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-session.mjs"></pc-asset>
             <pc-asset src="assets/fonts/arial.json" type="font" id="arial-font"></pc-asset>
+            <pc-asset src="assets/fonts/arial.ttf" type="binary" id="arial"></pc-asset>
             <pc-asset src="assets/scripts/text3d.mjs"></pc-asset>
-            <pc-asset id="arial" src="assets/fonts/arial.ttf" type="binary"></pc-asset>
             <!-- Scene -->
             <pc-scene>
                 <!-- Camera (with XR support) -->

--- a/examples/basic-physics.html
+++ b/examples/basic-physics.html
@@ -66,7 +66,7 @@
                     <pc-rigid-body type="dynamic" restitution="0.9"></pc-rigid-body>
                 </pc-model>
                 <!-- Ground -->
-                <pc-entity name="plane" scale="1000 1000 1000">
+                <pc-entity name="ground" scale="1000 1000 1000">
                     <pc-collision half-extents="100 0.5 100" linear-offset="0 -0.5 0"></pc-collision>
                     <pc-rigid-body></pc-rigid-body>
                     <pc-script>

--- a/examples/basic-shapes.html
+++ b/examples/basic-shapes.html
@@ -68,7 +68,7 @@
                 <pc-entity name="rim-light" position="-2 4 -4" rotation="-40 45 0">
                     <pc-light type="directional" intensity="0.75" cast-shadows shadow-type="vsm-16f" vsm-bias="0.01"></pc-light>
                 </pc-entity>
-                <!-- Box-->
+                <!-- Box -->
                 <pc-entity name="box" position="1.5 0.5 0">
                     <pc-render type="box" material="crimson"></pc-render>
                 </pc-entity>
@@ -89,7 +89,7 @@
                     <pc-render type="sphere" material="goldenrod"></pc-render>
                 </pc-entity>
                 <!-- Plane -->
-                <pc-entity name="plane" position="0 0 0" scale="7 1 7">
+                <pc-entity name="plane" scale="7 1 7">
                     <pc-render type="plane" material="lightgray"></pc-render>
                 </pc-entity>
             </pc-scene>

--- a/examples/basic-sound.html
+++ b/examples/basic-sound.html
@@ -34,7 +34,7 @@
                 <pc-entity name="light" rotation="45 0 0">
                     <pc-light></pc-light>
                 </pc-entity>
-                <!-- Cube -->
+                <!-- Nyan Cat -->
                 <pc-model asset="nyan-cat"></pc-model>
                 <!-- Music -->
                 <pc-entity name="music">

--- a/examples/physics-cluster.html
+++ b/examples/physics-cluster.html
@@ -59,7 +59,7 @@
                     </pc-entity>
                 </template>
                 <!-- Physical Pointer -->
-                <pc-entity name="pointer" position="0 0 0">
+                <pc-entity name="pointer">
                     <pc-entity scale="0.5 0.5 0.5">
                         <pc-render type="sphere"></pc-render>
                     </pc-entity>

--- a/examples/spinning-cube-dom-api.html
+++ b/examples/spinning-cube-dom-api.html
@@ -77,5 +77,6 @@
             script.setAttribute('name', 'rotate');
             scriptsComponent.appendChild(script);
         </script>
+        <script type="module" src="js/example.mjs"></script>
     </body>
 </html>

--- a/examples/spinning-cube-umd.html
+++ b/examples/spinning-cube-umd.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
         <title>PlayCanvas Web Components - Spinning Cube (UMD)</title>
-        <script src="/node_modules/playcanvas/build/playcanvas.js"></script>
+        <script src="../node_modules/playcanvas/build/playcanvas.js"></script>
         <script src="../dist/pwc.js"></script>
         <link rel="stylesheet" href="css/example.css">
     </head>

--- a/examples/splat-flipbook.html
+++ b/examples/splat-flipbook.html
@@ -68,24 +68,24 @@
                     </pc-script>
                 </pc-entity>
                 <!-- Shadow Catcher -->
-                <pc-entity name="shadow-catcher" position="0 0 0">
+                <pc-entity name="shadow-catcher">
                     <pc-render type="plane" cast-shadows="false"></pc-render>
                     <pc-script>
                         <pc-script-instance name="shadowCatcher" scale="10 10 10"></pc-script-instance>
                     </pc-script>
                 </pc-entity>
-                <!-- Light -->
-                <pc-entity name="light" rotation="55 320 0">
+                <!-- Lights -->
+                <pc-entity name="key-light" rotation="55 320 0">
                     <pc-light type="directional"
-                        cast-shadows shadow-bias="0.1" normal-offset-bias="0.05"
-                        shadow-distance="10" shadow-intensity="0.15"
-                        shadow-resolution="1024" shadow-type="pcf5-16f"></pc-light>
+                              cast-shadows shadow-bias="0.1" normal-offset-bias="0.05"
+                              shadow-distance="10" shadow-intensity="0.15"
+                              shadow-resolution="1024" shadow-type="pcf5-16f"></pc-light>
                 </pc-entity>
-                <pc-entity name="light" rotation="55 220 0">
+                <pc-entity name="fill-light" rotation="55 220 0">
                     <pc-light type="directional"
-                        cast-shadows shadow-bias="0.1" normal-offset-bias="0.05"
-                        shadow-distance="10" shadow-intensity="0.15"
-                        shadow-resolution="1024" shadow-type="pcf5-16f"></pc-light>
+                              cast-shadows shadow-bias="0.1" normal-offset-bias="0.05"
+                              shadow-distance="10" shadow-intensity="0.15"
+                              shadow-resolution="1024" shadow-type="pcf5-16f"></pc-light>
                 </pc-entity>
             </pc-scene>
         </pc-app>

--- a/examples/video-recorder.html
+++ b/examples/video-recorder.html
@@ -27,8 +27,8 @@
             <!-- Scene -->
             <pc-scene>
                 <!-- Camera -->
-                <pc-entity name="camera-grandparent">
-                    <pc-entity name="camera-parent">
+                <pc-entity name="camera-root">
+                    <pc-entity name="camera-pitch">
                         <pc-entity name="camera" position="0 1.5 1">
                             <pc-camera></pc-camera>
                         </pc-entity>

--- a/examples/video-texture.html
+++ b/examples/video-texture.html
@@ -22,11 +22,11 @@
             <pc-wasm name="DracoDecoderModule" glue="modules/draco/draco.wasm.js" wasm="modules/draco/draco.wasm.wasm" fallback="modules/draco/draco.js"></pc-wasm>
             <!-- Assets -->
             <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/shadow-catcher.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-controllers.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-menu.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-navigation.mjs"></pc-asset>
             <pc-asset src="../node_modules/playcanvas/scripts/esm/xr/xr-session.mjs"></pc-asset>
-            <pc-asset src="../node_modules/playcanvas/scripts/esm/shadow-catcher.mjs"></pc-asset>
             <pc-asset src="assets/fonts/arial.json" type="font" id="arial-font"></pc-asset>
             <pc-asset src="assets/scripts/video-texture.mjs"></pc-asset>
             <pc-asset src="assets/skies/octagon-lamps-photo-studio-2k.hdr" id="studio"></pc-asset>


### PR DESCRIPTION
Second of three stacked PRs from an audit of `examples/`. **Based on #403** — review that first; this diff shows only its own changes once #403 merges.

### What

A pass over the places where one example does something the other 36 do differently. Every touched page was checked in a browser.

**Naming**
- `video-recorder.html` called its two-level camera rig `camera-grandparent` / `camera-parent`, describing tree position rather than role. Measured over a second, the outer entity moves on Y only and the inner on X only, so they are now `camera-root` (matching the 13 other examples) and `camera-pitch`.
- `splat-flipbook.html` had two entities both named `light` — now `key-light` and `fill-light`, with the comment widened to `<!-- Lights -->`.
- `basic-physics.html` labelled a `plane` entity `<!-- Ground -->`; the entity is now `ground`, as in the four other examples that have one.
- `basic-sound.html` labelled a nyan cat `<!-- Cube -->`.

**Ordering**
- `video-texture.html` listed `shadow-catcher.mjs` after the four `xr/` scripts — the only break in the alphabetical engine-script order across all 37 pages.
- `3d-text.html` wrote one asset `id src type` where the line above it, and 19 other files, use `src type id`; it also sat below the scripts instead of with the other font.

**Formatting**
- `splat-flipbook.html`'s multi-line `<pc-light>` hung its continuations at +4 instead of aligning them to the first attribute, as `robot-arm` and `ragdoll` do.
- `basic-shapes.html` had `<!-- Box-->`, the one comment in `examples/` missing its inner space.
- Four entities carried an identity `position` or `scale` restating the default.

### Two behaviour changes, called out

- **`spinning-cube-umd.html`** loaded the engine from an absolute `/node_modules/…` path while the line directly below it — and every other example — is relative. Now relative, so the page no longer depends on being served from the repo root. Verified: `pc` and `pwc` both defined, no failed resources, cube still spins.
- **`spinning-cube-dom-api.html`** was the one import-map example without `js/example.mjs`, so it alone had no fullscreen, StackBlitz or view-source buttons. It now gets the same bar as `spinning-cube.html` (verified: 3 buttons, and no XR buttons, correctly, since it has no XR scripts). Say the word and I will drop this one — it is the only change here that adds something rather than aligning something.

### Left alone deliberately

- `ragdoll.html`'s snake_case `<pc-node>` names (`foot_l`, `hand_r`) look like outliers but are load-bearing: they must match the glTF's node names. The author-chosen `id`s beside them are already kebab-case.
- `scroll-view.html`'s repeated row names and id-first asset order — both internally consistent, and the sprite assets have no `src` to lead with.
- `2d-screen.html`'s `arial` / `courier` id pair, consistent as a pair even though 14 files call the same font `arial-font`.
- `robot-arm.html`'s `floor` vs everyone else's `ground` — internally consistent either way.
- The three shapes of label-plus-explanation comment (`Label (aside)`, `Label. Prose.`, bare prose). Normalising these is a large diff over judgement calls, not drift.

### Verification

All 37 pages re-audited after the change: no unsupported attributes, no malformed tags, no engine-script ordering violations, no duplicate entity names outside `scroll-view`'s deliberate row template, no identity transforms, no comment-spacing outliers. `npm test` and `npm run lint` both clean.
