### PR TITLE
Align pc-camera with the engine's camera defaults

### DIFF
--- a/src/components/camera-component.ts
+++ b/src/components/camera-component.ts
@@ -54,9 +54,11 @@ class CameraComponentElement extends ComponentElement {
 
     private _clearColorBuffer = true;
 
+    private _clearDepth = 1;
+
     private _clearDepthBuffer = true;
 
-    private _clearStencilBuffer = false;
+    private _clearStencilBuffer = true;
 
     private _cullFaces = true;
 
@@ -95,6 +97,7 @@ class CameraComponentElement extends ComponentElement {
         return {
             clearColor: this._clearColor,
             clearColorBuffer: this._clearColorBuffer,
+            clearDepth: this._clearDepth,
             clearDepthBuffer: this._clearDepthBuffer,
             clearStencilBuffer: this._clearStencilBuffer,
             cullFaces: this._cullFaces,
@@ -114,9 +117,24 @@ class CameraComponentElement extends ComponentElement {
         };
     }
 
-    get xrAvailable() {
+    /**
+     * Whether immersive VR is available. {@link startXr} tests the mode it is asked to start,
+     * so starting an AR session does not need this.
+     * @returns Whether immersive VR is available.
+     */
+    get xrAvailable(): boolean {
+        return this._xrAvailable(XRTYPE_VR);
+    }
+
+    /**
+     * Whether one immersive XR mode is available on this device.
+     *
+     * @param type - The XR session type to test.
+     * @returns Whether that mode is available.
+     */
+    private _xrAvailable(type: string): boolean {
         const xrManager = this.component?.system.app.xr;
-        return xrManager && xrManager.supported && xrManager.isAvailable(XRTYPE_VR);
+        return Boolean(xrManager?.supported && xrManager.isAvailable(type));
     }
 
     /**
@@ -128,10 +146,12 @@ class CameraComponentElement extends ComponentElement {
         type: 'immersive-ar' | 'immersive-vr',
         space: 'bounded-floor' | 'local' | 'local-floor' | 'unbounded' | 'viewer'
     ) {
-        if (this.component && this.xrAvailable) {
+        // Gated on the mode being started rather than on VR: a device can offer AR and not
+        // VR, and such a device would otherwise refuse an AR session it can serve
+        if (this.component && this._xrAvailable(type)) {
             this.component.startXr(type, space, {
                 callback: (err: any) => {
-                    if (err) console.error(`WebXR Immersive VR failed to start: ${err.message}`);
+                    if (err) console.error(`WebXR ${type} failed to start: ${err.message}`);
                 }
             });
         }
@@ -190,6 +210,25 @@ class CameraComponentElement extends ComponentElement {
      */
     get clearColorBuffer(): boolean {
         return this._clearColorBuffer;
+    }
+
+    /**
+     * Sets the depth value the depth buffer is cleared to. Defaults to 1.
+     * @param value - The clear depth value.
+     */
+    set clearDepth(value: number) {
+        this._clearDepth = value;
+        if (this.component) {
+            this.component.clearDepth = value;
+        }
+    }
+
+    /**
+     * Gets the depth value the depth buffer is cleared to.
+     * @returns The clear depth value.
+     */
+    get clearDepth(): number {
+        return this._clearDepth;
     }
 
     /**
@@ -502,6 +541,7 @@ class CameraComponentElement extends ComponentElement {
             ...super.observedAttributes,
             'clear-color',
             'clear-color-buffer',
+            'clear-depth',
             'clear-depth-buffer',
             'clear-stencil-buffer',
             'cull-faces',
@@ -531,11 +571,14 @@ class CameraComponentElement extends ComponentElement {
             case 'clear-color-buffer':
                 this.clearColorBuffer = parseBool(newValue, true);
                 break;
+            case 'clear-depth':
+                this.clearDepth = parseNumber(newValue, 1, name);
+                break;
             case 'clear-depth-buffer':
                 this.clearDepthBuffer = parseBool(newValue, true);
                 break;
             case 'clear-stencil-buffer':
-                this.clearStencilBuffer = parseBool(newValue, false);
+                this.clearStencilBuffer = parseBool(newValue, true);
                 break;
             case 'cull-faces':
                 this.cullFaces = parseBool(newValue, true);

--- a/src/components/camera-component.ts
+++ b/src/components/camera-component.ts
@@ -119,22 +119,39 @@ class CameraComponentElement extends ComponentElement {
     }
 
     /**
-     * Whether either of the immersive modes {@link startXr} can start - AR or VR - is available.
-     * Use {@link isXrAvailable} to test one of them on its own.
-     * @returns Whether immersive AR or VR is available.
+     * Whether immersive AR is available. A device can offer AR and not VR, so gate an
+     * AR-specific control on this rather than on {@link xrAvailable}.
+     * @returns Whether immersive AR is available.
      */
-    get xrAvailable(): boolean {
-        return this.isXrAvailable(XRTYPE_AR) || this.isXrAvailable(XRTYPE_VR);
+    get arAvailable(): boolean {
+        return this._available(XRTYPE_AR);
     }
 
     /**
-     * Whether one immersive XR mode is available on this device. A device can offer AR and not VR,
-     * so gate a mode-specific control on the mode rather than on {@link xrAvailable}.
+     * Whether immersive VR is available. A device can offer VR and not AR, so gate a
+     * VR-specific control on this rather than on {@link xrAvailable}.
+     * @returns Whether immersive VR is available.
+     */
+    get vrAvailable(): boolean {
+        return this._available(XRTYPE_VR);
+    }
+
+    /**
+     * Whether either of the immersive modes {@link startXr} can start is available. Enough to
+     * decide whether to offer XR at all; not enough to pick a mode.
+     * @returns Whether immersive AR or VR is available.
+     */
+    get xrAvailable(): boolean {
+        return this.arAvailable || this.vrAvailable;
+    }
+
+    /**
+     * Whether one XR session type is available on this device.
      *
      * @param type - The XR session type to test.
-     * @returns Whether that mode is available.
+     * @returns Whether that type is available.
      */
-    isXrAvailable(type: 'immersive-ar' | 'immersive-vr'): boolean {
+    private _available(type: string): boolean {
         const xrManager = this.component?.system.app.xr;
         return Boolean(xrManager?.supported && xrManager.isAvailable(type));
     }
@@ -150,7 +167,7 @@ class CameraComponentElement extends ComponentElement {
     ) {
         // Gated on the mode being started, not on XR in general: a device that offers only
         // one of the two would otherwise accept a session it cannot serve
-        if (this.component && this.isXrAvailable(type)) {
+        if (this.component && this._available(type)) {
             this.component.startXr(type, space, {
                 callback: (err: any) => {
                     if (err) console.error(`WebXR ${type} failed to start: ${err.message}`);

--- a/src/components/camera-component.ts
+++ b/src/components/camera-component.ts
@@ -13,6 +13,7 @@ import {
     TONEMAP_ACES,
     TONEMAP_HEJL,
     TONEMAP_NONE,
+    XRTYPE_AR,
     XRTYPE_VR
 } from 'playcanvas';
 
@@ -118,21 +119,22 @@ class CameraComponentElement extends ComponentElement {
     }
 
     /**
-     * Whether immersive VR is available. {@link startXr} tests the mode it is asked to start,
-     * so starting an AR session does not need this.
-     * @returns Whether immersive VR is available.
+     * Whether either of the immersive modes {@link startXr} can start - AR or VR - is available.
+     * Use {@link isXrAvailable} to test one of them on its own.
+     * @returns Whether immersive AR or VR is available.
      */
     get xrAvailable(): boolean {
-        return this._xrAvailable(XRTYPE_VR);
+        return this.isXrAvailable(XRTYPE_AR) || this.isXrAvailable(XRTYPE_VR);
     }
 
     /**
-     * Whether one immersive XR mode is available on this device.
+     * Whether one immersive XR mode is available on this device. A device can offer AR and not VR,
+     * so gate a mode-specific control on the mode rather than on {@link xrAvailable}.
      *
      * @param type - The XR session type to test.
      * @returns Whether that mode is available.
      */
-    private _xrAvailable(type: string): boolean {
+    isXrAvailable(type: 'immersive-ar' | 'immersive-vr'): boolean {
         const xrManager = this.component?.system.app.xr;
         return Boolean(xrManager?.supported && xrManager.isAvailable(type));
     }
@@ -146,9 +148,9 @@ class CameraComponentElement extends ComponentElement {
         type: 'immersive-ar' | 'immersive-vr',
         space: 'bounded-floor' | 'local' | 'local-floor' | 'unbounded' | 'viewer'
     ) {
-        // Gated on the mode being started rather than on VR: a device can offer AR and not
-        // VR, and such a device would otherwise refuse an AR session it can serve
-        if (this.component && this._xrAvailable(type)) {
+        // Gated on the mode being started, not on XR in general: a device that offers only
+        // one of the two would otherwise accept a session it cannot serve
+        if (this.component && this.isXrAvailable(type)) {
             this.component.startXr(type, space, {
                 callback: (err: any) => {
                     if (err) console.error(`WebXR ${type} failed to start: ${err.message}`);

--- a/src/components/camera-component.ts
+++ b/src/components/camera-component.ts
@@ -119,8 +119,8 @@ class CameraComponentElement extends ComponentElement {
     }
 
     /**
-     * Whether immersive AR is available. A device can offer AR and not VR, so gate an
-     * AR-specific control on this rather than on {@link xrAvailable}.
+     * Whether immersive AR is available. Independent of {@link vrAvailable}: a device can offer
+     * either mode without the other.
      * @returns Whether immersive AR is available.
      */
     get arAvailable(): boolean {
@@ -128,21 +128,12 @@ class CameraComponentElement extends ComponentElement {
     }
 
     /**
-     * Whether immersive VR is available. A device can offer VR and not AR, so gate a
-     * VR-specific control on this rather than on {@link xrAvailable}.
+     * Whether immersive VR is available. Independent of {@link arAvailable}: a device can offer
+     * either mode without the other.
      * @returns Whether immersive VR is available.
      */
     get vrAvailable(): boolean {
         return this._available(XRTYPE_VR);
-    }
-
-    /**
-     * Whether either of the immersive modes {@link startXr} can start is available. Enough to
-     * decide whether to offer XR at all; not enough to pick a mode.
-     * @returns Whether immersive AR or VR is available.
-     */
-    get xrAvailable(): boolean {
-        return this.arAvailable || this.vrAvailable;
     }
 
     /**

--- a/test/integration/components/camera-component.test.ts
+++ b/test/integration/components/camera-component.test.ts
@@ -177,8 +177,8 @@ describe('<pc-camera>', () => {
             const camera = get<CameraComponentElement>('pc-camera');
             stubXr(app, [XRTYPE_AR]);
 
-            expect(camera.isXrAvailable(XRTYPE_AR), 'the mode the device offers').toBe(true);
-            expect(camera.isXrAvailable(XRTYPE_VR), 'the mode it does not').toBe(false);
+            expect(camera.arAvailable, 'the mode the device offers').toBe(true);
+            expect(camera.vrAvailable, 'the mode it does not').toBe(false);
 
             // The getter is named for XR, not for VR: one immersive mode is enough for it
             expect(camera.xrAvailable).toBe(true);

--- a/test/integration/components/camera-component.test.ts
+++ b/test/integration/components/camera-component.test.ts
@@ -1,0 +1,186 @@
+import type { CameraComponent } from 'playcanvas';
+import {
+    Color,
+    Vec4,
+    GAMMA_NONE,
+    GAMMA_SRGB,
+    PROJECTION_ORTHOGRAPHIC,
+    PROJECTION_PERSPECTIVE,
+    TONEMAP_ACES,
+    TONEMAP_NONE,
+    XRTYPE_AR,
+    XRTYPE_VR
+} from 'playcanvas';
+import { describe, expect, it } from 'vitest';
+
+import type { CameraComponentElement } from '../../../src/components/camera-component';
+import { bootApp } from '../../helpers/app';
+import { useGuard } from '../../helpers/guard';
+
+const scene = (cameraAttributes = '') =>
+    `<pc-entity name="camera"><pc-camera ${cameraAttributes}></pc-camera></pc-entity>`;
+
+/** Reads an engine component property named by a table row. */
+const engineValue = (component: CameraComponent, property: string) =>
+    (component as unknown as Record<string, unknown>)[property];
+
+/**
+ * One row per attribute: the attribute, the engine property behind it, a non-default value, what
+ * the engine must report for it, and the default that removal must restore. Ordered by
+ * `observedAttributes` - the source of truth.
+ *
+ * Every `restored` value is the engine's own default bar one, called out in its row: the element
+ * and the engine agree on the camera's resting state, so a `<pc-camera>` carrying no attributes
+ * renders what a bare engine camera renders.
+ */
+const cases: [attribute: string, property: string, value: string, expected: unknown, restored: unknown][] = [
+    ['clear-color', 'clearColor', '1 0 0 1', new Color(1, 0, 0, 1), new Color(0.75, 0.75, 0.75, 1)],
+    ['clear-color-buffer', 'clearColorBuffer', 'false', false, true],
+    ['clear-depth', 'clearDepth', '0.5', 0.5, 1],
+    ['clear-depth-buffer', 'clearDepthBuffer', 'false', false, true],
+    ['clear-stencil-buffer', 'clearStencilBuffer', 'false', false, true],
+    ['cull-faces', 'cullFaces', 'false', false, true],
+    ['far-clip', 'farClip', '500', 500, 1000],
+    ['flip-faces', 'flipFaces', '', true, false],
+    ['fov', 'fov', '60', 60, 45],
+    ['frustum-culling', 'frustumCulling', 'false', false, true],
+    ['gamma', 'gammaCorrection', 'linear', GAMMA_NONE, GAMMA_SRGB],
+    ['horizontal-fov', 'horizontalFov', '', true, false],
+    ['near-clip', 'nearClip', '1', 1, 0.1],
+    ['ortho-height', 'orthoHeight', '5', 5, 10],
+    ['priority', 'priority', '2', 2, 0],
+    ['projection', 'projection', 'orthographic', PROJECTION_ORTHOGRAPHIC, PROJECTION_PERSPECTIVE],
+    ['rect', 'rect', '0 0 0.5 1', new Vec4(0, 0, 0.5, 1), new Vec4(0, 0, 1, 1)],
+    ['scissor-rect', 'scissorRect', '0 0 0.5 0.5', new Vec4(0, 0, 0.5, 0.5), new Vec4(0, 0, 1, 1)],
+    // The one exception: the engine defaults toneMapping to TONEMAP_LINEAR and this element writes
+    // TONEMAP_NONE. The two diverge only once Scene#exposure moves off 1, which no attribute
+    // reaches, so the deviation is pinned here rather than changed under existing apps.
+    ['tonemap', 'toneMapping', 'aces', TONEMAP_ACES, TONEMAP_NONE]
+];
+
+describe('<pc-camera>', () => {
+    const { warnings } = useGuard();
+
+    describe('#component', () => {
+        it('creates the camera component with the engine defaults', async () => {
+            const { get } = await bootApp(scene());
+            const component = get<CameraComponentElement>('pc-camera').component;
+
+            expect(component).toBeDefined();
+            expect(component.enabled).toBe(true);
+
+            for (const [attribute, property, , , restored] of cases) {
+                expect.soft(engineValue(component, property), attribute).toEqual(restored);
+            }
+        });
+    });
+
+    describe('attributes', () => {
+        it('applies every declarative attribute through the initial component data', async () => {
+            const markup = cases
+                .map(([attribute, , value]) => (value === '' ? attribute : `${attribute}="${value}"`))
+                .join(' ');
+            const { get } = await bootApp(scene(markup));
+            const component = get<CameraComponentElement>('pc-camera').component;
+
+            for (const [attribute, property, , expected] of cases) {
+                expect.soft(engineValue(component, property), attribute).toEqual(expected);
+            }
+        });
+
+        it('writes attribute changes through to the component', async () => {
+            const { get } = await bootApp(scene());
+            const camera = get<CameraComponentElement>('pc-camera');
+
+            for (const [attribute, property, value, expected] of cases) {
+                camera.setAttribute(attribute, value);
+                expect.soft(engineValue(camera.component, property), attribute).toEqual(expected);
+            }
+        });
+
+        it('restores the default when an attribute is removed', async () => {
+            const { get } = await bootApp(scene());
+            const camera = get<CameraComponentElement>('pc-camera');
+
+            for (const [attribute, property, value, , restored] of cases) {
+                camera.setAttribute(attribute, value);
+                camera.removeAttribute(attribute);
+                expect.soft(engineValue(camera.component, property), attribute).toEqual(restored);
+            }
+        });
+
+        it('falls back to the default and warns once per invalid value', async () => {
+            const { get } = await bootApp(
+                scene('fov="wide" projection="isometric" tonemap="reinhard" rect="0 0" clear-depth="near"')
+            );
+            const component = get<CameraComponentElement>('pc-camera').component;
+
+            warnings.expect("Invalid value 'wide' for attribute 'fov'. Expected a finite number. Using '45'.");
+            warnings.expect(
+                "Invalid value 'isometric' for attribute 'projection'. Valid values: perspective, orthographic. Using 'perspective'."
+            );
+            warnings.expect(
+                "Invalid value 'reinhard' for attribute 'tonemap'. Valid values: none, linear, filmic, hejl, aces, aces2, neutral. Using 'none'."
+            );
+            warnings.expect(
+                "Invalid value '0 0' for attribute 'rect'. Expected 4 space-separated numbers. Using '[0, 0, 1, 1]'."
+            );
+            warnings.expect("Invalid value 'near' for attribute 'clear-depth'. Expected a finite number. Using '1'.");
+
+            expect(component.fov).toBe(45);
+            expect(component.projection).toBe(PROJECTION_PERSPECTIVE);
+            expect(component.toneMapping).toBe(TONEMAP_NONE);
+            expect(component.rect).toEqual(new Vec4(0, 0, 1, 1));
+            expect(component.clearDepth).toBe(1);
+        });
+    });
+
+    describe('XR', () => {
+        it('reports no XR headlessly', async () => {
+            const { get } = await bootApp(scene());
+            const camera = get<CameraComponentElement>('pc-camera');
+
+            // The null device backs no XR session, so this is what every headless caller sees
+            expect(camera.xrAvailable).toBe(false);
+
+            // Nothing to end, and asking for either must not throw
+            expect(() => camera.endXr()).not.toThrow();
+            expect(() => camera.startXr('immersive-vr', 'local-floor')).not.toThrow();
+        });
+
+        it('tests availability for the mode it is asked to start', async () => {
+            const { app, get } = await bootApp(scene());
+            const camera = get<CameraComponentElement>('pc-camera');
+            const xr = app.xr;
+            if (xr === null) {
+                throw new Error('expected an XrManager on the application');
+            }
+
+            // Availability is device-driven and never true headlessly, so both halves of the check
+            // are stubbed: AR available and VR not, the split an AR-capable phone reports.
+            const asked: string[] = [];
+            Object.defineProperty(xr, 'supported', { value: true, configurable: true });
+            xr.isAvailable = (type: string) => {
+                asked.push(type);
+                return type === XRTYPE_AR;
+            };
+
+            // Stubbed so the element's decision is what is measured, not a session the null device
+            // could never open
+            const started: string[] = [];
+            const component = camera.component;
+            component.startXr = ((type: string) => {
+                started.push(type);
+            }) as typeof component.startXr;
+
+            camera.startXr('immersive-ar', 'local-floor');
+            camera.startXr('immersive-vr', 'local-floor');
+
+            expect(asked, 'each start tests its own mode').toEqual([XRTYPE_AR, XRTYPE_VR]);
+            expect(started, 'the available mode starts, the unavailable one does not').toEqual([XRTYPE_AR]);
+
+            // The getter is VR-specific by name and stays that way
+            expect(camera.xrAvailable).toBe(false);
+        });
+    });
+});

--- a/test/integration/components/camera-component.test.ts
+++ b/test/integration/components/camera-component.test.ts
@@ -1,4 +1,4 @@
-import type { CameraComponent } from 'playcanvas';
+import type { AppBase, CameraComponent } from 'playcanvas';
 import {
     Color,
     Vec4,
@@ -16,6 +16,30 @@ import { describe, expect, it } from 'vitest';
 import type { CameraComponentElement } from '../../../src/components/camera-component';
 import { bootApp } from '../../helpers/app';
 import { useGuard } from '../../helpers/guard';
+
+/**
+ * Stubs the availability half of XrManager, which is device-driven and never true headlessly.
+ * `supported` is a getter, hence defineProperty rather than assignment.
+ *
+ * @param app - The booted application.
+ * @param available - The session types to report as available.
+ * @returns The types the element asked about, in the order it asked.
+ */
+const stubXr = (app: AppBase, available: string[]) => {
+    const xr = app.xr;
+    if (xr === null) {
+        throw new Error('expected an XrManager on the application');
+    }
+
+    const asked: string[] = [];
+    Object.defineProperty(xr, 'supported', { value: true, configurable: true });
+    xr.isAvailable = (type: string) => {
+        asked.push(type);
+        return available.includes(type);
+    };
+
+    return asked;
+};
 
 const scene = (cameraAttributes = '') =>
     `<pc-entity name="camera"><pc-camera ${cameraAttributes}></pc-camera></pc-entity>`;
@@ -148,22 +172,33 @@ describe('<pc-camera>', () => {
             expect(() => camera.startXr('immersive-vr', 'local-floor')).not.toThrow();
         });
 
+        it('counts either immersive mode as XR being available', async () => {
+            const { app, get } = await bootApp(scene());
+            const camera = get<CameraComponentElement>('pc-camera');
+            stubXr(app, [XRTYPE_AR]);
+
+            expect(camera.isXrAvailable(XRTYPE_AR), 'the mode the device offers').toBe(true);
+            expect(camera.isXrAvailable(XRTYPE_VR), 'the mode it does not').toBe(false);
+
+            // The getter is named for XR, not for VR: one immersive mode is enough for it
+            expect(camera.xrAvailable).toBe(true);
+        });
+
+        it('reports no XR when neither immersive mode is offered', async () => {
+            const { app, get } = await bootApp(scene());
+            const camera = get<CameraComponentElement>('pc-camera');
+            const asked = stubXr(app, []);
+
+            expect(camera.xrAvailable).toBe(false);
+            expect(asked, 'both modes tested before giving up').toEqual([XRTYPE_AR, XRTYPE_VR]);
+        });
+
         it('tests availability for the mode it is asked to start', async () => {
             const { app, get } = await bootApp(scene());
             const camera = get<CameraComponentElement>('pc-camera');
-            const xr = app.xr;
-            if (xr === null) {
-                throw new Error('expected an XrManager on the application');
-            }
 
-            // Availability is device-driven and never true headlessly, so both halves of the check
-            // are stubbed: AR available and VR not, the split an AR-capable phone reports.
-            const asked: string[] = [];
-            Object.defineProperty(xr, 'supported', { value: true, configurable: true });
-            xr.isAvailable = (type: string) => {
-                asked.push(type);
-                return type === XRTYPE_AR;
-            };
+            // AR available and VR not - the split an AR-capable phone reports
+            const asked = stubXr(app, [XRTYPE_AR]);
 
             // Stubbed so the element's decision is what is measured, not a session the null device
             // could never open
@@ -178,9 +213,6 @@ describe('<pc-camera>', () => {
 
             expect(asked, 'each start tests its own mode').toEqual([XRTYPE_AR, XRTYPE_VR]);
             expect(started, 'the available mode starts, the unavailable one does not').toEqual([XRTYPE_AR]);
-
-            // The getter is VR-specific by name and stays that way
-            expect(camera.xrAvailable).toBe(false);
         });
     });
 });

--- a/test/integration/components/camera-component.test.ts
+++ b/test/integration/components/camera-component.test.ts
@@ -165,32 +165,33 @@ describe('<pc-camera>', () => {
             const camera = get<CameraComponentElement>('pc-camera');
 
             // The null device backs no XR session, so this is what every headless caller sees
-            expect(camera.xrAvailable).toBe(false);
+            expect(camera.arAvailable).toBe(false);
+            expect(camera.vrAvailable).toBe(false);
 
             // Nothing to end, and asking for either must not throw
             expect(() => camera.endXr()).not.toThrow();
             expect(() => camera.startXr('immersive-vr', 'local-floor')).not.toThrow();
         });
 
-        it('counts either immersive mode as XR being available', async () => {
+        it('reports each mode on its own', async () => {
             const { app, get } = await bootApp(scene());
             const camera = get<CameraComponentElement>('pc-camera');
-            stubXr(app, [XRTYPE_AR]);
+            const asked = stubXr(app, [XRTYPE_AR]);
 
+            // The split an AR-capable phone reports, and the reason there is a getter per mode
             expect(camera.arAvailable, 'the mode the device offers').toBe(true);
             expect(camera.vrAvailable, 'the mode it does not').toBe(false);
-
-            // The getter is named for XR, not for VR: one immersive mode is enough for it
-            expect(camera.xrAvailable).toBe(true);
+            expect(asked, 'each getter tests only its own mode').toEqual([XRTYPE_AR, XRTYPE_VR]);
         });
 
-        it('reports no XR when neither immersive mode is offered', async () => {
+        it('reports neither mode when the device offers none', async () => {
             const { app, get } = await bootApp(scene());
             const camera = get<CameraComponentElement>('pc-camera');
-            const asked = stubXr(app, []);
+            stubXr(app, []);
 
-            expect(camera.xrAvailable).toBe(false);
-            expect(asked, 'both modes tested before giving up').toEqual([XRTYPE_AR, XRTYPE_VR]);
+            // Distinct from the headless case above: XR is supported here, the modes are not
+            expect(camera.arAvailable).toBe(false);
+            expect(camera.vrAvailable).toBe(false);
         });
 
         it('tests availability for the mode it is asked to start', async () => {

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -333,7 +333,7 @@ if (manifest) {
         ['pc-anim', ['clips', 'component', 'pause', 'play', 'transition', ...ASYNC_MEMBERS]],
         ['pc-app', ['app', 'elementFromEntity', 'loadProgress', ...ASYNC_MEMBERS]],
         ['pc-asset', ['asset', 'get', ...ASYNC_MEMBERS]],
-        ['pc-camera', ['component', 'endXr', 'isXrAvailable', 'startXr', 'xrAvailable', ...ASYNC_MEMBERS]],
+        ['pc-camera', ['arAvailable', 'component', 'endXr', 'startXr', 'vrAvailable', 'xrAvailable', ...ASYNC_MEMBERS]],
         ['pc-entity', ['addEventListener', 'entity', 'removeEventListener', ...ASYNC_MEMBERS]],
         // roughness and roughnessMap are the alias accessors: their attributes resolve to the
         // gloss fields, so no attribute claims them as its backing member

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -333,7 +333,7 @@ if (manifest) {
         ['pc-anim', ['clips', 'component', 'pause', 'play', 'transition', ...ASYNC_MEMBERS]],
         ['pc-app', ['app', 'elementFromEntity', 'loadProgress', ...ASYNC_MEMBERS]],
         ['pc-asset', ['asset', 'get', ...ASYNC_MEMBERS]],
-        ['pc-camera', ['component', 'endXr', 'startXr', 'xrAvailable', ...ASYNC_MEMBERS]],
+        ['pc-camera', ['component', 'endXr', 'isXrAvailable', 'startXr', 'xrAvailable', ...ASYNC_MEMBERS]],
         ['pc-entity', ['addEventListener', 'entity', 'removeEventListener', ...ASYNC_MEMBERS]],
         // roughness and roughnessMap are the alias accessors: their attributes resolve to the
         // gloss fields, so no attribute claims them as its backing member

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -333,7 +333,7 @@ if (manifest) {
         ['pc-anim', ['clips', 'component', 'pause', 'play', 'transition', ...ASYNC_MEMBERS]],
         ['pc-app', ['app', 'elementFromEntity', 'loadProgress', ...ASYNC_MEMBERS]],
         ['pc-asset', ['asset', 'get', ...ASYNC_MEMBERS]],
-        ['pc-camera', ['arAvailable', 'component', 'endXr', 'startXr', 'vrAvailable', 'xrAvailable', ...ASYNC_MEMBERS]],
+        ['pc-camera', ['arAvailable', 'component', 'endXr', 'startXr', 'vrAvailable', ...ASYNC_MEMBERS]],
         ['pc-entity', ['addEventListener', 'entity', 'removeEventListener', ...ASYNC_MEMBERS]],
         // roughness and roughnessMap are the alias accessors: their attributes resolve to the
         // gloss fields, so no attribute claims them as its backing member


### PR DESCRIPTION
Audited `<pc-camera>` against the engine's `CameraComponent`. 18 of 29 value-typed settable properties were exposed; two of the 18 wrote a default the engine doesn't use, and the element had no test file. This fixes the defaults, adds the one missing attribute that needs no design work, replaces the XR availability getter, and adds the suite.

## The stencil default is the one with teeth

`clear-stencil-buffer` defaulted to `false`; the engine's camera defaults it to `true`. `getInitialComponentData` writes the value unconditionally, so **every** `<pc-camera>` turned stencil clearing off. `<pc-app>` allocates a stencil buffer by default, and the library ships stencil-based UI masking via `pc-element` / `pc-screen` — so the default left that buffer uncleared between frames.

The removal default in `attributeChangedCallback` moves with it. Without that, removing the attribute would have reintroduced the deviation.

## Missing attribute

`clear-depth` — the value the depth buffer is cleared to (default 1) — had no attribute, though `clear-depth-buffer` sitting beside it did.

## xrAvailable meant VR, and is replaced

`xrAvailable` tested `XRTYPE_VR` alone, and `startXr` gated on it. So `startXr('immersive-ar', …)` silently refused an AR session on any device offering AR but not VR — Android Chrome with ARCore, most obviously — and a getter named for XR was answering for one of the two modes.

It is replaced by one getter per mode:

- **`arAvailable`** and **`vrAvailable`**, named after their modes rather than as one `isXrAvailable(type)`: every other boolean in the library reads as a plain adjective, and this keeps the WebXR session string out of the call site, which matters because much of this library's audience writes inline `<script>` and imports nothing from `playcanvas`. WebXR has two immersive modes, so parameterizing over them was general beyond the domain — a third would be additive.
- **`xrAvailable` is gone.** It was `arAvailable || vrAvailable` and carried nothing the two don't. A caller wanting one Enter XR button writes that expression; a caller wanting an Enter VR button was always better served by `vrAvailable`, since the combined answer can't say which mode may be started.
- `startXr` gates on the mode it is asked to start, through a private per-type helper. Its failure message also said "Immersive VR" whatever mode was requested.

### ⚠️ Breaking

`xrAvailable` has been public since the element gained XR support. For the 1.0.0 migration notes:

| before | after |
| --- | --- |
| `camera.xrAvailable` gating VR | `camera.vrAvailable` |
| `camera.xrAvailable` gating AR | `camera.arAvailable` |
| `camera.xrAvailable`, either will do | `camera.arAvailable \|\| camera.vrAvailable` |

Free now, expensive after 1.0. Removal is also the more honest option than the alternative considered: keeping the name and widening it to mean either mode, which no consumer would notice until a VR button appeared on an AR-only phone and did nothing. A member that is gone is at least a type error.

## Tests

The element had no test file. It appeared in 11 suites, all incidentally, which is how both defaults survived. It now has one, on the `joint-component.test.ts` table pattern: 19 rows driving four passes — engine defaults on a bare element, initial component data, live attribute writes, restore-on-removal — plus the invalid-value warnings and four XR tests over a stubbed `XrManager`.

## Left alone deliberately

`tonemap` defaults to `TONEMAP_NONE` where the engine's camera uses `TONEMAP_LINEAR`. The two diverge only once `Scene#exposure` moves off 1, which no attribute reaches, and changing it would alter what every existing app renders. It's pinned in the test table with that reasoning rather than silently blessed, so it reads as known debt.

Also still open from the audit, both needing a design decision rather than a fix: `layers` (unexposed library-wide — no `pc-camera` attribute, no `layers` on `pc-render`/`pc-light`, no `pc-layer` element), which in turn gates `disable-post-effects-layer`; and the physical-units exposure trio (`aperture`/`shutter`/`sensitivity`), unreachable while `pc-scene` doesn't expose `Scene#physicalUnits`.

## Verification

- 965 tests pass across 45 files; ESLint, `type-check:src` and `type-check:test` clean.
- `npm run cem` regenerates and validates: `clear-depth` lands as `default: 1, type: number`, `clear-stencil-buffer` now `default: true`. 31 elements validated. `validate.mjs` pins each element's public non-attribute members, so the getter swap is recorded there.
- `npm run build` checked for the shipped surface: `arAvailable` and `vrAvailable` in `dist/components/camera-component.d.ts`, no `xrAvailable`, per-type helper stripped to `private _available`.
- Reverted the source and re-ran the new tests at each step: 6 of 7 failed against the pre-fix defaults, and 2 of 9 against the VR-only getter — including the mode-gating one, which asked `['immersive-vr', 'immersive-vr']` where it should ask `['immersive-ar', 'immersive-vr']`.

## Reviewer note

Anyone relying on the old `clear-stencil-buffer` default gets stencil clearing back on. That's a behavior change, intentionally — it restores the engine default rather than the library's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
