### PR TITLE
Describe the element, not the class, in editor tooltips

### DIFF
--- a/custom-elements-manifest.config.mjs
+++ b/custom-elements-manifest.config.mjs
@@ -3,6 +3,7 @@ import { customElementVsCodePlugin } from 'custom-element-vs-code-integration';
 
 import { attributesFromCallbackPlugin } from './utils/cem/attributes-plugin.mjs';
 import { manifestCleanupPlugin } from './utils/cem/cleanup-plugin.mjs';
+import { elementSummaryPlugin } from './utils/cem/summary-plugin.mjs';
 
 /**
  * The element's page in the User Manual, which both editors surface as a link at the foot of the
@@ -32,13 +33,16 @@ export default {
     plugins: [
         // Derives attribute metadata from each element's attributeChangedCallback
         attributesFromCallbackPlugin(),
+
+        // Publishes each element's `@elementSummary` as its `summary`
+        elementSummaryPlugin(),
         manifestCleanupPlugin(),
 
         // Editor integrations, generated from the manifest above. Both describe an element with
         // its `summary` where it has one, falling back to its `description` - which is why every
-        // element carries an `@summary`: the description is the class reference ("The XElement
-        // interface provides properties and methods for manipulating ..."), and what an author
-        // hovering a tag in HTML needs is a description of the element.
+        // element carries an `@elementSummary`: the description is the class reference ("The
+        // XElement interface provides properties and methods for manipulating ..."), and what an
+        // author hovering a tag in HTML needs is a description of the element.
         //
         // Methods are hidden from both for the same reason. They are the element's JavaScript
         // surface, documented in the API reference the tooltip links to, and listing them puts

--- a/custom-elements-manifest.config.mjs
+++ b/custom-elements-manifest.config.mjs
@@ -4,6 +4,19 @@ import { customElementVsCodePlugin } from 'custom-element-vs-code-integration';
 import { attributesFromCallbackPlugin } from './utils/cem/attributes-plugin.mjs';
 import { manifestCleanupPlugin } from './utils/cem/cleanup-plugin.mjs';
 
+/**
+ * The element's page in the User Manual, which both editors surface as a link at the foot of the
+ * tooltip - the equivalent of the MDN reference a standard element's tooltip carries. Every tag
+ * has a page, and `validate.mjs` checks that every generated link points at one.
+ *
+ * @param {string} tag - The element's tag name.
+ * @returns {{ name: string, url: string }} The reference to publish.
+ */
+const userManual = tag => ({
+    name: 'User Manual',
+    url: `https://developer.playcanvas.com/user-manual/web-components/tags/${tag}/`
+});
+
 export default {
     globs: ['src/**/*.ts'],
 
@@ -21,15 +34,29 @@ export default {
         attributesFromCallbackPlugin(),
         manifestCleanupPlugin(),
 
-        // Editor integrations, generated from the manifest above
+        // Editor integrations, generated from the manifest above. Both describe an element with
+        // its `summary` where it has one, falling back to its `description` - which is why every
+        // element carries an `@summary`: the description is the class reference ("The XElement
+        // interface provides properties and methods for manipulating ..."), and what an author
+        // hovering a tag in HTML needs is a description of the element.
+        //
+        // Methods are hidden from both for the same reason. They are the element's JavaScript
+        // surface, documented in the API reference the tooltip links to, and listing them puts
+        // several paragraphs about `ready()` above the attribute an author was reaching for.
         customElementVsCodePlugin({
             outdir: 'dist',
             htmlFileName: 'vscode.html-custom-data.json',
-            cssFileName: null
+            cssFileName: null,
+            hideMethodDocs: true,
+            referencesTemplate: (_name, tag) => (tag ? [userManual(tag)] : [])
         }),
         customElementJetBrainsPlugin({
             outdir: 'dist',
             webTypesFileName: 'web-types.json',
+            hideMethodDocs: true,
+
+            // The plugin takes a single reference and publishes its URL as the element's `doc-url`
+            referenceTemplate: (_name, tag) => userManual(tag),
 
             // The `web-types` field is declared in package.json by hand, so the plugin must not
             // rewrite the file on every build

--- a/src/app.ts
+++ b/src/app.ts
@@ -112,6 +112,10 @@ const ensureBaseStyles = () => {
  * tracked live via a ResizeObserver — so the element can be embedded at any size, resized by
  * its container, or made fullscreen with ordinary CSS such as `width: 100vw; height: 100dvh`.
  *
+ * @summary The `<pc-app>` element creates a PlayCanvas application and the canvas it renders into,
+ * and is the root of every scene. It holds the `<pc-asset>`, `<pc-material>`, `<pc-wasm>` and
+ * `<pc-scene>` elements, and the page's CSS sizes it, as it would a `<video>`.
+ *
  * @fires {ProgressEvent} progress - Fired while the application preloads its assets. `loaded` and
  * `total` are asset counts, not bytes, and an asset that fails to load still counts as loaded.
  * Fired at least once per boot, and the final event always has `loaded` equal to `total`. Does

--- a/src/app.ts
+++ b/src/app.ts
@@ -112,8 +112,8 @@ const ensureBaseStyles = () => {
  * tracked live via a ResizeObserver — so the element can be embedded at any size, resized by
  * its container, or made fullscreen with ordinary CSS such as `width: 100vw; height: 100dvh`.
  *
- * @summary The `<pc-app>` element creates a PlayCanvas application and the canvas it renders into,
- * and is the root of every scene. It holds the `<pc-asset>`, `<pc-material>`, `<pc-wasm>` and
+ * @elementSummary The `<pc-app>` element creates a PlayCanvas application and the canvas it renders
+ * into, and is the root of every scene. It holds the `<pc-asset>`, `<pc-material>`, `<pc-wasm>` and
  * `<pc-scene>` elements, and the page's CSS sizes it, as it would a `<video>`.
  *
  * @fires {ProgressEvent} progress - Fired while the application preloads its assets. `loaded` and

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -173,6 +173,10 @@ const processBufferView = (
  * Apart from `lazy` and the texture options, these attributes are read once when the asset is
  * created, so changing them later has no effect.
  *
+ * @summary The `<pc-asset>` element declares an asset for the application to load — a model,
+ * texture, font, sound, script or JSON file — under an `id` that other elements reference. Must be
+ * a direct child of `<pc-app>`.
+ *
  * @attribute {string} id - The identifier used to reference the asset from other elements.
  * @attribute {string} src - The URL of the asset to load.
  * @attribute {string} type - The asset type. Inferred from the `src` file extension when omitted.

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -173,7 +173,7 @@ const processBufferView = (
  * Apart from `lazy` and the texture options, these attributes are read once when the asset is
  * created, so changing them later has no effect.
  *
- * @summary The `<pc-asset>` element declares an asset for the application to load — a model,
+ * @elementSummary The `<pc-asset>` element declares an asset for the application to load — a model,
  * texture, font, sound, script or JSON file — under an `id` that other elements reference. Must be
  * a direct child of `<pc-app>`.
  *

--- a/src/components/anim-clip.ts
+++ b/src/components/anim-clip.ts
@@ -22,6 +22,10 @@ import { AnimComponentElement } from './anim-component';
  * named; in a multi-track source the track named `name` is chosen, falling back to the first
  * with a warning. The element becomes ready once its resolved track is assigned.
  *
+ * @summary The `<pc-anim-clip>` element declares one named animation clip on its parent
+ * `<pc-anim>`, taken from the `asset` it names or, without one, from the enclosing `<pc-model>`'s
+ * own animations. Must be a direct child of `<pc-anim>`.
+ *
  * @category Components
  */
 class AnimClipElement extends AsyncElement {

--- a/src/components/anim-clip.ts
+++ b/src/components/anim-clip.ts
@@ -22,7 +22,7 @@ import { AnimComponentElement } from './anim-component';
  * named; in a multi-track source the track named `name` is chosen, falling back to the first
  * with a warning. The element becomes ready once its resolved track is assigned.
  *
- * @summary The `<pc-anim-clip>` element declares one named animation clip on its parent
+ * @elementSummary The `<pc-anim-clip>` element declares one named animation clip on its parent
  * `<pc-anim>`, taken from the `asset` it names or, without one, from the enclosing `<pc-model>`'s
  * own animations. Must be a direct child of `<pc-anim>`.
  *

--- a/src/components/anim-component.ts
+++ b/src/components/anim-component.ts
@@ -48,9 +48,9 @@ type PlaybackState = {
  *
  * Engine component: {@link AnimComponent} (`anim`).
  *
- * @summary The `<pc-anim>` element plays animation clips over its entity's hierarchy, taken from
- * `<pc-anim-clip>` children or from the enclosing `<pc-model>`'s own animations. The first clip
- * plays automatically, and the `clip` attribute switches between them. Must be a child of a
+ * @elementSummary The `<pc-anim>` element plays animation clips over its entity's hierarchy, taken
+ * from `<pc-anim-clip>` children or from the enclosing `<pc-model>`'s own animations. The first
+ * clip plays automatically, and the `clip` attribute switches between them. Must be a child of a
  * `<pc-entity>`, `<pc-model>` or `<pc-node>`.
  *
  * @category Components

--- a/src/components/anim-component.ts
+++ b/src/components/anim-component.ts
@@ -48,6 +48,11 @@ type PlaybackState = {
  *
  * Engine component: {@link AnimComponent} (`anim`).
  *
+ * @summary The `<pc-anim>` element plays animation clips over its entity's hierarchy, taken from
+ * `<pc-anim-clip>` children or from the enclosing `<pc-model>`'s own animations. The first clip
+ * plays automatically, and the `clip` attribute switches between them. Must be a child of a
+ * `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ *
  * @category Components
  */
 class AnimComponentElement extends ComponentElement {

--- a/src/components/audio-listener-component.ts
+++ b/src/components/audio-listener-component.ts
@@ -10,6 +10,10 @@ import { ComponentElement } from './component';
  *
  * Engine component: {@link AudioListenerComponent} (`audiolistener`).
  *
+ * @summary The `<pc-audio-listener>` element makes its entity the point from which positional
+ * sounds are heard, typically the entity holding the `<pc-camera>`. Must be a child of a
+ * `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ *
  * @category Components
  */
 class AudioListenerComponentElement extends ComponentElement {

--- a/src/components/audio-listener-component.ts
+++ b/src/components/audio-listener-component.ts
@@ -10,8 +10,8 @@ import { ComponentElement } from './component';
  *
  * Engine component: {@link AudioListenerComponent} (`audiolistener`).
  *
- * @summary The `<pc-audio-listener>` element makes its entity the point from which positional
- * sounds are heard, typically the entity holding the `<pc-camera>`. Must be a child of a
+ * @elementSummary The `<pc-audio-listener>` element makes its entity the point from which
+ * positional sounds are heard, typically the entity holding the `<pc-camera>`. Must be a child of a
  * `<pc-entity>`, `<pc-model>` or `<pc-node>`.
  *
  * @category Components

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -19,9 +19,10 @@ const transitionModes = new Map<'tint' | 'sprite', number>([
  *
  * Engine component: {@link ButtonComponent} (`button`).
  *
- * @summary The `<pc-button>` element makes its entity respond to pointer input, tinting or swapping
- * its image as the pointer hovers, presses and releases it. The entity also needs a `<pc-element>`
- * with `use-input` set. Must be a child of a `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ * @elementSummary The `<pc-button>` element makes its entity respond to pointer input, tinting or
+ * swapping its image as the pointer hovers, presses and releases it. The entity also needs a
+ * `<pc-element>` with `use-input` set. Must be a child of a `<pc-entity>`, `<pc-model>` or
+ * `<pc-node>`.
  *
  * @category Components
  */

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -19,6 +19,10 @@ const transitionModes = new Map<'tint' | 'sprite', number>([
  *
  * Engine component: {@link ButtonComponent} (`button`).
  *
+ * @summary The `<pc-button>` element makes its entity respond to pointer input, tinting or swapping
+ * its image as the pointer hovers, presses and releases it. The entity also needs a `<pc-element>`
+ * with `use-input` set. Must be a child of a `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ *
  * @category Components
  */
 class ButtonComponentElement extends ComponentElement {

--- a/src/components/camera-component.ts
+++ b/src/components/camera-component.ts
@@ -43,6 +43,10 @@ const tonemaps = new Map<'none' | 'linear' | 'filmic' | 'hejl' | 'aces' | 'aces2
  *
  * Engine component: {@link CameraComponent} (`camera`).
  *
+ * @summary The `<pc-camera>` element renders the scene from its entity's transform, with attributes
+ * for the projection, field of view, clip planes, clear color and tonemapping. Must be a child of a
+ * `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ *
  * @category Components
  */
 class CameraComponentElement extends ComponentElement {

--- a/src/components/camera-component.ts
+++ b/src/components/camera-component.ts
@@ -43,9 +43,9 @@ const tonemaps = new Map<'none' | 'linear' | 'filmic' | 'hejl' | 'aces' | 'aces2
  *
  * Engine component: {@link CameraComponent} (`camera`).
  *
- * @summary The `<pc-camera>` element renders the scene from its entity's transform, with attributes
- * for the projection, field of view, clip planes, clear color and tonemapping. Must be a child of a
- * `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ * @elementSummary The `<pc-camera>` element renders the scene from its entity's transform, with
+ * attributes for the projection, field of view, clip planes, clear color and tonemapping. Must be a
+ * child of a `<pc-entity>`, `<pc-model>` or `<pc-node>`.
  *
  * @category Components
  */

--- a/src/components/collision-component.ts
+++ b/src/components/collision-component.ts
@@ -19,6 +19,10 @@ import { ComponentElement } from './component';
  *
  * Engine component: {@link CollisionComponent} (`collision`).
  *
+ * @summary The `<pc-collision>` element gives its entity a collision shape — a box, sphere,
+ * capsule, cone, cylinder or mesh — for the physics simulation to collide against. Pair it with a
+ * `<pc-rigid-body>`. Must be a child of a `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ *
  * @category Components
  */
 class CollisionComponentElement extends ComponentElement {

--- a/src/components/collision-component.ts
+++ b/src/components/collision-component.ts
@@ -19,7 +19,7 @@ import { ComponentElement } from './component';
  *
  * Engine component: {@link CollisionComponent} (`collision`).
  *
- * @summary The `<pc-collision>` element gives its entity a collision shape — a box, sphere,
+ * @elementSummary The `<pc-collision>` element gives its entity a collision shape — a box, sphere,
  * capsule, cone, cylinder or mesh — for the physics simulation to collide against. Pair it with a
  * `<pc-rigid-body>`. Must be a child of a `<pc-entity>`, `<pc-model>` or `<pc-node>`.
  *

--- a/src/components/element-component.ts
+++ b/src/components/element-component.ts
@@ -19,6 +19,10 @@ import { ComponentElement } from './component';
  *
  * Engine component: {@link ElementComponent} (`element`).
  *
+ * @summary The `<pc-element>` element gives its entity a 2D UI rectangle inside a `<pc-screen>`
+ * hierarchy, drawing an image, a line of text or nothing (`type="image"`, `"text"` or `"group"`).
+ * Must be a child of a `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ *
  * @category Components
  */
 class ElementComponentElement extends ComponentElement {

--- a/src/components/element-component.ts
+++ b/src/components/element-component.ts
@@ -19,9 +19,9 @@ import { ComponentElement } from './component';
  *
  * Engine component: {@link ElementComponent} (`element`).
  *
- * @summary The `<pc-element>` element gives its entity a 2D UI rectangle inside a `<pc-screen>`
- * hierarchy, drawing an image, a line of text or nothing (`type="image"`, `"text"` or `"group"`).
- * Must be a child of a `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ * @elementSummary The `<pc-element>` element gives its entity a 2D UI rectangle inside a
+ * `<pc-screen>` hierarchy, drawing an image, a line of text or nothing (`type="image"`, `"text"` or
+ * `"group"`). Must be a child of a `<pc-entity>`, `<pc-model>` or `<pc-node>`.
  *
  * @category Components
  */

--- a/src/components/gsplat-component.ts
+++ b/src/components/gsplat-component.ts
@@ -13,8 +13,8 @@ import { ComponentElement } from './component';
  *
  * Engine component: {@link GSplatComponent} (`gsplat`).
  *
- * @summary The `<pc-gsplat>` element renders the 3D Gaussian splats of a `gsplat` asset at its
- * entity, with attributes for shadow casting and level of detail. Must be a child of a
+ * @elementSummary The `<pc-gsplat>` element renders the 3D Gaussian splats of a `gsplat` asset at
+ * its entity, with attributes for shadow casting and level of detail. Must be a child of a
  * `<pc-entity>`, `<pc-model>` or `<pc-node>`.
  *
  * @category Components

--- a/src/components/gsplat-component.ts
+++ b/src/components/gsplat-component.ts
@@ -13,6 +13,10 @@ import { ComponentElement } from './component';
  *
  * Engine component: {@link GSplatComponent} (`gsplat`).
  *
+ * @summary The `<pc-gsplat>` element renders the 3D Gaussian splats of a `gsplat` asset at its
+ * entity, with attributes for shadow casting and level of detail. Must be a child of a
+ * `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ *
  * @category Components
  */
 class GSplatComponentElement extends ComponentElement {

--- a/src/components/joint-component.ts
+++ b/src/components/joint-component.ts
@@ -27,6 +27,10 @@ export type MotionMode = 'locked' | 'limited' | 'free';
  * a rigid body component; leaving `entity-b` empty constrains `entity-a` to a fixed point in world
  * space. The underlying engine component is in alpha, so its API may change.
  *
+ * @summary The `<pc-joint>` element constrains two rigid bodies to each other — a hinged door, a
+ * swinging chain, a sliding drawer. Its entity's transform is the joint frame, and `entity-a` and
+ * `entity-b` name the bodies. Must be a child of a `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ *
  * @fires {CustomEvent} break - Fired when the impulse on the joint exceeds `break-impulse` and the
  * constraint breaks. A broken joint no longer constrains its bodies; calling `refreshFrames()` on
  * the underlying component re-attaches it. Bubbles and is composed.

--- a/src/components/joint-component.ts
+++ b/src/components/joint-component.ts
@@ -27,9 +27,10 @@ export type MotionMode = 'locked' | 'limited' | 'free';
  * a rigid body component; leaving `entity-b` empty constrains `entity-a` to a fixed point in world
  * space. The underlying engine component is in alpha, so its API may change.
  *
- * @summary The `<pc-joint>` element constrains two rigid bodies to each other — a hinged door, a
- * swinging chain, a sliding drawer. Its entity's transform is the joint frame, and `entity-a` and
- * `entity-b` name the bodies. Must be a child of a `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ * @elementSummary The `<pc-joint>` element constrains two rigid bodies to each other — a hinged
+ * door, a swinging chain, a sliding drawer. Its entity's transform is the joint frame, and
+ * `entity-a` and `entity-b` name the bodies. Must be a child of a `<pc-entity>`, `<pc-model>` or
+ * `<pc-node>`.
  *
  * @fires {CustomEvent} break - Fired when the impulse on the joint exceeds `break-impulse` and the
  * constraint breaks. A broken joint no longer constrains its bodies; calling `refreshFrames()` on

--- a/src/components/layout-child-component.ts
+++ b/src/components/layout-child-component.ts
@@ -12,7 +12,7 @@ import { ComponentElement } from './component';
  *
  * Engine component: {@link LayoutChildComponent} (`layoutchild`).
  *
- * @summary The `<pc-layout-child>` element controls how its entity is sized by the
+ * @elementSummary The `<pc-layout-child>` element controls how its entity is sized by the
  * `<pc-layout-group>` above it, through minimum and maximum sizes and fit proportions. Must be a
  * child of a `<pc-entity>`, `<pc-model>` or `<pc-node>`.
  *

--- a/src/components/layout-child-component.ts
+++ b/src/components/layout-child-component.ts
@@ -12,6 +12,10 @@ import { ComponentElement } from './component';
  *
  * Engine component: {@link LayoutChildComponent} (`layoutchild`).
  *
+ * @summary The `<pc-layout-child>` element controls how its entity is sized by the
+ * `<pc-layout-group>` above it, through minimum and maximum sizes and fit proportions. Must be a
+ * child of a `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ *
  * @category Components
  */
 class LayoutChildComponentElement extends ComponentElement {

--- a/src/components/layout-group-component.ts
+++ b/src/components/layout-group-component.ts
@@ -34,6 +34,10 @@ const fittings = new Map<'none' | 'stretch' | 'shrink' | 'both', number>([
  *
  * Engine component: {@link LayoutGroupComponent} (`layoutgroup`).
  *
+ * @summary The `<pc-layout-group>` element arranges its entity's children in a row or column, with
+ * spacing, padding, alignment and fitting. Must be a child of a `<pc-entity>`, `<pc-model>` or
+ * `<pc-node>`.
+ *
  * @category Components
  */
 class LayoutGroupComponentElement extends ComponentElement {

--- a/src/components/layout-group-component.ts
+++ b/src/components/layout-group-component.ts
@@ -34,9 +34,9 @@ const fittings = new Map<'none' | 'stretch' | 'shrink' | 'both', number>([
  *
  * Engine component: {@link LayoutGroupComponent} (`layoutgroup`).
  *
- * @summary The `<pc-layout-group>` element arranges its entity's children in a row or column, with
- * spacing, padding, alignment and fitting. Must be a child of a `<pc-entity>`, `<pc-model>` or
- * `<pc-node>`.
+ * @elementSummary The `<pc-layout-group>` element arranges its entity's children in a row or
+ * column, with spacing, padding, alignment and fitting. Must be a child of a `<pc-entity>`,
+ * `<pc-model>` or `<pc-node>`.
  *
  * @category Components
  */

--- a/src/components/light-component.ts
+++ b/src/components/light-component.ts
@@ -39,9 +39,9 @@ const shadowTypes = new Map<
  *
  * Engine component: {@link LightComponent} (`light`).
  *
- * @summary The `<pc-light>` element lights the scene from its entity — as a directional, omni or
- * spot light — with attributes for color, intensity, range and shadows. Must be a child of a
- * `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ * @elementSummary The `<pc-light>` element lights the scene from its entity — as a directional,
+ * omni or spot light — with attributes for color, intensity, range and shadows. Must be a child of
+ * a `<pc-entity>`, `<pc-model>` or `<pc-node>`.
  *
  * @category Components
  */

--- a/src/components/light-component.ts
+++ b/src/components/light-component.ts
@@ -39,6 +39,10 @@ const shadowTypes = new Map<
  *
  * Engine component: {@link LightComponent} (`light`).
  *
+ * @summary The `<pc-light>` element lights the scene from its entity — as a directional, omni or
+ * spot light — with attributes for color, intensity, range and shadows. Must be a child of a
+ * `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ *
  * @category Components
  */
 class LightComponentElement extends ComponentElement {

--- a/src/components/particle-system-component.ts
+++ b/src/components/particle-system-component.ts
@@ -12,9 +12,9 @@ import { ComponentElement } from './component';
  *
  * Engine component: {@link ParticleSystemComponent} (`particlesystem`).
  *
- * @summary The `<pc-particle-system>` element emits particles from its entity, with attributes for
- * the emitter's shape, rate, lifetime, textures and blending. Must be a child of a `<pc-entity>`,
- * `<pc-model>` or `<pc-node>`.
+ * @elementSummary The `<pc-particle-system>` element emits particles from its entity, with
+ * attributes for the emitter's shape, rate, lifetime, textures and blending. Must be a child of a
+ * `<pc-entity>`, `<pc-model>` or `<pc-node>`.
  *
  * @category Components
  */

--- a/src/components/particle-system-component.ts
+++ b/src/components/particle-system-component.ts
@@ -12,6 +12,10 @@ import { ComponentElement } from './component';
  *
  * Engine component: {@link ParticleSystemComponent} (`particlesystem`).
  *
+ * @summary The `<pc-particle-system>` element emits particles from its entity, with attributes for
+ * the emitter's shape, rate, lifetime, textures and blending. Must be a child of a `<pc-entity>`,
+ * `<pc-model>` or `<pc-node>`.
+ *
  * @category Components
  */
 class ParticleSystemComponentElement extends ComponentElement {

--- a/src/components/render-component.ts
+++ b/src/components/render-component.ts
@@ -17,10 +17,10 @@ import { ComponentElement } from './component';
  *
  * Engine component: {@link RenderComponent} (`render`).
  *
- * @summary The `<pc-render>` element renders one of the engine's built-in primitives at its entity
- * — box, sphere, capsule, cone, cylinder or plane — shaded by the `<pc-material>` its `material`
- * attribute names. For glTF content, use `<pc-model>` instead. Must be a child of a `<pc-entity>`,
- * `<pc-model>` or `<pc-node>`.
+ * @elementSummary The `<pc-render>` element renders one of the engine's built-in primitives at its
+ * entity — box, sphere, capsule, cone, cylinder or plane — shaded by the `<pc-material>` its
+ * `material` attribute names. For glTF content, use `<pc-model>` instead. Must be a child of a
+ * `<pc-entity>`, `<pc-model>` or `<pc-node>`.
  *
  * @category Components
  */

--- a/src/components/render-component.ts
+++ b/src/components/render-component.ts
@@ -17,6 +17,11 @@ import { ComponentElement } from './component';
  *
  * Engine component: {@link RenderComponent} (`render`).
  *
+ * @summary The `<pc-render>` element renders one of the engine's built-in primitives at its entity
+ * — box, sphere, capsule, cone, cylinder or plane — shaded by the `<pc-material>` its `material`
+ * attribute names. For glTF content, use `<pc-model>` instead. Must be a child of a `<pc-entity>`,
+ * `<pc-model>` or `<pc-node>`.
+ *
  * @category Components
  */
 class RenderComponentElement extends ComponentElement {

--- a/src/components/rigid-body-component.ts
+++ b/src/components/rigid-body-component.ts
@@ -13,6 +13,11 @@ import { ComponentElement } from './component';
  *
  * Engine component: {@link RigidBodyComponent} (`rigidbody`).
  *
+ * @summary The `<pc-rigid-body>` element hands its entity to the physics simulation, with
+ * attributes for its type, mass, friction and restitution. It needs a sibling `<pc-collision>` for
+ * its shape, and `Ammo` loaded through `<pc-wasm>`. Must be a child of a `<pc-entity>`,
+ * `<pc-model>` or `<pc-node>`.
+ *
  * @category Components
  */
 class RigidBodyComponentElement extends ComponentElement {

--- a/src/components/rigid-body-component.ts
+++ b/src/components/rigid-body-component.ts
@@ -13,7 +13,7 @@ import { ComponentElement } from './component';
  *
  * Engine component: {@link RigidBodyComponent} (`rigidbody`).
  *
- * @summary The `<pc-rigid-body>` element hands its entity to the physics simulation, with
+ * @elementSummary The `<pc-rigid-body>` element hands its entity to the physics simulation, with
  * attributes for its type, mass, friction and restitution. It needs a sibling `<pc-collision>` for
  * its shape, and `Ammo` loaded through `<pc-wasm>`. Must be a child of a `<pc-entity>`,
  * `<pc-model>` or `<pc-node>`.

--- a/src/components/screen-component.ts
+++ b/src/components/screen-component.ts
@@ -22,6 +22,10 @@ const scaleModes = new Map<'none' | 'blend', string>([
  *
  * Engine component: {@link ScreenComponent} (`screen`).
  *
+ * @summary The `<pc-screen>` element gives its entity a 2D space — in screen space or in the world
+ * — that a hierarchy of `<pc-element>` descendants lays out inside. Must be a child of a
+ * `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ *
  * @category Components
  */
 class ScreenComponentElement extends ComponentElement {

--- a/src/components/screen-component.ts
+++ b/src/components/screen-component.ts
@@ -22,8 +22,8 @@ const scaleModes = new Map<'none' | 'blend', string>([
  *
  * Engine component: {@link ScreenComponent} (`screen`).
  *
- * @summary The `<pc-screen>` element gives its entity a 2D space — in screen space or in the world
- * — that a hierarchy of `<pc-element>` descendants lays out inside. Must be a child of a
+ * @elementSummary The `<pc-screen>` element gives its entity a 2D space — in screen space or in the
+ * world — that a hierarchy of `<pc-element>` descendants lays out inside. Must be a child of a
  * `<pc-entity>`, `<pc-model>` or `<pc-node>`.
  *
  * @category Components

--- a/src/components/script-component.ts
+++ b/src/components/script-component.ts
@@ -250,8 +250,8 @@ export type ScriptNameChangeEvent = {
  *
  * Engine component: {@link ScriptComponent} (`script`).
  *
- * @summary The `<pc-script>` element holds the `<pc-script-instance>` children that attach scripts
- * to its entity. Must be a child of a `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ * @elementSummary The `<pc-script>` element holds the `<pc-script-instance>` children that attach
+ * scripts to its entity. Must be a child of a `<pc-entity>`, `<pc-model>` or `<pc-node>`.
  *
  * @category Components
  */

--- a/src/components/script-component.ts
+++ b/src/components/script-component.ts
@@ -250,6 +250,9 @@ export type ScriptNameChangeEvent = {
  *
  * Engine component: {@link ScriptComponent} (`script`).
  *
+ * @summary The `<pc-script>` element holds the `<pc-script-instance>` children that attach scripts
+ * to its entity. Must be a child of a `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ *
  * @category Components
  */
 class ScriptComponentElement extends ComponentElement {

--- a/src/components/script-instance.ts
+++ b/src/components/script-instance.ts
@@ -29,6 +29,10 @@ import { parseBool } from '../parse';
  * The element becomes ready once its script instance has been created by the parent
  * `<pc-script>` element.
  *
+ * @summary The `<pc-script-instance>` element attaches one script class, named by `name`, to the
+ * entity of its parent `<pc-script>`. Its other attributes set script attributes of the same name,
+ * and `attributes` takes a JSON object instead. Must be a direct child of `<pc-script>`.
+ *
  * @fires {CustomEvent} scriptattributeschange - Fired when the script's attributes change. The
  * `detail` carries the new `attributes` object. Bubbles.
  * @fires {CustomEvent} scriptenablechange - Fired when the script's enabled state changes. The

--- a/src/components/script-instance.ts
+++ b/src/components/script-instance.ts
@@ -29,9 +29,9 @@ import { parseBool } from '../parse';
  * The element becomes ready once its script instance has been created by the parent
  * `<pc-script>` element.
  *
- * @summary The `<pc-script-instance>` element attaches one script class, named by `name`, to the
- * entity of its parent `<pc-script>`. Its other attributes set script attributes of the same name,
- * and `attributes` takes a JSON object instead. Must be a direct child of `<pc-script>`.
+ * @elementSummary The `<pc-script-instance>` element attaches one script class, named by `name`, to
+ * the entity of its parent `<pc-script>`. Its other attributes set script attributes of the same
+ * name, and `attributes` takes a JSON object instead. Must be a direct child of `<pc-script>`.
  *
  * @fires {CustomEvent} scriptattributeschange - Fired when the script's attributes change. The
  * `detail` carries the new `attributes` object. Bubbles.

--- a/src/components/scroll-view-component.ts
+++ b/src/components/scroll-view-component.ts
@@ -31,6 +31,10 @@ const visibilities = new Map<'always' | 'when-required', number>([
  *
  * Engine component: {@link ScrollViewComponent} (`scrollview`).
  *
+ * @summary The `<pc-scroll-view>` element scrolls a larger content entity within a clipped viewport
+ * at its entity, optionally driven by the `<pc-scrollbar>` elements it references. Must be a child
+ * of a `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ *
  * @category Components
  */
 class ScrollViewComponentElement extends ComponentElement {

--- a/src/components/scroll-view-component.ts
+++ b/src/components/scroll-view-component.ts
@@ -31,9 +31,9 @@ const visibilities = new Map<'always' | 'when-required', number>([
  *
  * Engine component: {@link ScrollViewComponent} (`scrollview`).
  *
- * @summary The `<pc-scroll-view>` element scrolls a larger content entity within a clipped viewport
- * at its entity, optionally driven by the `<pc-scrollbar>` elements it references. Must be a child
- * of a `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ * @elementSummary The `<pc-scroll-view>` element scrolls a larger content entity within a clipped
+ * viewport at its entity, optionally driven by the `<pc-scrollbar>` elements it references. Must be
+ * a child of a `<pc-entity>`, `<pc-model>` or `<pc-node>`.
  *
  * @category Components
  */

--- a/src/components/scrollbar-component.ts
+++ b/src/components/scrollbar-component.ts
@@ -18,9 +18,9 @@ const orientations = new Map<'horizontal' | 'vertical', number>([
  *
  * Engine component: {@link ScrollbarComponent} (`scrollbar`).
  *
- * @summary The `<pc-scrollbar>` element gives its entity a draggable handle reporting a position
- * from 0 to 1, which a `<pc-scroll-view>` references to scroll its content. Must be a child of a
- * `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ * @elementSummary The `<pc-scrollbar>` element gives its entity a draggable handle reporting a
+ * position from 0 to 1, which a `<pc-scroll-view>` references to scroll its content. Must be a
+ * child of a `<pc-entity>`, `<pc-model>` or `<pc-node>`.
  *
  * @category Components
  */

--- a/src/components/scrollbar-component.ts
+++ b/src/components/scrollbar-component.ts
@@ -18,6 +18,10 @@ const orientations = new Map<'horizontal' | 'vertical', number>([
  *
  * Engine component: {@link ScrollbarComponent} (`scrollbar`).
  *
+ * @summary The `<pc-scrollbar>` element gives its entity a draggable handle reporting a position
+ * from 0 to 1, which a `<pc-scroll-view>` references to scroll its content. Must be a child of a
+ * `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ *
  * @category Components
  */
 class ScrollbarComponentElement extends ComponentElement {

--- a/src/components/sound-component.ts
+++ b/src/components/sound-component.ts
@@ -12,6 +12,10 @@ import { ComponentElement } from './component';
  *
  * Engine component: {@link SoundComponent} (`sound`).
  *
+ * @summary The `<pc-sound>` element holds the `<pc-sound-slot>` children that play sounds at its
+ * entity, along with the positional audio settings they share. Must be a child of a `<pc-entity>`,
+ * `<pc-model>` or `<pc-node>`.
+ *
  * @category Components
  */
 class SoundComponentElement extends ComponentElement {

--- a/src/components/sound-component.ts
+++ b/src/components/sound-component.ts
@@ -12,9 +12,9 @@ import { ComponentElement } from './component';
  *
  * Engine component: {@link SoundComponent} (`sound`).
  *
- * @summary The `<pc-sound>` element holds the `<pc-sound-slot>` children that play sounds at its
- * entity, along with the positional audio settings they share. Must be a child of a `<pc-entity>`,
- * `<pc-model>` or `<pc-node>`.
+ * @elementSummary The `<pc-sound>` element holds the `<pc-sound-slot>` children that play sounds at
+ * its entity, along with the positional audio settings they share. Must be a child of a
+ * `<pc-entity>`, `<pc-model>` or `<pc-node>`.
  *
  * @category Components
  */

--- a/src/components/sound-slot.ts
+++ b/src/components/sound-slot.ts
@@ -11,8 +11,8 @@ import { SoundComponentElement } from './sound-component';
  * `<pc-sound-slot>` elements. The SoundSlotElement interface also inherits the properties and
  * methods of the {@link AsyncElement} interface.
  *
- * @summary The `<pc-sound-slot>` element declares one named sound on its parent `<pc-sound>` — its
- * asset, volume, pitch, looping and autoplay. Must be a direct child of `<pc-sound>`.
+ * @elementSummary The `<pc-sound-slot>` element declares one named sound on its parent `<pc-sound>`
+ * — its asset, volume, pitch, looping and autoplay. Must be a direct child of `<pc-sound>`.
  */
 class SoundSlotElement extends AsyncElement {
     private _asset = '';

--- a/src/components/sound-slot.ts
+++ b/src/components/sound-slot.ts
@@ -10,6 +10,9 @@ import { SoundComponentElement } from './sound-component';
  * The SoundSlotElement interface provides properties and methods for manipulating
  * `<pc-sound-slot>` elements. The SoundSlotElement interface also inherits the properties and
  * methods of the {@link AsyncElement} interface.
+ *
+ * @summary The `<pc-sound-slot>` element declares one named sound on its parent `<pc-sound>` — its
+ * asset, volume, pitch, looping and autoplay. Must be a direct child of `<pc-sound>`.
  */
 class SoundSlotElement extends AsyncElement {
     private _asset = '';

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -15,8 +15,8 @@ import { parseBool, parseTags, parseVec3 } from './parse';
  * them, registered either with {@link EventTarget.addEventListener} or with the matching inline `onpointer*`
  * attribute.
  *
- * @summary The `<pc-entity>` element creates an entity: a named, transformable node of the scene
- * hierarchy, and the host for component elements such as `<pc-camera>`, `<pc-light>` and
+ * @elementSummary The `<pc-entity>` element creates an entity: a named, transformable node of the
+ * scene hierarchy, and the host for component elements such as `<pc-camera>`, `<pc-light>` and
  * `<pc-render>`. Place it in the `<pc-scene>`, or nest it under another `<pc-entity>`, a
  * `<pc-model>` or a `<pc-node>` to parent it there.
  *

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -15,6 +15,11 @@ import { parseBool, parseTags, parseVec3 } from './parse';
  * them, registered either with {@link EventTarget.addEventListener} or with the matching inline `onpointer*`
  * attribute.
  *
+ * @summary The `<pc-entity>` element creates an entity: a named, transformable node of the scene
+ * hierarchy, and the host for component elements such as `<pc-camera>`, `<pc-light>` and
+ * `<pc-render>`. Place it in the `<pc-scene>`, or nest it under another `<pc-entity>`, a
+ * `<pc-model>` or a `<pc-node>` to parent it there.
+ *
  * @attribute {boolean} enabled - The enabled state of the entity.
  * @attribute {string} name - The name of the entity.
  * @attribute {string} position - The position of the entity.

--- a/src/material.ts
+++ b/src/material.ts
@@ -143,9 +143,9 @@ type TextureSlot =
  * The two aliases are documented here rather than on an accessor, because they resolve to the
  * `gloss` properties and would otherwise inherit gloss's description - which reads inverted.
  *
- * @summary The `<pc-material>` element defines a physically based material, which `<pc-render>`
- * elements apply by naming its `id`. It is metal/rough by default, with `metalness` starting at 0.
- * Must be a direct child of `<pc-app>`.
+ * @elementSummary The `<pc-material>` element defines a physically based material, which
+ * `<pc-render>` elements apply by naming its `id`. It is metal/rough by default, with `metalness`
+ * starting at 0. Must be a direct child of `<pc-app>`.
  *
  * @attribute {number} roughness - The roughness of the material, from 0 (shiny) to 1 (rough). An
  * alias for `gloss` that also inverts it, so do not combine it with the `gloss` attributes.

--- a/src/material.ts
+++ b/src/material.ts
@@ -143,6 +143,10 @@ type TextureSlot =
  * The two aliases are documented here rather than on an accessor, because they resolve to the
  * `gloss` properties and would otherwise inherit gloss's description - which reads inverted.
  *
+ * @summary The `<pc-material>` element defines a physically based material, which `<pc-render>`
+ * elements apply by naming its `id`. It is metal/rough by default, with `metalness` starting at 0.
+ * Must be a direct child of `<pc-app>`.
+ *
  * @attribute {number} roughness - The roughness of the material, from 0 (shiny) to 1 (rough). An
  * alias for `gloss` that also inverts it, so do not combine it with the `gloss` attributes.
  * @attribute {string} roughness-map - The id of the `pc-asset` to use as the roughness map. An

--- a/src/model.ts
+++ b/src/model.ts
@@ -125,6 +125,11 @@ const formatHierarchy = (root: HierarchyNode, counts: ReadonlyMap<string, number
  * intersects the model's geometry, exactly as for `<pc-entity>` — a hit on a content node that no
  * `pc-node` fronts resolves to this element.
  *
+ * @summary The `<pc-model>` element instantiates a 3D model from a container asset (typically a
+ * GLB) beneath an entity of its own, so the element's transform and tags place the instance in the
+ * scene. Its `<pc-node>` children override what the asset authored. Place it in the `<pc-scene>`,
+ * or nest it under a `<pc-entity>`, another `<pc-model>` or a `<pc-node>`.
+ *
  * @attribute {boolean} enabled - The enabled state of the model.
  * @attribute {string} name - The name of the model.
  * @attribute {string} position - The position of the model.

--- a/src/model.ts
+++ b/src/model.ts
@@ -125,10 +125,10 @@ const formatHierarchy = (root: HierarchyNode, counts: ReadonlyMap<string, number
  * intersects the model's geometry, exactly as for `<pc-entity>` — a hit on a content node that no
  * `pc-node` fronts resolves to this element.
  *
- * @summary The `<pc-model>` element instantiates a 3D model from a container asset (typically a
- * GLB) beneath an entity of its own, so the element's transform and tags place the instance in the
- * scene. Its `<pc-node>` children override what the asset authored. Place it in the `<pc-scene>`,
- * or nest it under a `<pc-entity>`, another `<pc-model>` or a `<pc-node>`.
+ * @elementSummary The `<pc-model>` element instantiates a 3D model from a container asset
+ * (typically a GLB) beneath an entity of its own, so the element's transform and tags place the
+ * instance in the scene. Its `<pc-node>` children override what the asset authored. Place it in the
+ * `<pc-scene>`, or nest it under a `<pc-entity>`, another `<pc-model>` or a `<pc-node>`.
  *
  * @attribute {boolean} enabled - The enabled state of the model.
  * @attribute {string} name - The name of the model.

--- a/src/node.ts
+++ b/src/node.ts
@@ -164,9 +164,10 @@ const levenshtein = (a: string, b: string): number => {
  * The pointer events below are dispatched by the containing `<pc-app>` element when the pointer
  * intersects the bound node's geometry, exactly as for `<pc-entity>`.
  *
- * @summary The `<pc-node>` element binds to a node inside the hierarchy a `<pc-model>` instantiated
- * and declares overrides against it: a transform, an enabled state, tags, components to add, or
- * content to attach. Its `name` is a lookup, never a rename. Must be a descendant of `<pc-model>`.
+ * @elementSummary The `<pc-node>` element binds to a node inside the hierarchy a `<pc-model>`
+ * instantiated and declares overrides against it: a transform, an enabled state, tags, components
+ * to add, or content to attach. Its `name` is a lookup, never a rename. Must be a descendant of
+ * `<pc-model>`.
  *
  * @attribute {string} name - The name of the node to bind, resolved within the nearest ancestor
  * `pc-model` (or `pc-node`) once it has instantiated.

--- a/src/node.ts
+++ b/src/node.ts
@@ -164,6 +164,10 @@ const levenshtein = (a: string, b: string): number => {
  * The pointer events below are dispatched by the containing `<pc-app>` element when the pointer
  * intersects the bound node's geometry, exactly as for `<pc-entity>`.
  *
+ * @summary The `<pc-node>` element binds to a node inside the hierarchy a `<pc-model>` instantiated
+ * and declares overrides against it: a transform, an enabled state, tags, components to add, or
+ * content to attach. Its `name` is a lookup, never a rename. Must be a descendant of `<pc-model>`.
+ *
  * @attribute {string} name - The name of the node to bind, resolved within the nearest ancestor
  * `pc-model` (or `pc-node`) once it has instantiated.
  * @attribute {number} index - Which match to bind when `name` matches more than one node,

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -10,8 +10,8 @@ import { parseColor, parseEnum, parseNumber, parseVec3 } from './parse';
  * The SceneElement interface also inherits the properties and methods of the
  * {@link HTMLElement} interface.
  *
- * @summary The `<pc-scene>` element holds the entity hierarchy the application renders, along with
- * the scene-wide fog and gravity settings. Must be a direct child of `<pc-app>`.
+ * @elementSummary The `<pc-scene>` element holds the entity hierarchy the application renders,
+ * along with the scene-wide fog and gravity settings. Must be a direct child of `<pc-app>`.
  */
 class SceneElement extends AsyncElement {
     /**

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -9,6 +9,9 @@ import { parseColor, parseEnum, parseNumber, parseVec3 } from './parse';
  * {@link https://developer.playcanvas.com/user-manual/web-components/tags/pc-scene/ | `<pc-scene>`} elements.
  * The SceneElement interface also inherits the properties and methods of the
  * {@link HTMLElement} interface.
+ *
+ * @summary The `<pc-scene>` element holds the entity hierarchy the application renders, along with
+ * the scene-wide fog and gravity settings. Must be a direct child of `<pc-app>`.
  */
 class SceneElement extends AsyncElement {
     /**

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -11,9 +11,9 @@ import { parseBool, parseEnum, parseNumber, parseVec3 } from './parse';
  * `<pc-sky>` elements. The SkyElement interface also inherits the properties and
  * methods of the {@link HTMLElement} interface.
  *
- * @summary The `<pc-sky>` element renders a skybox from a texture asset, projected as an infinite
- * background, a box or a dome, and optionally lights the scene from it. Must be a direct child of
- * `<pc-scene>`.
+ * @elementSummary The `<pc-sky>` element renders a skybox from a texture asset, projected as an
+ * infinite background, a box or a dome, and optionally lights the scene from it. Must be a direct
+ * child of `<pc-scene>`.
  */
 class SkyElement extends AsyncElement {
     private _asset = '';

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -10,6 +10,10 @@ import { parseBool, parseEnum, parseNumber, parseVec3 } from './parse';
  * The SkyElement interface provides properties and methods for manipulating
  * `<pc-sky>` elements. The SkyElement interface also inherits the properties and
  * methods of the {@link HTMLElement} interface.
+ *
+ * @summary The `<pc-sky>` element renders a skybox from a texture asset, projected as an infinite
+ * background, a box or a dome, and optionally lights the scene from it. Must be a direct child of
+ * `<pc-scene>`.
  */
 class SkyElement extends AsyncElement {
     private _asset = '';

--- a/src/wasm.ts
+++ b/src/wasm.ts
@@ -17,6 +17,10 @@ import { AsyncElement } from './async-element';
  * A `<pc-wasm>` without a `name` warns and never becomes ready; a containing `<pc-app>` still
  * boots.
  *
+ * @summary The `<pc-wasm>` element loads a WebAssembly module the engine needs before the
+ * application starts — `Ammo` for physics, `Basis` or `DracoDecoderModule` for compressed assets.
+ * Must be a direct child of `<pc-app>`.
+ *
  * @attribute {string} name - The name of the WebAssembly module to configure, e.g. `Basis` or
  * `Ammo`.
  * @attribute {string} glue - The URL of the module's glue script.

--- a/src/wasm.ts
+++ b/src/wasm.ts
@@ -17,7 +17,7 @@ import { AsyncElement } from './async-element';
  * A `<pc-wasm>` without a `name` warns and never becomes ready; a containing `<pc-app>` still
  * boots.
  *
- * @summary The `<pc-wasm>` element loads a WebAssembly module the engine needs before the
+ * @elementSummary The `<pc-wasm>` element loads a WebAssembly module the engine needs before the
  * application starts — `Ammo` for physics, `Basis` or `DracoDecoderModule` for compressed assets.
  * Must be a direct child of `<pc-app>`.
  *

--- a/typedoc.json
+++ b/typedoc.json
@@ -11,6 +11,7 @@
         "@defaultValue",
         "@deprecated",
         "@document",
+        "@elementSummary",
         "@example",
         "@expandType",
         "@extends",
@@ -101,6 +102,22 @@
         "Forum": "https://forum.playcanvas.com/",
         "GitHub": "https://github.com/playcanvas/web-components"
     },
+    "notRenderedTags": [
+        "@showCategories",
+        "@showGroups",
+        "@hideCategories",
+        "@hideGroups",
+        "@disableGroups",
+        "@expand",
+        "@preventExpand",
+        "@expandType",
+        "@summary",
+        "@group",
+        "@groupDescription",
+        "@category",
+        "@categoryDescription",
+        "@elementSummary"
+    ],
     "sidebarLinks": {
         "Home": "/"
     },

--- a/typedoc.json
+++ b/typedoc.json
@@ -110,5 +110,6 @@
     "readme": "none",
     "searchGroupBoosts": {
         "Classes": 2
-    }
+    },
+    "useFirstParagraphOfCommentAsSummary": true
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -110,6 +110,5 @@
     "readme": "none",
     "searchGroupBoosts": {
         "Classes": 2
-    },
-    "useFirstParagraphOfCommentAsSummary": true
+    }
 }

--- a/utils/cem/cleanup-plugin.mjs
+++ b/utils/cem/cleanup-plugin.mjs
@@ -200,12 +200,18 @@ export const manifestCleanupPlugin = () => ({
         rewriteDescriptions(customElementsManifest);
 
         // The editor integrations append their own `---` separated sections directly after the
-        // class description. In markdown, a `---` line immediately below a paragraph makes that
-        // paragraph a heading, which renders the last paragraph of every element's tooltip at
-        // heading size. A trailing blank line keeps the separator a separator.
+        // text they describe an element with - its summary, or its description where it has no
+        // summary. In markdown, a `---` line immediately below a paragraph makes that paragraph a
+        // heading, which renders the last paragraph of every element's tooltip at heading size. A
+        // trailing blank line keeps the separator a separator.
         for (const { declaration } of declarations.values()) {
-            if (declaration.customElement && declaration.description) {
-                declaration.description = `${declaration.description.trimEnd()}\n`;
+            if (!declaration.customElement) {
+                continue;
+            }
+            for (const key of ['description', 'summary']) {
+                if (declaration[key]) {
+                    declaration[key] = `${declaration[key].trimEnd()}\n`;
+                }
             }
         }
     }

--- a/utils/cem/summary-plugin.mjs
+++ b/utils/cem/summary-plugin.mjs
@@ -1,0 +1,60 @@
+/**
+ * Custom Elements Manifest plugin that publishes each element's `@elementSummary` as the
+ * declaration's `summary`.
+ *
+ * The editor integrations describe a tag with its `summary` where it has one, falling back to its
+ * `description`. The description is the class reference - "The XElement interface provides
+ * properties and methods for manipulating `<pc-x>` elements" - which is what the API reference
+ * needs and the opposite of what an author hovering a tag in HTML is asking about. So every
+ * element carries a second, element-voice paragraph for the editors to use.
+ *
+ * That paragraph cannot be an `@summary`, even though that is the field it ends up in: TypeDoc
+ * prefers `@summary` for the short description beside each entry in its module index, so writing
+ * it there would put markup guidance ("Must be a child of a `<pc-entity>`") into the JavaScript
+ * API reference. `@elementSummary` is invisible to TypeDoc - it is listed in `notRenderedTags` -
+ * and the analyzer has no meaning for it either, hence this plugin. `@element` would have been the
+ * natural name, but the analyzer reads that one as an alias of `@tag`, which would set every
+ * element's `tagName` to the first word of its prose.
+ */
+
+/**
+ * The text of a JSDoc tag. TypeScript hands back a plain string unless the comment holds an inline
+ * tag, in which case it is the parsed parts - which is how a `{@link}` in the prose would arrive.
+ *
+ * @param {string | Array<{ text?: string, name?: object }> | undefined} comment - The tag's comment.
+ * @returns {string} The comment as text.
+ */
+const commentText = (comment) => {
+    if (typeof comment === 'string') {
+        return comment;
+    }
+    return (comment ?? [])
+        .map(part => `${part.name?.getText?.() ?? ''}${part.text ?? ''}`)
+        .join('');
+};
+
+/**
+ * @returns {object} The analyzer plugin.
+ */
+export const elementSummaryPlugin = () => ({
+    name: 'pwc-element-summary',
+
+    analyzePhase({ ts, node, moduleDoc }) {
+        if (!ts.isClassDeclaration(node) || !node.name) {
+            return;
+        }
+
+        const classDoc = moduleDoc.declarations?.find(declaration => declaration.name === node.name.getText());
+        if (!classDoc) {
+            return;
+        }
+
+        for (const jsDoc of node.jsDoc ?? []) {
+            for (const tag of jsDoc.tags ?? []) {
+                if (tag.tagName?.getText() === 'elementSummary') {
+                    classDoc.summary = commentText(tag.comment);
+                }
+            }
+        }
+    }
+});

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -398,7 +398,7 @@ if (manifest) {
         // The opening is pinned to the voice the browsers' own HTML data uses ("The h1 element
         // represents a section heading"), which is the register the tooltip sits in.
         check((declaration.summary ?? '').startsWith(`The \`<${tag}>\` element`),
-            `${tag} has no element-voice @summary, so its tooltip would describe the class: ${JSON.stringify((declaration.summary ?? '').slice(0, 120))}`);
+            `${tag} has no element-voice @elementSummary, so its tooltip would describe the class: ${JSON.stringify((declaration.summary ?? '').slice(0, 120))}`);
 
         for (const item of declaration.attributes ?? []) {
             check(Boolean(item.type?.text), `${tag}[${item.name}] has no type`);

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -36,6 +36,14 @@ const readJson = (name) => {
 
 const manifest = readJson('custom-elements.json');
 
+/**
+ * Each element's summary, as the manifest carries it. The editor integrations open an element's
+ * tooltip with it, so the checks on their generated files compare against this.
+ *
+ * @type {Map<string, string>}
+ */
+const summaries = new Map();
+
 if (manifest) {
     check(Boolean(manifest.schemaVersion), 'manifest is missing schemaVersion');
     check((manifest.modules ?? []).length > 0, 'manifest has no modules');
@@ -46,6 +54,7 @@ if (manifest) {
         for (const declaration of module.declarations ?? []) {
             if (declaration.tagName) {
                 elements.set(declaration.tagName, declaration);
+                summaries.set(declaration.tagName, declaration.summary ?? '');
             }
         }
     }
@@ -382,6 +391,15 @@ if (manifest) {
 
     // Global invariants
     for (const [tag, declaration] of elements) {
+        // Every element needs a summary, because that is what the editor integrations describe a
+        // tag with. Without one they fall back to the description, which is the class reference
+        // ("The XElement interface provides properties and methods for manipulating ...") - true
+        // of the JavaScript class, and not what an author hovering a tag in HTML is asking about.
+        // The opening is pinned to the voice the browsers' own HTML data uses ("The h1 element
+        // represents a section heading"), which is the register the tooltip sits in.
+        check((declaration.summary ?? '').startsWith(`The \`<${tag}>\` element`),
+            `${tag} has no element-voice @summary, so its tooltip would describe the class: ${JSON.stringify((declaration.summary ?? '').slice(0, 120))}`);
+
         for (const item of declaration.attributes ?? []) {
             check(Boolean(item.type?.text), `${tag}[${item.name}] has no type`);
 
@@ -433,19 +451,47 @@ if (vsCode) {
     check(tonemap?.values?.length === 7,
         `VS Code custom data should offer 7 values for pc-camera[tonemap], found ${tonemap?.values?.length}`);
 
+    const tooltip = tag => (typeof tag.description === 'string' ? tag.description : tag.description?.value ?? '');
+
     // A `---` directly below a paragraph is markdown for "make that paragraph a heading", which
     // would render the last paragraph of the tooltip at heading size
-    const setext = (vsCode.tags ?? [])
-        .filter(tag => /[^\n]\n---/.test(typeof tag.description === 'string' ? tag.description : tag.description?.value ?? ''))
-        .map(tag => tag.name);
+    const setext = (vsCode.tags ?? []).filter(tag => /[^\n]\n---/.test(tooltip(tag))).map(tag => tag.name);
     check(setext.length === 0,
         `${setext.length} VS Code tooltip(s) would render a paragraph as a heading: ${setext.join(', ')}`);
+
+    // The tooltip an author sees while writing HTML opens with the element's summary, links to the
+    // element's page, and leaves the JavaScript surface to the API reference. Each of the three is
+    // one plugin option away from regressing, and all three regress silently - the file is still
+    // valid, it just answers a question nobody asked.
+    for (const tag of vsCode.tags ?? []) {
+        const text = tooltip(tag);
+        const summary = summaries.get(tag.name);
+        check(Boolean(summary) && text.startsWith(summary),
+            `the VS Code tooltip for ${tag.name} does not open with its summary: ${JSON.stringify(text.slice(0, 120))}`);
+        check(!text.includes('Methods:'),
+            `the VS Code tooltip for ${tag.name} lists methods, which belong to the API reference`);
+        const url = tag.references?.[0]?.url;
+        check(url === `https://developer.playcanvas.com/user-manual/web-components/tags/${tag.name}/`,
+            `the VS Code tooltip for ${tag.name} does not reference its User Manual page: ${JSON.stringify(url)}`);
+    }
 }
 
 const webTypes = readJson('web-types.json');
 if (webTypes) {
     const elements = webTypes.contributions?.html?.elements ?? [];
     check(elements.length === TAGS.length, `web-types has ${elements.length} elements, expected ${TAGS.length}`);
+
+    // The same three properties as the VS Code tooltip above, in the shape JetBrains IDEs read
+    for (const element of elements) {
+        const text = element.description ?? '';
+        const summary = summaries.get(element.name);
+        check(Boolean(summary) && text.startsWith(summary),
+            `the web-types description for ${element.name} does not open with its summary: ${JSON.stringify(text.slice(0, 120))}`);
+        check(!text.includes('Methods:'),
+            `the web-types description for ${element.name} lists methods, which belong to the API reference`);
+        check(element['doc-url'] === `https://developer.playcanvas.com/user-manual/web-components/tags/${element.name}/`,
+            `the web-types entry for ${element.name} does not link its User Manual page: ${JSON.stringify(element['doc-url'])}`);
+    }
 }
 
 if (failures.length > 0) {


### PR DESCRIPTION
Hovering a `pc-*` tag in an HTML file showed the JavaScript class reference rather than anything about the element:

> The EntityElement interface provides properties and methods for manipulating `<pc-entity>` elements. The EntityElement interface also inherits the properties and methods of the HTMLElement interface.
>
> ---
>
> ### **Methods:**
>  - **ready(): \_\_** - Returns a promise that resolves with this element when it's ready. This is the low-level primitive underlying whenReady … *(four more paragraphs)*

Both editor integration plugins describe a tag with `summary || description`, and no element carried a summary, so they fell back to the class JSDoc. That prose is deliberate and correct for the API reference — it mirrors how MDN documents `HTMLVideoElement` — but a tag hover is a different question, and a standard element like `h1` answers it properly ("The h1 element represents a section heading", plus an MDN link).

## What changed

**An `@elementSummary` on all 31 element classes.** What the element does and where it belongs, in the voice the browsers' own HTML data uses. The class description is untouched, so the API reference still reads as the class reference.

```
The `<pc-entity>` element creates an entity: a named, transformable node of the
scene hierarchy, and the host for component elements such as `<pc-camera>`,
`<pc-light>` and `<pc-render>`. Place it in the `<pc-scene>`, or nest it under
another `<pc-entity>`, a `<pc-model>` or a `<pc-node>` to parent it there.
```

**`summary-plugin.mjs`** publishes that tag as the declaration's `summary`, which is the field the editor integrations read. Two naming constraints are worth knowing, because both fail quietly:

- It cannot be `@summary`. TypeDoc prefers `@summary` for the short description beside each entry in its module index, which would put markup guidance ("Must be a child of a `<pc-entity>`") into a JavaScript API reference.
- It cannot be `@element`. The analyzer reads that as an alias of `@tag`, so every element's `tagName` would become the first word of its prose.

**`typedoc.json`** declares the tag, or TypeDoc warns once per element, and lists it in `notRenderedTags`, or TypeDoc renders it on every class page. That option *replaces* its default rather than extending it, so the 13 defaults are repeated alongside `@elementSummary`. They are the organizational tags — `@category`, `@group`, `@summary` and the rest — and dropping any of them starts rendering it. Worth a glance on TypeDoc upgrades.

**Both plugins now hide methods and publish a User Manual link.** Methods are the element's JavaScript surface, documented in the API reference; listing them put several paragraphs about `ready()` above the attribute an author was reaching for. In their place each tag carries its User Manual page — `references` for VS Code, `doc-url` for JetBrains — the equivalent of the MDN link a standard element's tooltip gets.

**`cleanup-plugin.mjs`** — its setext-heading guard (a `---` line under a paragraph makes that paragraph an `<h1>`) covered only `description`. The plugins now append that separator after the summary, so the guard covers both fields.

**`validate.mjs`** — three build gates, because all three properties regress silently: the file stays valid, it just answers a question nobody asked.

- every element needs a summary that opens `The \`<tag>\` element`
- each generated tooltip must open with that summary, in both files
- no tooltip lists methods, and each links its own User Manual page

## Result

```
The `<pc-light>` element lights the scene from its entity — as a directional, omni or
spot light — with attributes for color, intensity, range and shadows. Must be a child of a
`<pc-entity>`, `<pc-model>` or `<pc-node>`.

---

### **Events:**
 - **ready** - Fired when the element is fully initialized — once per readiness cycle …

User Manual → https://developer.playcanvas.com/user-manual/web-components/tags/pc-light/
```

## Notes for review

- The summaries are prose, so they are worth a read for accuracy. Each states the element's purpose and its parent requirement, taken from the runtime warnings (`component.ts` accepts `pc-entity`, `pc-model` or `pc-node` as a component's host) and from the matching User Manual page.
- `pc-entity` and `pc-model` are phrased as "place it in the `<pc-scene>`, or nest it under …" rather than a hard constraint, because `entity-owner.ts` parents under the nearest ancestor entity element and falls back to the application root — the tag pages state a narrower rule.
- **The API reference is unchanged in content.** Diffing a full `typedoc` build against one from `main`: the only differences are the `Defined in …#L<n>` source links, shifted by the comment lines this adds above each class, and the `sitemap.xml` build timestamps. No rendered prose, no new sections, no index entries.
- Verified with `npm run cem` (31 elements), `lint`, `type-check:src` and `test` (956 passing). The generated editor files were diffed against the pre-change build and are identical apart from where the prose soft-wraps, which the longer tag name shifts and markdown collapses. The three new checks were confirmed to fire by deleting `pc-light`'s summary from the generated manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
