### PR TITLE
Fly the Solar System camera as a probe tied to the page scroll

### DIFF
--- a/examples/assets/scripts/solar-system.mjs
+++ b/examples/assets/scripts/solar-system.mjs
@@ -131,12 +131,14 @@ export class TourStop extends Script {
      */
     radius = 1;
 }
-
 /**
- * Drives the camera along a line of tour stops — the children of a target entity, in order,
- * plus a final overview pose. The page reports a fractional stop index by firing a 'tour:t'
- * event on the application (typically mapped from scroll position) and the camera chases it
- * with frame-rate independent damping, framing each stop off-center on alternating sides.
+ * Drives the camera as a probe flying the line of tour stops — the children of a target
+ * entity, in order, plus a final overview pose. The page reports a fractional stop index by
+ * firing a 'tour:t' event on the application (typically mapped from scroll position) and the
+ * camera follows it directly, so the shot is a function of the scroll rather than of elapsed
+ * time. The stops are not framings cut between but points on one continuous trajectory: the
+ * probe coasts down the line of subjects, passing each at that stop's framing distance, and
+ * keeps the subject it is passing in shot until the pass is over before slewing to the next.
  */
 export class PlanetTour extends Script {
     static scriptName = 'planetTour';
@@ -150,7 +152,7 @@ export class PlanetTour extends Script {
     planets = null;
 
     /**
-     * The camera distance from each stop, as a multiple of the stop's radius.
+     * The distance the probe passes each stop at, as a multiple of the stop radius.
      *
      * @attribute
      * @type {number}
@@ -159,7 +161,7 @@ export class PlanetTour extends Script {
 
     /**
      * The lateral framing offset, as a fraction of the half viewport width. Stops alternate
-     * sides, and the offset fades out on portrait aspect ratios to center the subject.
+     * sides, and the offset gives way to `rise` on portrait aspect ratios.
      *
      * @attribute
      * @type {number}
@@ -167,29 +169,44 @@ export class PlanetTour extends Script {
     side = 0.35;
 
     /**
-     * The camera height above each stop, as a fraction of the camera distance.
+     * The vertical framing offset, as a fraction of the half viewport height. The portrait
+     * counterpart of `side`: where a landscape viewport seats the narrative beside the
+     * subject, a portrait one stacks it below, so the subject has to lift clear of it.
      *
      * @attribute
      * @type {number}
      */
-    lift = 0.12;
+    rise = 0.6;
 
     /**
-     * The exponential rate at which the camera chases the requested stop index.
+     * The exponential smoothing applied to the reported stop index, in seconds. The camera is
+     * a function of scroll position, so smoothing here is pure lag - keep it short enough to
+     * merely absorb the discrete steps of a mouse wheel, or 0 to track the scroll exactly.
      *
      * @attribute
      * @type {number}
      */
-    damping = 5;
+    smoothing = 0.04;
 
     /**
-     * The fraction of each segment spent holding on its stop before and after the transit,
-     * so a subject stays framed while its narrative is in view. Must be below 0.5.
+     * The ease applied across each pass, as a power. 1 coasts at a constant rate; much above
+     * that and the pass becomes a hold and a lurch. Keep it close to 1 and let the flattened
+     * ends do no more than take the edge off the swing through closest approach.
      *
      * @attribute
      * @type {number}
      */
-    dwell = 0.18;
+    ease = 1.4;
+
+    /**
+     * The fraction of a segment spent slewing from one subject to the next, centered on the
+     * midpoint between them. Smaller values hold a subject in shot for longer - ideally for as
+     * long as its narrative is on screen - at the cost of a faster pan between subjects.
+     *
+     * @attribute
+     * @type {number}
+     */
+    track = 0.4;
 
     /**
      * The idle drift amplitude multiplier. Set to 0 to disable drift.
@@ -221,12 +238,12 @@ export class PlanetTour extends Script {
         this._time = 0;
         this._stops = null;
 
-        this._posA = new Vec3();
-        this._posB = new Vec3();
-        this._lookA = new Vec3();
-        this._lookB = new Vec3();
         this._position = new Vec3();
         this._look = new Vec3();
+        this._subject = new Vec3();
+        this._forward = new Vec3();
+        this._right = new Vec3();
+        this._up = new Vec3();
 
         this.app.on('tour:t', (t) => {
             this._target = t;
@@ -270,40 +287,85 @@ export class PlanetTour extends Script {
     }
 
     /**
-     * Computes the camera pose for a stop. Regular stops frame their subject at a distance
-     * proportional to its radius, biased sideways so the subject composes off-center; the
-     * overview stop uses its explicit position and target.
+     * The distance the probe passes a stop at. Dividing by the viewport fit holds the subject
+     * to the same share of the frame on a narrow viewport as on a wide one. The overview stop
+     * has no subject, and so no standoff.
      *
      * @param {number} index - The stop index.
+     * @returns {number} The standoff distance.
+     */
+    _standoff(index) {
+        const { width, height } = this.app.graphicsDevice;
+        const fit = Math.min(1, width / Math.max(1, height));
+        return ((this._stops[index].radius ?? 0) * this.frame) / fit;
+    }
+
+    /**
+     * Eases progress across one segment. Barely off linear: just enough flattening at the ends
+     * to blunt the angular swing through a closest approach, while leaving the pass a coast.
+     *
+     * @param {number} u - The progress across the segment, 0 to 1.
+     * @returns {number} The eased progress.
+     */
+    _ease(u) {
+        return u < 0.5 ?
+            0.5 * (2 * u) ** this.ease :
+            1 - 0.5 * (2 - 2 * u) ** this.ease;
+    }
+
+    /**
+     * Computes the probe pose partway from one stop to the next. The probe coasts along the
+     * line joining the two subjects, and its standoff from that line changes only while it is
+     * slewing between them, never during a pass. The look target holds on the subject being
+     * passed and slews to the next across the middle of the segment, so each subject is
+     * watched through its whole pass - closing, abeam, then receding - and its closest
+     * approach can only fall on that subject's own stop.
+     *
+     * The subjects are strung along the world Y axis, so the standoff is taken along Z: the
+     * probe flies the line from the same side throughout.
+     *
+     * @param {number} index - The stop being passed.
+     * @param {number} u - The progress towards the next stop, 0 to 1.
      * @param {Vec3} position - The vector to receive the camera position.
      * @param {Vec3} look - The vector to receive the look target.
      */
-    _stopPose(index, position, look) {
-        const stop = this._stops[index];
-        if (stop.target) {
-            position.copy(stop.position);
-            look.copy(stop.target);
-            return;
-        }
+    _flyby(index, u, position, look) {
+        const a = this._stops[index];
+        const b = this._stops[index + 1];
 
+        // The slew from one subject to the next, held off until the pass of the first is over
+        const slew = math.clamp((u - 0.5) / Math.max(0.0001, this.track) + 0.5, 0, 1);
+        const hand = slew * slew * (3 - 2 * slew);
+        this._subject.lerp(a.position, b.position, hand);
+
+        // Coast along the line joining the two subjects, changing standoff only while slewing
+        // between them. Holding it steady through a pass leaves the separation along the line
+        // as the only thing changing, so the subject in shot closes and then recedes evenly
+        // however different the two framing distances are
+        position.lerp(a.position, b.position, this._ease(u));
+        position.z += math.lerp(this._standoff(index), this._standoff(index + 1), hand);
+
+        // Offset the look target in the camera's own frame rather than along world axes. A
+        // tracking shot swings through steep angles as a subject goes by, and a world-space
+        // offset would slide the subject around the frame as it did so
         const { width, height } = this.app.graphicsDevice;
         const aspect = width / Math.max(1, height);
-        const fit = Math.min(1, aspect);
-        const distance = (stop.radius * this.frame) / fit;
-
-        position.set(stop.position.x, stop.position.y + distance * this.lift, stop.position.z + distance);
-
-        // Bias the look target so the subject composes off-center: sideways on landscape
-        // (alternating sides per stop) and upward on portrait, where the narrative sits
-        // below the subject instead of beside it
-        const halfHeight = Math.tan(this.entity.camera.fov * 0.5 * math.DEG_TO_RAD) * distance;
-        const halfWidth = halfHeight * aspect;
         const ramp = math.clamp((aspect - 0.9) / 0.4, 0, 1);
+        const halfHeight = Math.tan(this.entity.camera.fov * 0.5 * math.DEG_TO_RAD) *
+            position.distance(this._subject);
         const sign = index % 2 === 0 ? 1 : -1;
+
+        this._forward.sub2(this._subject, position).normalize();
+        this._right.cross(this._forward, Vec3.UP).normalize();
+        this._up.cross(this._right, this._forward);
+
+        // Sides alternate per stop, so the bias hands over with the look target
+        const dx = -math.lerp(sign, -sign, hand) * this.side * halfHeight * aspect * ramp;
+        const dy = -this.rise * halfHeight * (1 - ramp);
         look.set(
-            stop.position.x - sign * this.side * halfWidth * ramp,
-            stop.position.y - 0.3 * halfHeight * (1 - ramp),
-            stop.position.z
+            this._subject.x + this._right.x * dx + this._up.x * dy,
+            this._subject.y + this._right.y * dx + this._up.y * dy,
+            this._subject.z + this._right.z * dx + this._up.z * dy
         );
     }
 
@@ -317,25 +379,26 @@ export class PlanetTour extends Script {
         }
         const count = this._stops.length;
 
-        // Chase the requested stop index with frame-rate independent damping
-        this._t += (this._target - this._t) * (1 - Math.exp(-this.damping * dt));
+        // Track the reported stop index. Every term below is a function of that index, so
+        // the shot is tied to the scroll and this smoothing is the only lag in the chain
+        this._t = this.smoothing > 0 ?
+            this._t + (this._target - this._t) * (1 - Math.exp(-dt / this.smoothing)) :
+            this._target;
         this._time += dt;
 
-        // Blend the camera pose between the two neighboring stops. The blend holds on each
-        // stop for the dwell fraction at both ends of the segment (keeping the subject
-        // framed while its narrative is read) and eases through the transit between them
         const t = math.clamp(this._t, 0, count - 1);
         const index = Math.max(0, Math.min(Math.floor(t), count - 2));
-        const next = Math.min(index + 1, count - 1);
-        const span = Math.max(0.0001, 1 - 2 * this.dwell);
-        let blend = math.clamp((t - index - this.dwell) / span, 0, 1);
-        blend = blend * blend * (3 - 2 * blend);
+        const u = math.clamp(t - index, 0, 1);
+        const overview = this._stops[index + 1].target;
 
-        this._stopPose(index, this._posA, this._lookA);
-        this._stopPose(next, this._posB, this._lookB);
-
-        this._position.lerp(this._posA, this._posB, blend);
-        this._look.lerp(this._lookA, this._lookB, blend);
+        // The overview stop has no subject to fly past, so the closing segment holds the probe
+        // at its last closest approach and blends from there into the explicit overview pose
+        this._flyby(index, overview ? 0 : u, this._position, this._look);
+        if (overview) {
+            const e = this._ease(u);
+            this._position.lerp(this._position, this._stops[index + 1].position, e);
+            this._look.lerp(this._look, overview, e);
+        }
 
         // A gentle idle drift, scaled to the current viewing distance
         const sway = this._position.distance(this._look) * 0.02 * this.drift;

--- a/examples/solar-system.html
+++ b/examples/solar-system.html
@@ -543,16 +543,17 @@
             <!-- Scene -->
             <pc-scene>
                 <!-- Camera -->
-                <pc-entity name="camera" position="0 7.6 63">
+                <pc-entity name="camera" position="0 0 63">
                     <pc-camera clear-color="0 0 0 0" fov="35" near-clip="0.5" far-clip="1500" tonemap="neutral"></pc-camera>
                     <pc-script>
                         <pc-script-instance name="planetTour"
                                             planets="entity:planets"
                                             frame="7"
                                             side="0.35"
-                                            lift="0.12"
-                                            damping="5"
-                                            dwell="0.3"
+                                            rise="0.6"
+                                            smoothing="0.04"
+                                            ease="1.4"
+                                            track="0.4"
                                             drift="1"
                                             overview-position="7 -250 22"
                                             overview-target="-20 -150 0"></pc-script-instance>
@@ -808,11 +809,12 @@
                 { element: document.getElementById('stars-near'), factor: 0.12, density: 55, alpha: 0.85 }
             ];
 
-            // A snappier camera and no idle drift under reduced motion - runtime changes to
-            // pc-script-instance attributes are applied live to the script instance
+            // Lock the camera to the scroll position and drop the idle drift under reduced
+            // motion - runtime changes to pc-script-instance attributes are applied live to
+            // the script instance
             if (reducedMotion) {
                 const tour = document.querySelector('pc-script-instance[name="planetTour"]');
-                tour.setAttribute('damping', '30');
+                tour.setAttribute('smoothing', '0');
                 tour.setAttribute('drift', '0');
             }
 
@@ -878,23 +880,30 @@
             // ---- scroll to tour progress ----
 
             let app = null;
-            let tops = [];
+            let anchors = [];
             let tourProgress = 0;
 
+            // The scroll offset at which each section's copy sits vertically centered in the
+            // viewport. That is the moment the camera should reach the matching tour stop, so
+            // the closest approach of each fly-by lands on the copy describing it
             const measure = () => {
-                tops = sections.map((section) => section.offsetTop);
+                anchors = sections.map((section) => {
+                    const box = section.querySelector('.copy') || section;
+                    const rect = box.getBoundingClientRect();
+                    return rect.top + window.scrollY + rect.height / 2 - window.innerHeight / 2;
+                });
             };
 
-            // Piecewise map of scroll position to a fractional stop index: section i aligned
-            // with the viewport top means the camera has settled at stop i
+            // Piecewise map of scroll position to a fractional stop index, keyed on those
+            // anchors: scrolling from one to the next drives one whole tour segment
             const computeT = () => {
                 const y = window.scrollY;
-                let i = sections.length - 1;
-                while (i > 0 && y < tops[i]) i--;
-                const start = tops[i];
-                const end = i + 1 < tops.length ? tops[i + 1] : start + sections[i].offsetHeight;
+                let i = anchors.length - 1;
+                while (i > 0 && y < anchors[i]) i--;
+                const start = anchors[i];
+                const end = i + 1 < anchors.length ? anchors[i + 1] : start + 1;
                 const f = end > start ? (y - start) / (end - start) : 0;
-                return Math.max(0, Math.min(sections.length - 1, i + f));
+                return Math.max(0, Math.min(anchors.length - 1, i + f));
             };
 
             const onScroll = () => {


### PR DESCRIPTION
Reworks the Solar System example's camera so the scroll drives a Voyager-style probe fly-by of each body rather than a cut between static framings.

## Why

The tour held one framing per planet and blended between the two either side of the current scroll position, with an exponential chase on top. Measured on `main`:

| Symptom | Cause |
| --- | --- |
| Camera kept moving after the scroll stopped | `damping="5"` — a 200 ms time constant |
| 60% of every segment was frozen, then lurched | `dwell="0.3"` — all motion crammed into `t=0.3→0.7` |
| Closest approach landed before the copy it describes | progress was keyed on `section.offsetTop` |
| The Sun *grew* as the shot left it (0.14 → 0.32 apparent radius) | a straight chord from the Sun's framing (63 units out) to Mercury's (7.35) carries the camera inward faster than it descends |

Blending between two framings is a dolly in and out — it can't read as a pass, however it's eased.

## What changed

`PlanetTour` no longer treats stops as framings to blend. They're points on one continuous trajectory, and a stop is just where the probe happens to be abeam of that subject.

- **Continuous coast.** Position lerps along the line joining the two subjects at `ease="1.4"`, barely off linear. No hold, no lurch.
- **A tracked pass.** The look target holds on the subject being passed and slews to the next only across the middle of the segment (`track="0.4"`). Mercury stays locked 11° off the view axis for 450 px of scroll while the camera sweeps from 24 units above it to 39 below — seen from above, then equator-on, then below.
- **Standoff changes only while slewing, never during a pass.** This is the load-bearing part. With standoff frozen through a pass, separation along the line is the only thing varying, so a subject closes and recedes evenly and its closest approach can only fall on its own stop — however far apart the two framing distances are. The Sun's 63 → 7.35 plunge now happens while it is swinging out of frame (113° off axis).
- **Framing offsets move into the camera's own right/up basis.** A tracking shot swings through angles steep enough that a world-axis offset would slide the subject around the frame.
- **Progress anchors on each section's copy being vertically centered** (`getBoundingClientRect` on `.copy`) instead of the section's top edge.

Attribute changes on `pc-script-instance[name="planetTour"]`:

- `damping` (rate) → `smoothing` (seconds, `0.04`) — now the only lag anywhere in the chain
- `dwell` → removed; `ease` `3.4` → `1.4`
- `track="0.4"` — new, the slew window
- `lift`, `arc` → removed, both superseded by the trajectory
- `rise="0.6"` — new; the portrait counterpart of `side`. Needed because centering the copy moved it into the space the subject occupied, and the old hardcoded `0.3` lift was tuned for a bottom-aligned copy.

## Verification

Ran at 1280×720, 1440×810 and 375×812, plus a real wheel-scroll pass on WebGPU.

Distance to each subject as % change from its own anchor (1280×720):

```
stop      at anchor | -300  -150  +150  +300 px
Mercury      7.35   | 163%   15%   17%   92%
Venus       10.85   |  42%    8%    8%   47%
Earth       11.55   |  41%    7%    7%   39%
Jupiter     31.50   |  -7%    1%    1%    7%
```

Symmetric about every anchor — that symmetry is what the old dolly lacked. Every stop is its own closest approach. The Sun holds flat at `0.1428 → 0.1448` apparent radius across the first 300 px instead of climbing to `0.3173`.

Scroll coupling under real wheel input: `target` and `t` agree to `2e-6` stop-index units.

Also checked: copy center lands exactly on the viewport center at each anchor (`360` vs `360` at 720p; `406` vs `406` at 812p); the finale still reaches the exact `overview-position` `7 -250 22` and holds to the end of scroll; the reduced-motion path (`smoothing`→0, `drift`→0) still applies live via the element's attributes.

## Notes for review

- The `pc-app` markup is untouched apart from the camera's authored first-frame position, which moves `0 7.6 63` → `0 0 63` now that the probe passes each subject level with it rather than above it. It's only visible for the frame before the script runs, behind the page's own loader.
- Two pre-existing traits I deliberately left alone: in portrait the hardcoded `overview-position` sits closer to Neptune than Neptune's own portrait standoff (the overview pose doesn't scale with aspect), and there is a ~100 px stars-only beat at the exact midpoint of each segment — that's the moment both copy blocks are half off-screen, and it's the scene's authored scale (1-unit planets 30 units apart) that makes it unavoidable, not the curve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
