### PR TITLE
Clear all 24 TypeDoc warnings from the docs build

### DIFF
--- a/src/asset.ts
+++ b/src/asset.ts
@@ -26,7 +26,8 @@ const renderModes = new Map<'simple' | 'sliced' | 'tiled', number>([
     ['tiled', SPRITE_RENDERMODE_TILED]
 ]);
 
-type AddressMode = 'repeat' | 'clamp' | 'mirror';
+/** The addressing modes for a texture asset. */
+export type AddressMode = 'repeat' | 'clamp' | 'mirror';
 
 const addressModes = new Map<AddressMode, number>([
     ['repeat', ADDRESS_REPEAT],
@@ -34,7 +35,8 @@ const addressModes = new Map<AddressMode, number>([
     ['mirror', ADDRESS_MIRRORED_REPEAT]
 ]);
 
-type MinFilterMode =
+/** The minification filter modes for a texture asset. */
+export type MinFilterMode =
     'nearest' | 'linear' | 'nearest-mip-nearest' | 'linear-mip-nearest' | 'nearest-mip-linear' | 'linear-mip-linear';
 
 const minFilterModes = new Map<MinFilterMode, number>([
@@ -46,8 +48,11 @@ const minFilterModes = new Map<MinFilterMode, number>([
     ['linear-mip-linear', FILTER_LINEAR_MIPMAP_LINEAR]
 ]);
 
-// Magnification has no mip variants - the engine (and the GPU) only accepts these two.
-type MagFilterMode = 'nearest' | 'linear';
+/**
+ * The magnification filter modes for a texture asset. Magnification has no mip variants - the
+ * engine (and the GPU) only accepts these two.
+ */
+export type MagFilterMode = 'nearest' | 'linear';
 
 const magFilterModes = new Map<MagFilterMode, number>([
     ['nearest', FILTER_NEAREST],

--- a/src/components/joint-component.ts
+++ b/src/components/joint-component.ts
@@ -5,9 +5,14 @@ import { getEntity, parseBool, parseEnum, parseNumber, parseVec2, parseVec3 } fr
 
 import { ComponentElement } from './component';
 
-type JointType = 'fixed' | 'ball' | 'hinge' | 'slider' | '6dof';
+/** The constraint types supported by the `<pc-joint>` element. */
+export type JointType = 'fixed' | 'ball' | 'hinge' | 'slider' | '6dof';
 
-type MotionMode = 'locked' | 'limited' | 'free';
+/**
+ * The motion modes for a single joint axis: fully constrained (`locked`), constrained within
+ * limits (`limited`) or unconstrained (`free`).
+ */
+export type MotionMode = 'locked' | 'limited' | 'free';
 
 /**
  * The JointComponentElement interface provides properties and methods for manipulating

--- a/src/entity-base.ts
+++ b/src/entity-base.ts
@@ -78,7 +78,7 @@ class EntityBaseElement extends AsyncElement {
      * Tracks whether an inline `onpointer*` attribute is present. The browser itself compiles and
      * runs these attributes — they are standard `GlobalEventHandlers`, so setting one replaces
      * the previous handler and removing it removes the handler, exactly like `onclick` on any
-     * HTML element. But because they bypass {@link addEventListener}, the connect/disconnect
+     * HTML element. But because they bypass {@link EventTarget.addEventListener}, the connect/disconnect
      * bookkeeping that lets the application lazily attach its canvas pointer handlers must be
      * kept in sync here.
      *
@@ -122,7 +122,7 @@ class EntityBaseElement extends AsyncElement {
 
     /**
      * Whether the element has a listener for an event type, registered either with
-     * {@link addEventListener} or with the matching inline `onpointer*` attribute. Read by the
+     * {@link EventTarget.addEventListener} or with the matching inline `onpointer*` attribute. Read by the
      * containing `<pc-app>` element to gate pointer event synthesis.
      *
      * @param type - The event type.

--- a/src/entity-owner.ts
+++ b/src/entity-owner.ts
@@ -69,7 +69,7 @@ class EntityOwnerElement extends EntityBaseElement {
     private _tags: string[] = [];
 
     /**
-     * Whether the hierarchy has been built for this entity — set once {@link _buildHierarchy} has
+     * Whether the hierarchy has been built for this entity — set once `_buildHierarchy` has
      * parented it. Read by subclasses that gate work on the entity being in the scene graph.
      */
     protected _built = false;
@@ -170,7 +170,7 @@ class EntityOwnerElement extends EntityBaseElement {
     }
 
     /**
-     * Called by {@link _buildHierarchy} once the backing entity has been parented — exactly once
+     * Called by `_buildHierarchy` once the backing entity has been parented — exactly once
      * per build cycle. The default announces readiness, which is what a parented `<pc-entity>`
      * means; `<pc-model>` overrides it to start loading content instead, because its readiness
      * tracks the content settling rather than the host entering the scene graph.

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -12,7 +12,7 @@ import { parseBool, parseTags, parseVec3 } from './parse';
  *
  * The pointer events below are dispatched by the containing `<pc-app>` element when the pointer
  * intersects this entity's geometry. They are only generated while the entity has a listener for
- * them, registered either with {@link addEventListener} or with the matching inline `onpointer*`
+ * them, registered either with {@link EventTarget.addEventListener} or with the matching inline `onpointer*`
  * attribute.
  *
  * @attribute {boolean} enabled - The enabled state of the entity.

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,17 @@ export {
     whenReady
 };
 
+export type { AddressMode, MagFilterMode, MinFilterMode } from './asset';
 export type { AsyncElementTagName } from './async-element';
+export type { JointType, MotionMode } from './components/joint-component';
+export type {
+    BlendType,
+    ColorChannel,
+    CullMode,
+    FresnelModel,
+    OccludeSpecular,
+    OpacityDither,
+    ScalarChannel
+} from './material';
 export type { HierarchyMaterial, HierarchyNode } from './model';
-export type { MaterialOverrides } from './node';
+export type { MaterialOverrides, NodeBindingState } from './node';

--- a/src/material.ts
+++ b/src/material.ts
@@ -29,7 +29,8 @@ import type { AppElement } from './app';
 import { useAsset } from './asset';
 import { parseBool, parseColor, parseEnum, parseNumber, parseVec2 } from './parse';
 
-type BlendType =
+/** The blend modes for a material. */
+export type BlendType =
     | 'none'
     | 'normal'
     | 'additive'
@@ -56,7 +57,8 @@ const blendTypes = new Map<BlendType, number>([
     ['subtractive', BLEND_SUBTRACTIVE]
 ]);
 
-type CullMode = 'none' | 'back' | 'front' | 'front-and-back';
+/** The face culling modes for a material. */
+export type CullMode = 'none' | 'back' | 'front' | 'front-and-back';
 
 const cullModes = new Map<CullMode, number>([
     ['none', CULLFACE_NONE],
@@ -65,14 +67,16 @@ const cullModes = new Map<CullMode, number>([
     ['front-and-back', CULLFACE_FRONTANDBACK]
 ]);
 
-type FresnelModel = 'none' | 'schlick';
+/** The Fresnel models for a material. */
+export type FresnelModel = 'none' | 'schlick';
 
 const fresnelModels = new Map<FresnelModel, number>([
     ['none', FRESNEL_NONE],
     ['schlick', FRESNEL_SCHLICK]
 ]);
 
-type OccludeSpecular = 'none' | 'ao' | 'gloss-dependent';
+/** The specular occlusion modes for a material. */
+export type OccludeSpecular = 'none' | 'ao' | 'gloss-dependent';
 
 const occludeSpeculars = new Map<OccludeSpecular, number>([
     ['none', SPECOCC_NONE],
@@ -80,17 +84,20 @@ const occludeSpeculars = new Map<OccludeSpecular, number>([
     ['gloss-dependent', SPECOCC_GLOSSDEPENDENT]
 ]);
 
+/** The opacity dithering modes for a material. */
+export type OpacityDither = 'none' | 'bayer8' | 'bluenoise' | 'ignnoise';
+
 // The DITHER_* constants are strings whose values are exactly these names, so a parsed value is
 // assigned to the material unchanged rather than mapped through a table.
-type OpacityDither = 'none' | 'bayer8' | 'bluenoise' | 'ignnoise';
-
 const opacityDithers: OpacityDither[] = ['none', 'bayer8', 'bluenoise', 'ignnoise'];
 
-type ColorChannel = 'r' | 'g' | 'b' | 'a' | 'rgb';
+/** The texture channels a color map can sample. */
+export type ColorChannel = 'r' | 'g' | 'b' | 'a' | 'rgb';
 
 const colorChannels: ColorChannel[] = ['r', 'g', 'b', 'a', 'rgb'];
 
-type ScalarChannel = 'r' | 'g' | 'b' | 'a';
+/** The texture channels a scalar map can sample. */
+export type ScalarChannel = 'r' | 'g' | 'b' | 'a';
 
 const scalarChannels: ScalarChannel[] = ['r', 'g', 'b', 'a'];
 

--- a/src/node.ts
+++ b/src/node.ts
@@ -15,7 +15,7 @@ import { parseBool, parseTags, parseVec3 } from './parse';
  * `missing`/`ambiguous`/`duplicate` when resolution failed — each accompanied by a warning
  * naming the cause.
  */
-type NodeBindingState = 'pending' | 'bound' | 'missing' | 'ambiguous' | 'duplicate';
+export type NodeBindingState = 'pending' | 'bound' | 'missing' | 'ambiguous' | 'duplicate';
 
 /**
  * The authored values a bound node's overrides displaced, captured per property when the first


### PR DESCRIPTION
`npm run docs` emitted 24 warnings. This clears all of them at the source — `typedoc.json` is untouched — and makes the generated reference genuinely better along the way.

## What changed

**Exported and documented the 13 enum-like union types referenced by public signatures** — `AddressMode`, `MinFilterMode`, `MagFilterMode` (`asset.ts`); `BlendType`, `CullMode`, `FresnelModel`, `OccludeSpecular`, `OpacityDither`, `ColorChannel`, `ScalarChannel` (`material.ts`); `JointType`, `MotionMode` (`joint-component.ts`); `NodeBindingState` (`node.ts`). Each gets a one-line doc comment and a type-only re-export from `index.ts`. Both halves are needed: exporting silences TypeDoc's `notExported` validation, but under `excludeNotDocumented` an un-commented alias still doesn't render, leaving dead unlinked type names in signatures. With both, properties like `blendType` and `addressU` now hyperlink to pages listing their allowed values. Existing notes were preserved: `MagFilterMode`'s "no mip variants" rationale moved into its (now user-visible) doc comment, and the `DITHER_*` implementation note stayed with the array it explains.

**Qualified `{@link addEventListener}` as `{@link EventTarget.addEventListener}`** in `entity.ts` and `entity-base.ts`. The already-bundled `typedoc-plugin-mdn-links` keys the method under `EventTarget`, so the qualified form resolves to a working MDN link while the bare member name cannot. (The occurrence in `_hasListeners` is inside an `@internal` comment and never warned, but is updated for consistency.)

**Downgraded `{@link _buildHierarchy}` to backticks** in `entity-owner.ts`. The method is deliberately `@internal`, so a link to it can never resolve; plain code formatting matches how the rest of the file refers to it.

## Notes for reviewers

- The new type exports are additive and non-breaking.
- Verified: `npm run docs` now reports 0 warnings; lint, `type-check` (src + test), and the full test suite (952/952) pass; the build succeeds with the custom elements manifest validating at the same 31 elements; publint is clean; and both emitted declaration flavors (`dist/index.d.ts` / `.d.cts`) compile standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
