### PR TITLE
Expose exposure on pc-scene

### DIFF
--- a/src/scene.ts
+++ b/src/scene.ts
@@ -11,9 +11,15 @@ import { parseColor, parseEnum, parseNumber, parseVec3 } from './parse';
  * {@link HTMLElement} interface.
  *
  * @elementSummary The `<pc-scene>` element holds the entity hierarchy the application renders,
- * along with the scene-wide fog and gravity settings. Must be a direct child of `<pc-app>`.
+ * along with the scene-wide fog, exposure and gravity settings. Must be a direct child of
+ * `<pc-app>`.
  */
 class SceneElement extends AsyncElement {
+    /**
+     * The exposure of the scene.
+     */
+    private _exposure = 1;
+
     /**
      * The fog type of the scene.
      */
@@ -96,6 +102,8 @@ class SceneElement extends AsyncElement {
 
     private _updateSceneSettings() {
         if (this._scene) {
+            this._scene.exposure = this._exposure;
+
             this._scene.fog.type = this._fog;
             this._scene.fog.color = this._fogColor;
             this._scene.fog.density = this._fogDensity;
@@ -115,6 +123,26 @@ class SceneElement extends AsyncElement {
      */
     private _applyGravity(value: Vec3) {
         this.closestApp?.app?.systems.rigidbody?.gravity.copy(value);
+    }
+
+    /**
+     * Sets the exposure of the scene, which tweaks the overall brightness of the rendered image.
+     * Ignored if the scene is using physical units. Defaults to 1.
+     * @param value - The exposure.
+     */
+    set exposure(value: number) {
+        this._exposure = value;
+        if (this.scene) {
+            this.scene.exposure = value;
+        }
+    }
+
+    /**
+     * Gets the exposure of the scene.
+     * @returns The exposure.
+     */
+    get exposure() {
+        return this._exposure;
     }
 
     /**
@@ -233,11 +261,14 @@ class SceneElement extends AsyncElement {
     }
 
     static get observedAttributes() {
-        return ['fog', 'fog-color', 'fog-density', 'fog-start', 'fog-end', 'gravity'];
+        return ['exposure', 'fog', 'fog-color', 'fog-density', 'fog-start', 'fog-end', 'gravity'];
     }
 
     attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
         switch (name) {
+            case 'exposure':
+                this.exposure = parseNumber(newValue, 1, name);
+                break;
             case 'fog':
                 this.fog = parseEnum(newValue, ['none', 'linear', 'exp', 'exp2'], 'none', name);
                 break;

--- a/test/integration/lifecycle.test.ts
+++ b/test/integration/lifecycle.test.ts
@@ -149,7 +149,7 @@ describe('<pc-app> lifecycle', () => {
     it('re-boots a removed pc-app when it is re-added within the same task', async () => {
         const handle = await bootApp(`
             ${MODEL_ASSET_TAG}
-            <pc-scene fog="linear"></pc-scene>
+            <pc-scene fog="linear" exposure="0.5"></pc-scene>
             <pc-entity name="e">
                 <pc-camera></pc-camera>
                 <pc-sound><pc-sound-slot name="blip"></pc-sound-slot></pc-sound>
@@ -205,6 +205,7 @@ describe('<pc-app> lifecycle', () => {
         const sceneElement = get<SceneElement>('pc-scene');
         expect(sceneElement.scene).toBe(app!.scene);
         expect(app!.scene.fog.type).toBe('linear');
+        expect(app!.scene.exposure).toBe(0.5);
 
         expect(uncaught.seen).toEqual([]);
     });


### PR DESCRIPTION
Exposure is the engine's lever on the overall brightness of the rendered image, and it was the one scene-wide setting `<pc-scene>` had no attribute for. A page lighting itself from an HDR sky had to reach for `app.scene.exposure` from script to stop the image clipping:

```js
const { app } = await whenReady('pc-app');
app.scene.exposure = 0.38;
```

which is now:

```html
<pc-scene exposure="0.38" fog="exp2" fog-color="#d1dbe3" fog-density="0.0035">
```

## Notes

- Defaults to **1**, the value the engine gives a scene it built itself, so markup without the attribute is unchanged.
- Applied from `_updateSceneSettings()` rather than the setter alone, so a scene re-acquired after its `<pc-app>` is removed and re-added carries the authored value across instead of reverting to the engine default. The lifecycle test that already pins `fog` across that path now pins `exposure` with it.
- The engine ignores `exposure` when a scene is in physical units, which `<pc-scene>` does not expose. The setter documents that interaction rather than the element growing a second attribute to explain the first.

## Testing

- `npm run lint`, `tsc --noEmit` and `npm run build` clean; manifest validates 31 elements and lists `exposure` on `pc-scene` (type `number`, default `1`), as does the generated VS Code custom data.
- Full suite passes.
- Checked in a browser: `exposure="0.38"` in markup reaches `app.scene.exposure` with no script, setting the attribute to `0.9` updates it live, and removing it restores `1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
