### PR TITLE
Add a UI Layout example, on a world-space screen

### DIFF
--- a/examples/assets/scripts/ui-layout.mjs
+++ b/examples/assets/scripts/ui-layout.mjs
@@ -4,11 +4,20 @@ import { Script } from 'playcanvas';
  * Drives the world-space layout board. The controls along its foot resize the panel, retune the
  * tile field's layout group and add or remove tiles.
  *
- * Everything the script touches, it touches through element attributes rather than through the
- * engine components behind them. That keeps the board's state readable in devtools, and it side
- * steps a timing trap: a cloned tile's `<pc-element>` component does not exist the instant the
- * `<pc-entity>` reports ready, so assigning `entity.element.text` there is a silent no-op, while
- * an attribute is picked up whenever the component does arrive.
+ * Which of the two APIs the script reaches for depends on when the thing it is addressing was
+ * built, and the split is worth understanding before copying either half:
+ *
+ * - Anything declared in the page - the panel, the readout, the control buttons and their labels -
+ *   has its components by the time `initialize()` runs, so those go through the components
+ *   directly: `button.on('click')`, `element.text`.
+ * - A tile cloned at runtime does not. Its `<pc-element>` component does not exist the instant the
+ *   `<pc-entity>` reports ready, so assigning `entity.element.color` there is a silent no-op. Its
+ *   tint and number are therefore set as attributes on the clone, which the component picks up
+ *   whenever it does arrive.
+ *
+ * The panel's size and the readout text go through attributes too, for a different reason: they
+ * are the derived state, and having them on the elements means the board can be read in devtools
+ * while it animates.
  *
  * Two things the board is built to show off:
  *
@@ -230,9 +239,13 @@ export class UiLayout extends Script {
         return Math.max(1, Math.ceil(this.tiles.length / perRow));
     }
 
