### PR TITLE
Remove stray Components doc category from AnimClipElement

### DIFF
--- a/src/components/anim-clip.ts
+++ b/src/components/anim-clip.ts
@@ -25,8 +25,6 @@ import { AnimComponentElement } from './anim-component';
  * @elementSummary The `<pc-anim-clip>` element declares one named animation clip on its parent
  * `<pc-anim>`, taken from the `asset` it names or, without one, from the enclosing `<pc-model>`'s
  * own animations. Must be a direct child of `<pc-anim>`.
- *
- * @category Components
  */
 class AnimClipElement extends AsyncElement {
     /**


### PR DESCRIPTION
The API reference listed `AnimClipElement` under the **Components** category, but `<pc-anim-clip>` is not a component — it is a child element that declares one named clip on its parent `<pc-anim>`.

The cause: its doc header copied the `@category Components` TypeDoc tag from the component element files. The analogous child-declaration elements — `SoundSlotElement` (`<pc-sound-slot>`) and `ScriptInstanceElement` (`<pc-script-instance>`) — carry no category tag and render in the default **Other** section.

This removes the stray tag. Rebuilt the docs locally and confirmed `AnimClipElement` now appears under **Other** with its analogues, while `AnimComponentElement` (`<pc-anim>`) correctly remains under **Components**. No runtime change — doc comment only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
