### PR TITLE
Hand the example the keyboard when the pointer is over it

### DIFF
--- a/examples/js/browser.mjs
+++ b/examples/js/browser.mjs
@@ -58,6 +58,7 @@ class ExampleBrowser {
         this.setupSearch();
         this.setupTitleBar();
         this.setupKeyboard();
+        this.setupFocus();
         this.setupMobileMenu();
         this.loadInitialExample();
     }
@@ -310,6 +311,25 @@ class ExampleBrowser {
         this.noResults.hidden = visible > 0;
         this.searchCount.textContent = q === '' ? '' : `${visible}/${this.entries.length}`;
         this.updatePrevNextState();
+    }
+
+    setupFocus() {
+        // An example hears the keyboard only while the iframe holds focus, and the shell hears
+        // the shortcuts below only while it does - the two cannot both have the arrow keys. So
+        // focus follows the pointer: whatever you are pointing at is what you are typing at.
+        // Without this, an example that reads keys does nothing until it is clicked, which reads
+        // as a broken demo rather than an unfocused frame.
+        this.frame.addEventListener('pointerenter', () => {
+            // Crossing the viewport on the way somewhere else must not swallow the rest of a
+            // search query, so a search in progress keeps the keys.
+            if (document.activeElement !== this.searchInput) {
+                this.frame.contentWindow.focus();
+            }
+        });
+
+        this.frame.addEventListener('pointerleave', () => {
+            this.frame.blur();
+        });
     }
 
     setupKeyboard() {


### PR DESCRIPTION
An example that reads the keyboard does nothing in the examples browser until you click it first. The iframe never receives focus, so every keystroke goes to the shell — which reads as a broken demo rather than an unfocused frame.

Four examples are driven this way: Vehicle Physics, Falling Blocks, First Person Controller and First Person Teleport. (`camera-controls.mjs`, which 19 examples use, binds no keys, so most examples are unaffected either way.)

## Why not just focus the iframe on load

Because the shell owns the keyboard and [says so](https://github.com/playcanvas/web-components/blob/main/examples/js/browser.mjs#L316): once focus is inside the iframe, keys belong to the example. ArrowUp/ArrowDown navigate the list — deliberately live even while the search box has focus — plus `[`, `]`, `/` and Escape. An example is always loaded, so focusing on load would retire all four shortcuts permanently, and the clash is direct: Vehicle Physics drives with the arrow keys.

So focus follows the pointer instead. Whatever you are pointing at is what you are typing at, which resolves the clash without the shell needing to know what any example binds:

- pointer enters the viewport → the example gets the keys, no click
- pointer leaves → the shell gets them back, and arrow navigation works again
- a search in progress keeps the keys, so crossing the viewport on the way somewhere else cannot swallow the rest of a query

## Testing

`npm run lint` and the full suite (981 tests) pass.

Traced `document.activeElement` in the shell while moving the pointer for real:

| pointer | active element | keys go to |
| --- | --- | --- |
| over the example | `IFRAME` | the example |
| back on the sidebar | `BODY` | the shell |
| crossing the example while the search box has focus | `INPUT` | the search box |

One caveat on what could be measured: an embedded browser pane's window does not hold OS focus, so `document.hasFocus()` returns false even for the shell. I verified the focus state that routes keystrokes, not the keystrokes themselves.

## Trade-offs worth a second opinion

- Focus following the mouse is unconventional on the web. It is invisible when it works, but it is a real behaviour change.
- Driving with the keyboard and moving the pointer off the viewport drops control until it returns. That is the same gesture that hands the arrow keys back to the list, so the two cannot both be had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