+    /**
+     * Retitles a control. The label is declared in the page rather than cloned, so its component
+     * exists by the time this first runs and can be written to directly - the guard is for the
+     * misconfigured case, not a timing one.
+     */
     _label(controlName, text) {
-        const control = this.entity.findByName(controlName);
-        const label = control?.findByName('label');
+        const label = this.entity.findByName(controlName)?.findByName('label');
         if (label?.element) {
             label.element.text = text;
         }

--- a/examples/assets/scripts/ui-layout.mjs
+++ b/examples/assets/scripts/ui-layout.mjs
@@ -1,0 +1,263 @@
+import { Script } from 'playcanvas';
+
+/**
+ * Drives the world-space layout board. The controls along its foot resize the panel, retune the
+ * tile field's layout group and add or remove tiles.
+ *
+ * Everything the script touches, it touches through element attributes rather than through the
+ * engine components behind them. That keeps the board's state readable in devtools, and it side
+ * steps a timing trap: a cloned tile's `<pc-element>` component does not exist the instant the
+ * `<pc-entity>` reports ready, so assigning `entity.element.text` there is a silent no-op, while
+ * an attribute is picked up whenever the component does arrive.
+ *
+ * Two things the board is built to show off:
+ *
+ * - Nine-slicing. The panel, its shadow, the header, the field, every tile and every button are
+ *   all the same two sliced sprites, tinted. Resizing the panel restretches them together and
+ *   their corners stay the size the atlas declares, however far the middle grows.
+ * - Anchoring and fitting doing the work instead of script. The panel's width is the only thing
+ *   animated here. The header, field and control row are each anchored to two opposite edges, so
+ *   they follow on their own, and the control row hands its width out to its buttons in
+ *   proportion to each one's `fit-width-proportion`.
+ *
+ * Attached to the board entity.
+ */
+export class UiLayout extends Script {
+    static scriptName = 'uiLayout';
+
+    /** Tiles present when the board first appears. */
+    initialTileCount = 12;
+
+    /** Bounds on the tile count, so the field can be neither emptied nor overrun. */
+    minTileCount = 1;
+
+    maxTileCount = 16;
+
+    /**
+     * The width range the - and + controls move the panel through, in screen units. The floor is
+     * set by the control row: below it the buttons would be at their `min-width` and would start
+     * to overrun the panel rather than shrink any further.
+     */
+    minPanelWidth = 600;
+
+    maxPanelWidth = 940;
+
+    widthStep = 85;
+
+    /**
+     * Tile footprint and field insets, mirroring the markup. The script needs these to work out
+     * how many rows the tiles will wrap into, which is what the panel height follows.
+     */
+    tileWidth = 128;
+
+    tileHeight = 86;
+
+    tileSpacing = 12;
+
+    /** Panel width less the field's own margins and the tile group's padding. */
+    fieldInset = 48;
+
+    /** Panel height less the field: the header band, the control row and the gaps around them. */
+    chromeHeight = 210;
+
+    /** Rows the field holds when tiles run in columns instead, where rows cannot be counted. */
+    verticalRows = 3;
+
+    /** Seconds a width change takes to play out. */
+    transitionDuration = 0.3;
+
+    /** Tile tints, cycled by index. */
+    palette = [
+        '0.19 0.6 0.85',
+        '0.4 0.76 0.35',
+        '0.97 0.75 0.1',
+        '0.88 0.4 0.14',
+        '0.6 0.44 0.85'
+    ];
+
+    initialize() {
+        this.panelElement = document.getElementById('panel-element');
+        this.shadowElement = document.getElementById('shadow-element');
+        this.readoutElement = document.getElementById('readout-element');
+        this.tilesGroup = document.getElementById('tiles-group');
+        this.tileTemplate = document.getElementById('tile');
+
+        // The field is where tiles are appended, so it is the group element's parent entity.
+        this.tilesElement = this.tilesGroup.parentElement;
+
+        this.horizontal = true;
+        this.wrap = true;
+
+        // Both dimensions are eased, so each needs a current value and a target to move towards.
+        this.width = this.maxPanelWidth;
+        this.targetWidth = this.width;
+        this.tiles = [];
+        this.height = this._targetHeight();
+
+        this._wireControls();
+
+        for (let i = 0; i < this.initialTileCount; i++) {
+            this.addTile();
+        }
+
+        // Snap rather than ease on the first frame, so the board does not unfold on load.
+        this.height = this._targetHeight();
+        this._applySize();
+        this._applyLayout();
+    }
+
+    /**
+     * Binds each control to its action. The buttons are declared in the page so their labels and
+     * layout stay in the markup; only the behaviour lives here.
+     */
+    _wireControls() {
+        const actions = {
+            narrower: () => this._nudgeWidth(-this.widthStep),
+            wider: () => this._nudgeWidth(this.widthStep),
+            orientation: () => {
+                this.horizontal = !this.horizontal;
+                this._applyLayout();
+            },
+            wrap: () => {
+                this.wrap = !this.wrap;
+                this._applyLayout();
+            },
+            remove: () => this.removeTile(),
+            add: () => this.addTile()
+        };
+
+        for (const [name, action] of Object.entries(actions)) {
+            this.entity.findByName(`control-${name}`)?.button?.on('click', action);
+        }
+    }
+
+    _nudgeWidth(delta) {
+        const width = this.targetWidth + delta;
+        this.targetWidth = Math.max(this.minPanelWidth, Math.min(this.maxPanelWidth, width));
+        this._updateReadout();
+    }
+
+    /**
+     * Adds one tile by cloning the page's `<template>`. The web-components lifecycle turns the
+     * cloned markup into entities, so the tile only needs its tint and its number.
+     */
+    addTile() {
+        if (this.tiles.length >= this.maxTileCount) {
+            return;
+        }
+
+        const fragment = this.tileTemplate.content.cloneNode(true);
+        const tileElement = fragment.querySelector('pc-entity');
+        const index = this.tiles.length + 1;
+
+        tileElement.querySelector(':scope > pc-element')
+            .setAttribute('color', this.palette[(index - 1) % this.palette.length]);
+        tileElement.querySelector('pc-entity[name="tile-label"] > pc-element')
+            .setAttribute('text', String(index));
+
+        this.tiles.push(tileElement);
+        this.tilesElement.appendChild(fragment);
+        this._updateReadout();
+    }
+
+    removeTile() {
+        if (this.tiles.length <= this.minTileCount) {
+            return;
+        }
+
+        // Removing the element destroys its entity through the web-components lifecycle.
+        this.tiles.pop().remove();
+        this._updateReadout();
+    }
+
+    /** Pushes the current orientation and wrap onto the tile field's layout group. */
+    _applyLayout() {
+        this.tilesGroup.setAttribute('orientation', this.horizontal ? 'horizontal' : 'vertical');
+
+        // A boolean element attribute is presence-based, so wrap is added and removed rather
+        // than set to a string - `wrap="false"` would still read as wrap on.
+        if (this.wrap) {
+            this.tilesGroup.setAttribute('wrap', '');
+        } else {
+            this.tilesGroup.removeAttribute('wrap');
+        }
+
+        this._label('control-orientation', this.horizontal ? 'Row' : 'Column');
+        this._label('control-wrap', this.wrap ? 'Wrap on' : 'Wrap off');
+        this._updateReadout();
+    }
+
+    /**
+     * Sizes the panel and its shadow. Nothing inside the panel is touched: the bands are anchored
+     * to its edges, so they follow, and the control row refits its own buttons.
+     */
+    _applySize() {
+        for (const element of [this.panelElement, this.shadowElement]) {
+            element.setAttribute('width', String(Math.round(this.width)));
+            element.setAttribute('height', String(Math.round(this.height)));
+        }
+    }
+
+    /**
+     * The height the panel wants: enough for the rows the tiles wrap into at the target width, so
+     * the panel grows and shrinks with its content instead of reserving room for the largest case.
+     * This is also the only thing here that stretches a sliced sprite vertically.
+     */
+    _targetHeight() {
+        const rows = this._rowsAt(this.targetWidth);
+        return this.chromeHeight + rows * this.tileHeight + (rows - 1) * this.tileSpacing;
+    }
+
+    /**
+     * How many rows of tiles the field has to be tall enough for, at a given panel width.
+     *
+     * Only one of the four cases can be counted. Running in columns, the wrap goes the other way
+     * and the answer is whatever the field is tall enough to hold, which is circular; and with
+     * wrap off the tiles run past the field's edge however tall it is. Both are fixed rather than
+     * derived, and the field masks whatever spills.
+     */
+    _rowsAt(panelWidth) {
+        if (!this.horizontal) {
+            return this.verticalRows;
+        }
+        if (!this.wrap) {
+            return 1;
+        }
+
+        const usable = panelWidth - this.fieldInset;
+        const stride = this.tileWidth + this.tileSpacing;
+        const perRow = Math.max(1, Math.floor((usable + this.tileSpacing) / stride));
+        return Math.max(1, Math.ceil(this.tiles.length / perRow));
+    }
+
+    _label(controlName, text) {
+        const control = this.entity.findByName(controlName);
+        const label = control?.findByName('label');
+        if (label?.element) {
+            label.element.text = text;
+        }
+    }
+
+    _updateReadout() {
+        const parts = [
+            this.horizontal ? 'horizontal' : 'vertical',
+            this.wrap ? 'wrap on' : 'wrap off',
+            `${this.tiles.length} tiles`,
+            `${Math.round(this.targetWidth)} wide`
+        ];
+        this.readoutElement.setAttribute('text', parts.join('   '));
+    }
+
+    update(dt) {
+        const targetHeight = this._targetHeight();
+        if (Math.abs(this.targetWidth - this.width) < 0.5 && Math.abs(targetHeight - this.height) < 0.5) {
+            return;
+        }
+
+        // Framerate-independent exponential ease towards both targets.
+        const t = 1 - Math.exp(-dt / (this.transitionDuration / 3));
+        this.width += (this.targetWidth - this.width) * t;
+        this.height += (targetHeight - this.height) * t;
+        this._applySize();
+    }
+}

--- a/examples/js/example-list.mjs
+++ b/examples/js/example-list.mjs
@@ -64,5 +64,6 @@ export const examples = [
     { name: '2D Screen', path: '2d-screen.html', category: 'UI & Text' },
     { name: 'Text', path: 'text.html', category: 'UI & Text' },
     { name: '3D Text', path: '3d-text.html', category: 'UI & Text' },
-    { name: 'Scroll View', path: 'scroll-view.html', category: 'UI & Text' }
+    { name: 'Scroll View', path: 'scroll-view.html', category: 'UI & Text' },
+    { name: 'UI Layout', path: 'ui-layout.html', category: 'UI & Text' }
 ];

--- a/examples/ui-layout.html
+++ b/examples/ui-layout.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+        <title>PlayCanvas Web Components - UI Layout</title>
+        <script type="importmap">
+            {
+                "imports": {
+                    "@playcanvas/web-components": "../dist/pwc.mjs",
+                    "playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"
+                }
+            }
+        </script>
+        <script type="module" src="../dist/pwc.mjs"></script>
+        <link rel="stylesheet" href="css/example.css">
+    </head>
+    <body>
+        <pc-app>
+            <!-- Assets -->
+            <pc-asset src="../node_modules/playcanvas/scripts/esm/camera-controls.mjs"></pc-asset>
+            <pc-asset src="assets/scripts/ui-layout.mjs"></pc-asset>
+            <pc-asset src="assets/fonts/kenney-future.json" type="font" id="kenney"></pc-asset>
+            <!-- Texture atlas. The atlas must be declared before the sprites that reference it.
+                 Both frames carry a border, so both can be nine-sliced: the panel's is its 10px
+                 rounded corner, and the button's bottom border is the 10px bevel that would
+                 otherwise squash when the control row stretches it. -->
+            <pc-asset id="ui-sheet" type="textureatlas" src="assets/textures/ui-spritesheet.png" min-filter="linear-mip-linear" mag-filter="linear" anisotropy="1" mipmaps srgb data='{"rgbm":false,"frames":{"0":{"name":"blue_button","border":[8,10,8,7],"rect":[1,150,190,45],"pivot":[0.5,0.5]},"3":{"name":"grey_panel","border":[10,10,10,10],"rect":[41,1,100,100],"pivot":[0.5,0.5]}}}'></pc-asset>
+            <!-- Sprites. pixels-per-unit="1" keeps one atlas pixel to one screen unit, so a
+                 sliced border stays the size the atlas declares at any element size. -->
+            <pc-asset id="panel-sprite" type="sprite" atlas="ui-sheet" frame-keys="3" pixels-per-unit="1" render-mode="sliced"></pc-asset>
+            <pc-asset id="button-sprite" type="sprite" atlas="ui-sheet" frame-keys="0" pixels-per-unit="1" render-mode="sliced"></pc-asset>
+            <!-- Scene -->
+            <pc-scene>
+                <!-- Camera -->
+                <pc-entity name="camera-root">
+                    <pc-entity name="camera" position="1.65 2.15 5.7">
+                        <pc-camera clear-color="#11151c" fov="42"></pc-camera>
+                        <pc-script>
+                            <pc-script-instance name="cameraControls"
+                                                enable-fly="false"
+                                                enable-pan="false"
+                                                focus-point="0 1.6 0"
+                                                pitch-range="-35 35"
+                                                zoom-range="3.5 11"></pc-script-instance>
+                        </pc-script>
+                    </pc-entity>
+                </pc-entity>
+                <!-- Board. A world-space screen - no screen-space attribute - so the interface is
+                     an object in the scene that the camera orbits, not an overlay on top of it.
+                     The entity scale is what converts screen units to world units.
+
+                     Only the panel's width is scripted. Every band inside it is anchored to two
+                     opposite edges, so the header, field and control row follow the panel on
+                     their own, and the control row's layout group redistributes its buttons. -->
+                <pc-entity name="board" position="0 1.6 0" scale="0.0052 0.0052 0.0052">
+                    <pc-screen resolution="1000 640" reference-resolution="1000 640"></pc-screen>
+                    <pc-script>
+                        <pc-script-instance name="uiLayout"></pc-script-instance>
+                    </pc-script>
+
+                    <!-- Drop shadow: the same sliced sprite, tinted black and offset, which
+                         lifts the board off the backdrop. -->
+                    <pc-entity name="panel-shadow" position="7 -11 -1">
+                        <pc-element id="shadow-element" type="image" anchor="0.5 0.5 0.5 0.5" pivot="0.5 0.5" width="900" height="520" color="0 0 0" opacity="0.5" sprite-asset="panel-sprite"></pc-element>
+                    </pc-entity>
+
+                    <!-- Panel -->
+                    <pc-entity name="panel">
+                        <pc-element id="panel-element" type="image" anchor="0.5 0.5 0.5 0.5" pivot="0.5 0.5" width="900" height="520" color="0.15 0.18 0.24" sprite-asset="panel-sprite"></pc-element>
+
+                        <!-- Header bar, pinned to the panel's top edge -->
+                        <pc-entity name="header">
+                            <pc-element type="image" anchor="0 1 1 1" pivot="0.5 1" margin="14 0 14 14" height="66" color="0.11 0.13 0.18" sprite-asset="panel-sprite"></pc-element>
+
+                            <pc-entity name="title">
+                                <pc-element type="text" anchor="0 0.5 0 0.5" pivot="0 0.5" margin="20 0 0 0" font-asset="kenney" font-size="26" color="0.93 0.96 1" text="UI Layout"></pc-element>
+                            </pc-entity>
+                            <pc-entity name="readout">
+                                <pc-element id="readout-element" type="text" anchor="1 0.5 1 0.5" pivot="1 0.5" margin="0 0 20 0" auto-width="false" auto-height="false" auto-fit-width width="330" height="20" font-asset="kenney" font-size="16" min-font-size="8" max-font-size="16" color="0.42 0.54 0.68" text="-"></pc-element>
+                            </pc-entity>
+                        </pc-entity>
+
+                        <!-- Tile field. Stretched between the header and the control row, so it
+                             grows with the panel in both directions. -->
+                        <pc-entity name="field">
+                            <pc-element type="image" anchor="0 0 1 1" pivot="0.5 0.5" margin="14 84 14 92" color="0.09 0.11 0.15" sprite-asset="panel-sprite" mask></pc-element>
+
+                            <pc-entity name="tiles">
+                                <pc-element type="group" anchor="0 0 1 1" pivot="0.5 0.5" margin="10 10 10 10"></pc-element>
+                                <pc-layout-group id="tiles-group" orientation="horizontal" wrap reverse-y alignment="0 1" spacing="12 12"></pc-layout-group>
+                            </pc-entity>
+                        </pc-entity>
+
+                        <!-- Control row, pinned to the panel's bottom edge. width-fitting="stretch"
+                             hands the row's width out to the buttons in proportion to each one's
+                             fit-width-proportion, so they refill the row whenever it resizes. -->
+                        <pc-entity name="controls">
+                            <pc-element type="group" anchor="0 0 1 0" pivot="0.5 0" margin="14 14 14 0" height="56"></pc-element>
+                            <pc-layout-group orientation="horizontal" alignment="0 0.5" spacing="10 0" width-fitting="both" height-fitting="stretch"></pc-layout-group>
+
+                            <pc-entity name="control-narrower">
+                                <pc-element type="image" anchor="0 0 0 0" pivot="0 0" width="90" height="56" color="0.26 0.31 0.4" sprite-asset="button-sprite" use-input></pc-element>
+                                <pc-layout-child fit-width-proportion="0.55" min-width="56"></pc-layout-child>
+                                <pc-button transition-mode="tint" hover-tint="1.3 1.3 1.3 1" pressed-tint="0.65 0.65 0.65 1" fade-duration="80"></pc-button>
+                                <pc-entity name="label">
+                                    <pc-element type="text" anchor="0.5 0.5 0.5 0.5" pivot="0.5 0.5" font-asset="kenney" font-size="26" color="0.93 0.96 1" text="-"></pc-element>
+                                </pc-entity>
+                            </pc-entity>
+
+                            <pc-entity name="control-wider">
+                                <pc-element type="image" anchor="0 0 0 0" pivot="0 0" width="90" height="56" color="0.26 0.31 0.4" sprite-asset="button-sprite" use-input></pc-element>
+                                <pc-layout-child fit-width-proportion="0.55" min-width="56"></pc-layout-child>
+                                <pc-button transition-mode="tint" hover-tint="1.3 1.3 1.3 1" pressed-tint="0.65 0.65 0.65 1" fade-duration="80"></pc-button>
+                                <pc-entity name="label">
+                                    <pc-element type="text" anchor="0.5 0.5 0.5 0.5" pivot="0.5 0.5" font-asset="kenney" font-size="26" color="0.93 0.96 1" text="+"></pc-element>
+                                </pc-entity>
+                            </pc-entity>
+
+                            <pc-entity name="control-orientation">
+                                <pc-element type="image" anchor="0 0 0 0" pivot="0 0" width="90" height="56" color="0.19 0.6 0.85" sprite-asset="button-sprite" use-input></pc-element>
+                                <pc-layout-child fit-width-proportion="1.5" min-width="104"></pc-layout-child>
+                                <pc-button transition-mode="tint" hover-tint="1.25 1.25 1.25 1" pressed-tint="0.65 0.65 0.65 1" fade-duration="80"></pc-button>
+                                <pc-entity name="label">
+                                    <pc-element type="text" anchor="0 0.5 1 0.5" pivot="0.5 0.5" margin="10 0 10 0" auto-width="false" auto-height="false" auto-fit-width font-asset="kenney" font-size="18" min-font-size="9" max-font-size="18" height="24" color="1 1 1" text="Row"></pc-element>
+                                </pc-entity>
+                            </pc-entity>
+
+                            <pc-entity name="control-wrap">
+                                <pc-element type="image" anchor="0 0 0 0" pivot="0 0" width="90" height="56" color="0.4 0.76 0.35" sprite-asset="button-sprite" use-input></pc-element>
+                                <pc-layout-child fit-width-proportion="1.5" min-width="104"></pc-layout-child>
+                                <pc-button transition-mode="tint" hover-tint="1.25 1.25 1.25 1" pressed-tint="0.65 0.65 0.65 1" fade-duration="80"></pc-button>
+                                <pc-entity name="label">
+                                    <pc-element type="text" anchor="0 0.5 1 0.5" pivot="0.5 0.5" margin="10 0 10 0" auto-width="false" auto-height="false" auto-fit-width font-asset="kenney" font-size="18" min-font-size="9" max-font-size="18" height="24" color="0.06 0.16 0.05" text="Wrap on"></pc-element>
+                                </pc-entity>
+                            </pc-entity>
+
+                            <pc-entity name="control-remove">
+                                <pc-element type="image" anchor="0 0 0 0" pivot="0 0" width="90" height="56" color="0.88 0.4 0.14" sprite-asset="button-sprite" use-input></pc-element>
+                                <pc-layout-child fit-width-proportion="1.2" min-width="92"></pc-layout-child>
+                                <pc-button transition-mode="tint" hover-tint="1.25 1.25 1.25 1" pressed-tint="0.65 0.65 0.65 1" fade-duration="80"></pc-button>
+                                <pc-entity name="label">
+                                    <pc-element type="text" anchor="0 0.5 1 0.5" pivot="0.5 0.5" margin="10 0 10 0" auto-width="false" auto-height="false" auto-fit-width font-asset="kenney" font-size="18" min-font-size="9" max-font-size="18" height="24" color="1 1 1" text="Remove"></pc-element>
+                                </pc-entity>
+                            </pc-entity>
+
+                            <pc-entity name="control-add">
+                                <pc-element type="image" anchor="0 0 0 0" pivot="0 0" width="90" height="56" color="0.97 0.75 0.1" sprite-asset="button-sprite" use-input></pc-element>
+                                <pc-layout-child fit-width-proportion="1.2" min-width="92"></pc-layout-child>
+                                <pc-button transition-mode="tint" hover-tint="1.25 1.25 1.25 1" pressed-tint="0.65 0.65 0.65 1" fade-duration="80"></pc-button>
+                                <pc-entity name="label">
+                                    <pc-element type="text" anchor="0 0.5 1 0.5" pivot="0.5 0.5" margin="10 0 10 0" auto-width="false" auto-height="false" auto-fit-width font-asset="kenney" font-size="18" min-font-size="9" max-font-size="18" height="24" color="0.16 0.13 0.03" text="Add tile"></pc-element>
+                                </pc-entity>
+                            </pc-entity>
+                        </pc-entity>
+                    </pc-entity>
+                </pc-entity>
+            </pc-scene>
+        </pc-app>
+
+        <!-- Tile template. Cloned by the board script, so a tile's own layout stays declarative. -->
+        <template id="tile">
+            <pc-entity name="tile">
+                <pc-element type="image" anchor="0 1 0 1" pivot="0 1" width="128" height="86" color="0.19 0.6 0.85" sprite-asset="panel-sprite"></pc-element>
+                <pc-layout-child min-width="128" min-height="86"></pc-layout-child>
+                <pc-entity name="tile-label">
+                    <pc-element type="text" anchor="0.5 0.5 0.5 0.5" pivot="0.5 0.5" font-asset="kenney" font-size="30" color="1 1 1" text="1"></pc-element>
+                </pc-entity>
+            </pc-entity>
+        </template>
+
+        <script type="module" src="js/example.mjs"></script>
+    </body>
+</html>


### PR DESCRIPTION
### Why

The UI elements had one demonstration between them, `scroll-view.html`, and both it and `2d-screen.html` put their screen in screen space. So two gaps: nothing showed a `<pc-screen>` **without** `screen-space`, and nothing showed nine-slicing or layout fitting *doing* anything — they were used statically, where the effect is invisible.

Coverage-wise, `pc-scroll-view`, `pc-scrollbar`, `pc-layout-group` and `pc-layout-child` all had exactly one usage in the repo, all four in the same file.

### What

`examples/ui-layout.html` + `examples/assets/scripts/ui-layout.mjs` — an interactive layout board whose subject *is* the layout system. It hangs in the scene as an object the camera orbits, and its controls resize and rewire it while you watch.

**World-space screen.** No `screen-space` attribute, so the entity scale converts screen units to world units and `cameraControls` orbits it. I verified up front that this path actually works — a throwaway probe confirmed a world-space screen renders and that its buttons receive clicks (`hoverstart` fired, the handler ran, the label updated) before I designed anything around it.

**Nine-slicing, made visible.** Panel, drop shadow, header, field, all 12 tiles and all 6 buttons are the same two sliced sprites, tinted. The width controls animate the panel and the whole board restretches with corners intact. Note the atlas data: I gave the *button* frame a border of `[8,10,8,7]`, because the Kenney button art ships with none — without it the 10px bottom bevel squashes as the control row stretches it.

**Anchoring and fitting instead of script.** The script sets the panel's width and height, and nothing else. Each band inside is anchored to two opposite edges so it follows on its own, and the control row's `width-fitting="both"` hands its width out by each button's `fit-width-proportion`. Measured at 940 wide: 115/115/171/171/146/146, filling all 862 of it.

**Wrap, orientation, masking.** The field wraps into as many rows as it needs and the panel height follows the row count. Orientation runs the tiles in columns instead. Wrap off runs them off the field edge, where a `mask` on the field clips them rather than letting them spill outside the panel.

### Notes for reviewers

- **Attributes, not components.** The script drives everything through element attributes. That is deliberate and worth knowing generally: a cloned tile's `<pc-element>` does not exist the instant its `<pc-entity>` reports ready, so `entity.element.text = ...` there is a silent no-op, while an attribute is picked up whenever the component does arrive. This cost me a debugging round — all twelve tiles rendered with the template's default label.
- **`minPanelWidth = 600` is load-bearing.** Below it the buttons sit on their `min-width` and start overrunning the panel instead of shrinking further. Found by driving it to an earlier floor of 470 and watching "Add tile" spill outside; the constant carries a comment saying so.
- **`chromeHeight` and the tile metrics are duplicated between the script and the markup.** The script needs the tile footprint to work out the row count, which is what the panel height follows. Change one and the other needs the same edit — flagging it as the least satisfying part of the design.
- **No XR.** A world-space panel is the obvious VR demo and 14 examples already carry the standard XR block, but whether `xr-controllers` ray input reaches `ElementInput` on a world-space screen is not something I can verify without a headset, so I did not ship the claim. Good follow-up if someone can try it on device.

### Verification

Driven with synthesized mouse events against the running page: world-space buttons receive input, every one of the six controls acts, tile add/remove works up to its bounds, and no page load fails a resource. `npm test` 952 passing (the markup guardrail from #405 validated this new page along with the other 37), `npm run lint` and `npm run type-check` clean.
