### PR TITLE
Align pc-light with the engine's shadow defaults

### DIFF
--- a/src/components/light-component.ts
+++ b/src/components/light-component.ts
@@ -54,15 +54,15 @@ class LightComponentElement extends ComponentElement {
 
     private _intensity = 1;
 
-    private _normalOffsetBias = 0.05;
+    private _normalOffsetBias = 0;
 
     private _outerConeAngle = 45;
 
     private _range = 10;
 
-    private _shadowBias = 0.2;
+    private _shadowBias = 0.05;
 
-    private _shadowDistance = 16;
+    private _shadowDistance = 40;
 
     private _shadowIntensity = 1;
 
@@ -81,7 +81,7 @@ class LightComponentElement extends ComponentElement {
 
     private _type: 'directional' | 'omni' | 'spot' = 'directional';
 
-    private _vsmBias = 0.01;
+    private _vsmBias = 0.0025;
 
     private _vsmBlurSize = 11;
 
@@ -115,7 +115,7 @@ class LightComponentElement extends ComponentElement {
             shadowIntensity: this._shadowIntensity,
             shadowResolution: this._shadowResolution,
             shadowSamples: this._shadowSamples,
-            shadowType: shadowTypes.get(this._shadowType),
+            shadowType: shadowTypes.get(this._shadowType) ?? SHADOW_PCF3_32F,
             type: this._type,
             vsmBias: this._vsmBias,
             vsmBlurSize: this._vsmBlurSize
@@ -516,10 +516,10 @@ class LightComponentElement extends ComponentElement {
     static get observedAttributes() {
         return [
             ...super.observedAttributes,
-            'color',
             'cast-shadows',
-            'intensity',
+            'color',
             'inner-cone-angle',
+            'intensity',
             'normal-offset-bias',
             'outer-cone-angle',
             'penumbra-falloff',
@@ -542,11 +542,11 @@ class LightComponentElement extends ComponentElement {
         super.attributeChangedCallback(name, _oldValue, newValue);
 
         switch (name) {
-            case 'color':
-                this.color = parseColor(newValue, Color.WHITE, name);
-                break;
             case 'cast-shadows':
                 this.castShadows = parseBool(newValue, false);
+                break;
+            case 'color':
+                this.color = parseColor(newValue, Color.WHITE, name);
                 break;
             case 'inner-cone-angle':
                 this.innerConeAngle = parseNumber(newValue, 40, name);
@@ -555,7 +555,7 @@ class LightComponentElement extends ComponentElement {
                 this.intensity = parseNumber(newValue, 1, name);
                 break;
             case 'normal-offset-bias':
-                this.normalOffsetBias = parseNumber(newValue, 0.05, name);
+                this.normalOffsetBias = parseNumber(newValue, 0, name);
                 break;
             case 'outer-cone-angle':
                 this.outerConeAngle = parseNumber(newValue, 45, name);
@@ -570,19 +570,19 @@ class LightComponentElement extends ComponentElement {
                 this.range = parseNumber(newValue, 10, name);
                 break;
             case 'shadow-bias':
-                this.shadowBias = parseNumber(newValue, 0.2, name);
-                break;
-            case 'shadow-distance':
-                this.shadowDistance = parseNumber(newValue, 16, name);
+                this.shadowBias = parseNumber(newValue, 0.05, name);
                 break;
             case 'shadow-blocker-samples':
                 this.shadowBlockerSamples = parseNumber(newValue, 16, name);
                 break;
-            case 'shadow-resolution':
-                this.shadowResolution = parseNumber(newValue, 1024, name);
+            case 'shadow-distance':
+                this.shadowDistance = parseNumber(newValue, 40, name);
                 break;
             case 'shadow-intensity':
                 this.shadowIntensity = parseNumber(newValue, 1, name);
+                break;
+            case 'shadow-resolution':
+                this.shadowResolution = parseNumber(newValue, 1024, name);
                 break;
             case 'shadow-samples':
                 this.shadowSamples = parseNumber(newValue, 16, name);
@@ -594,7 +594,7 @@ class LightComponentElement extends ComponentElement {
                 this.type = parseEnum(newValue, ['directional', 'omni', 'spot'], 'directional', name);
                 break;
             case 'vsm-bias':
-                this.vsmBias = parseNumber(newValue, 0.01, name);
+                this.vsmBias = parseNumber(newValue, 0.0025, name);
                 break;
             case 'vsm-blur-size':
                 this.vsmBlurSize = parseNumber(newValue, 11, name);

--- a/test/integration/components/light-component.test.ts
+++ b/test/integration/components/light-component.test.ts
@@ -1,0 +1,171 @@
+import type { LightComponent } from 'playcanvas';
+import { Color, Entity, SHADOW_PCF1_32F, SHADOW_PCF3_32F, SHADOW_VSM_16F } from 'playcanvas';
+import { describe, expect, it } from 'vitest';
+
+import type { LightComponentElement } from '../../../src/components/light-component';
+import { bootApp } from '../../helpers/app';
+import { useGuard } from '../../helpers/guard';
+
+const scene = (lightAttributes = '') => `<pc-entity name="light"><pc-light ${lightAttributes}></pc-light></pc-entity>`;
+
+/** Reads an engine component property named by a table row. */
+const engineValue = (component: LightComponent, property: string) =>
+    (component as unknown as Record<string, unknown>)[property];
+
+/**
+ * One row per attribute: the attribute, the engine property behind it, a non-default value, what
+ * the engine must report for it, and the default that removal must restore. Ordered by
+ * `observedAttributes` - the source of truth.
+ *
+ * Every `restored` value is the engine's own default. The four shadow-tuning ones used to differ,
+ * which is what `matches a light the engine built itself` below now holds them to.
+ */
+const cases: [attribute: string, property: string, value: string, expected: unknown, restored: unknown][] = [
+    ['cast-shadows', 'castShadows', '', true, false],
+    ['color', 'color', '1 0 0', new Color(1, 0, 0), new Color(1, 1, 1)],
+    ['inner-cone-angle', 'innerConeAngle', '20', 20, 40],
+    ['intensity', 'intensity', '2', 2, 1],
+    ['normal-offset-bias', 'normalOffsetBias', '0.1', 0.1, 0],
+    ['outer-cone-angle', 'outerConeAngle', '30', 30, 45],
+    ['penumbra-falloff', 'penumbraFalloff', '5', 5, 1],
+    ['penumbra-size', 'penumbraSize', '0.5', 0.5, 1],
+    ['range', 'range', '25', 25, 10],
+    ['shadow-bias', 'shadowBias', '0.1', 0.1, 0.05],
+    ['shadow-blocker-samples', 'shadowBlockerSamples', '8', 8, 16],
+    ['shadow-distance', 'shadowDistance', '60', 60, 40],
+    ['shadow-intensity', 'shadowIntensity', '0.6', 0.6, 1],
+    ['shadow-resolution', 'shadowResolution', '2048', 2048, 1024],
+    ['shadow-samples', 'shadowSamples', '8', 8, 16],
+    ['shadow-type', 'shadowType', 'pcf1-32f', SHADOW_PCF1_32F, SHADOW_PCF3_32F],
+    ['type', 'type', 'omni', 'omni', 'directional'],
+    ['vsm-bias', 'vsmBias', '0.01', 0.01, 0.0025],
+    ['vsm-blur-size', 'vsmBlurSize', '5', 5, 11]
+];
+
+describe('<pc-light>', () => {
+    const { warnings } = useGuard();
+
+    describe('#component', () => {
+        it('creates the light component with the engine defaults', async () => {
+            const { get } = await bootApp(scene());
+            const component = get<LightComponentElement>('pc-light').component;
+
+            expect(component).toBeDefined();
+            expect(component.enabled).toBe(true);
+
+            for (const [attribute, property, , , restored] of cases) {
+                expect.soft(engineValue(component, property), attribute).toEqual(restored);
+            }
+        });
+
+        it('matches a light the engine built itself', async () => {
+            const { app, get } = await bootApp(scene());
+            const element = get<LightComponentElement>('pc-light').component;
+
+            // Every property the element writes, compared against a component built from no data
+            // at all. Catches a default drifting on either side, including the properties the
+            // element does not expose but does not touch either.
+            const bare = new Entity('bare', app);
+            app.root.addChild(bare);
+            const engine = bare.addComponent('light') as LightComponent;
+
+            for (const [attribute, property] of cases) {
+                expect
+                    .soft(engineValue(element, property), `${attribute} vs a bare engine light`)
+                    .toEqual(engineValue(engine, property));
+            }
+        });
+    });
+
+    describe('attributes', () => {
+        it('applies every declarative attribute through the initial component data', async () => {
+            const markup = cases
+                .map(([attribute, , value]) => (value === '' ? attribute : `${attribute}="${value}"`))
+                .join(' ');
+            const { get } = await bootApp(scene(markup));
+            const component = get<LightComponentElement>('pc-light').component;
+
+            for (const [attribute, property, , expected] of cases) {
+                expect.soft(engineValue(component, property), attribute).toEqual(expected);
+            }
+        });
+
+        it('writes attribute changes through to the component', async () => {
+            const { get } = await bootApp(scene());
+            const light = get<LightComponentElement>('pc-light');
+
+            for (const [attribute, property, value, expected] of cases) {
+                light.setAttribute(attribute, value);
+                expect.soft(engineValue(light.component, property), attribute).toEqual(expected);
+            }
+        });
+
+        it('restores the engine default when an attribute is removed', async () => {
+            const { get } = await bootApp(scene());
+            const light = get<LightComponentElement>('pc-light');
+
+            for (const [attribute, property, value, , restored] of cases) {
+                light.setAttribute(attribute, value);
+                light.removeAttribute(attribute);
+                expect.soft(engineValue(light.component, property), attribute).toEqual(restored);
+            }
+        });
+
+        it('falls back to the default and warns once per invalid value', async () => {
+            const { get } = await bootApp(
+                scene('type="area" shadow-type="pcf7-32f" intensity="bright" shadow-bias="soft"')
+            );
+            const component = get<LightComponentElement>('pc-light').component;
+
+            warnings.expect(
+                "Invalid value 'area' for attribute 'type'. Valid values: directional, omni, spot. Using 'directional'."
+            );
+            warnings.expect(
+                "Invalid value 'pcf7-32f' for attribute 'shadow-type'. Valid values: pcf1-16f, pcf1-32f, pcf3-16f, pcf3-32f, pcf5-16f, pcf5-32f, vsm-16f, vsm-32f, pcss-32f. Using 'pcf3-32f'."
+            );
+            warnings.expect("Invalid value 'bright' for attribute 'intensity'. Expected a finite number. Using '1'.");
+            warnings.expect(
+                "Invalid value 'soft' for attribute 'shadow-bias'. Expected a finite number. Using '0.05'."
+            );
+
+            expect(component.type).toBe('directional');
+            expect(component.shadowType).toBe(SHADOW_PCF3_32F);
+            expect(component.intensity).toBe(1);
+            expect(component.shadowBias).toBe(0.05);
+        });
+
+        it('maps each PCF shadow type name to its own engine constant', async () => {
+            const { get } = await bootApp(scene());
+            const light = get<LightComponentElement>('pc-light');
+
+            // The PCF family is not device-gated, so these reach the component unchanged. VSM and
+            // PCSS are covered by the downgrade test below.
+            const names = ['pcf1-16f', 'pcf1-32f', 'pcf3-16f', 'pcf3-32f', 'pcf5-16f', 'pcf5-32f'] as const;
+
+            const values = names.map((name) => {
+                light.setAttribute('shadow-type', name);
+                return light.component.shadowType;
+            });
+
+            expect(new Set(values).size, 'each name resolves to its own constant').toBe(names.length);
+            expect(values[names.indexOf('pcf3-32f')]).toBe(SHADOW_PCF3_32F);
+        });
+
+        it('lets the engine downgrade a shadow type the device cannot render', async () => {
+            const { get } = await bootApp(scene());
+            const light = get<LightComponentElement>('pc-light');
+
+            // Light#shadowType downgrades by device capability, and the two paths differ: the null
+            // device renders half-float but not float, so 32-bit VSM drops one step to 16-bit
+            // while PCSS drops all the way to PCF3. The element keeps the request either way -
+            // this divergence is the engine's, not the element's, and is pinned so a change to
+            // either side shows up here.
+            light.setAttribute('shadow-type', 'vsm-32f');
+            expect(light.shadowType, 'the element keeps the request').toBe('vsm-32f');
+            expect(light.component.shadowType, '32-bit VSM falls to 16-bit').toBe(SHADOW_VSM_16F);
+
+            light.setAttribute('shadow-type', 'pcss-32f');
+            expect(light.component.shadowType, 'PCSS falls to PCF3').toBe(SHADOW_PCF3_32F);
+        });
+    });
+});


### PR DESCRIPTION
Audited `<pc-light>` against the engine's `LightComponent`, the same way as #411 — by diffing a bare `<pc-light>` against a light component the engine builds from no data, rather than reading defaults off the typings. **19 of 46 settable properties are exposed, and four of the 19 wrote the element's own default rather than the engine's.**

## The four defaults

| property | was | now (engine) |
| --- | --- | --- |
| `normalOffsetBias` | 0.05 | **0** |
| `shadowBias` | 0.2 | **0.05** |
| `shadowDistance` | 16 | **40** |
| `vsmBias` | 0.01 | **0.0025** |

All four go through `getInitialComponentData` unconditionally, so every `<pc-light>` carried them. They arrived together in `db61972` (Oct 2024) with no rationale recorded, and read as a set tuned to make shadows look acceptable out of the box at a small scene scale — the library-side quality default this project has decided against elsewhere. Same call as `clear-stencil-buffer` in #411: expose the attribute, let the app opt in.

The removal defaults in `attributeChangedCallback` move with the fields. Without that, removing an attribute would have restored the old value.

Two examples show the deviation confusing its own authors:

- [basic-shapes.html:61](examples/basic-shapes.html) sets `vsm-bias="0.01"` — already the default. That value *is* needed in an engine example, where the default is 0.0025, so it looks copied across without noticing.
- [ragdoll.html:79](examples/ragdoll.html) sets `shadow-distance="16"` — also already the default — under a comment explaining the choice.

### ⚠️ This one is visible

Unlike the stencil fix, this changes what existing apps render. Shadows now spread the same 1024 map over 40 units rather than 16, and the lower bias pair removes a margin against acne. Anyone who liked the old look sets four attributes; the defaults now match what every engine doc and example assumes.

### Measured, per example

Forcing `backend="webgl2"` on a copy of each example makes `gl.readPixels` available, so the change is measured rather than guessed. Each example was stepped 180 frames to settle, then rendered twice per capture, and every run ends by restoring the authored attributes and confirming the frame is byte-identical to the start — so the numbers are not contaminated by leftover state.

| example | light | pixels changed >4/255 | changed >32/255 | max Δ | speckle engine → old |
| --- | --- | --- | --- | --- | --- |
| `basic-physics` | directional | 2.83% | **0.00%** | 40 | 0.092 → 0.096 |
| `positional-sound` | directional | 0.54% | **0.00%** | 29 | 0.070 → 0.068 |
| `3d-text` | directional | 2.57% | **0.63%** | 169 | 0.049 → 0.048 |
| `physics-cluster` | omni | 0.04% | **0.00%** | 19 | 0.002 → 0.002 |

"Speckle" counts pixels darker than both horizontal neighbours by >18/255, at full resolution — shadow acne is exactly that signal, and downsampling averages it away. **It does not rise anywhere.** Three of the four are flat or fractionally lower with the engine defaults, which is the opposite of the concern that motivated asking about this change.

Each row is calibrated against a control in the same scene: a `shadow-distance` of 400, roughly 10x the new default. In `basic-physics` that control moves 2.61% of pixels, against 2.83% for the defaults change — so a couple of percent is the scale of a *large* shadow change here, because the shadow footprint is only a few percent of the frame. Three examples change imperceptibly at that scale.

`3d-text` is the one visible change, and the one to look at before merging. It sets `shadow-resolution="2048"`, so the crisper map lets the lower bias show: 0.63% of pixels shift hard, above its own control's 0.42%. The direction is benign — the shadowed area is unchanged (96.06% vs 96.10% of pixels below luminance 60) while mean luminance drops from 8.82 to 8.30, i.e. shadows sit tighter against their casters instead of being pushed off them. That is what dropping `shadowBias` from 0.2 to 0.05 is supposed to do, and is arguably the better picture, but it is a judgement about how the example should look rather than something a metric settles.

## Tests

The element had no test file — it appeared in three suites, all incidentally, which is how four defaults survived. It gets one on the `joint`/`camera` table pattern: 19 rows over engine defaults, initial component data, live writes, restore-on-removal, plus invalid-value warnings.

The load-bearing one is **`matches a light the engine built itself`** — it compares the element's component against `entity.addComponent('light')` with no data, property by property. That's the test that would have caught all four, and it catches drift on either side of the boundary in future.

Two engine behaviors got pinned while writing it. `Light#shadowType` downgrades by device capability and the two paths differ: the null device renders half-float but not float, so 32-bit VSM drops one step to `SHADOW_VSM_16F` while PCSS drops all the way to `SHADOW_PCF3_32F`. The element keeps the requested name either way, so `light.shadowType` and `light.component.shadowType` legitimately disagree — worth having written down.

## Also in here

- `getInitialComponentData` gains the `?? SHADOW_PCF3_32F` fallback its own setter already had. Unreachable today (`parseEnum` constrains the key) but it matches the setter and the camera's pattern.
- `observedAttributes` and the `switch` are put in alphabetical order. They disagreed with each other in three places, and the new suite's table treats `observedAttributes` as the ordering source of truth.

## Not in here

**27 properties remain unexposed.** Grouped, for whoever picks these up:

- **Cascaded shadow maps** — `numCascades`, `cascadeBlend`, `cascadeDistribution`, `shadowUpdateOverrides`. The main quality lever for directional shadows, and the most valuable group.
- **Performance** — `shadowUpdateMode`. "Render this static light's shadows once" is a large, cheap win HTML can't ask for.
- **Shading** — `falloffMode`, `affectSpecularity`, `vsmBlurMode`, `shape` (area lights).
- **Cookies** — 8 properties. `cookieAsset` needs an asset reference, which `pc-sky`'s `asset` already models.
- **Lightmapping** — `bake`, `bakeDir`, `bakeNumSamples`, `bakeArea`, `affectDynamic`, `affectLightmapped`, `isStatic`, `mask`. Coherent to omit while there's no lightmapper story. `mask` carries an engine-documented footgun: writing it doesn't update the three helpers, and a later helper write can clobber it.
- **`luminance`** — same unreachable-without-`Scene#physicalUnits` gap as the camera's `aperture`/`shutter`/`sensitivity`.
- **`layers`** — the library-wide gap from #411, unchanged.

The JSDoc also states a default for exactly one of the 19 attributes (`type`). The manifest derives them from the field initializers so editor tooltips are fine, but the API reference states none — worth a sweep, separate from this.

## Verification

- 973 tests pass across 46 files; ESLint, `type-check:src`, `type-check:test` clean; `npm run cem` validates 31 elements.
- Examples measured under WebGL2 as above; temporary copies removed.
- Reverted the source and re-ran: **4 tests fail across 11 assertions**, naming each of the four defaults in both the engine-default table and the bare-engine-light comparison.

## Clean bills of health

All 19 setters write the matching engine property. `shadowType` covers all 9 live `SHADOW_*` values. The `type` union correctly omits `'point'` (an alias of `omni`, same value). `color`, `intensity`, `range`, both cone angles, both penumbra properties and the four remaining shadow properties all already matched the engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
