### PR TITLE
Synthesize click events on entity-fronting elements

### DIFF
--- a/examples/tweening.html
+++ b/examples/tweening.html
@@ -34,7 +34,7 @@
                 <pc-model name="star" asset="star"
                           onpointerenter="this.entity.script.tweener.play(0)"
                           onpointerleave="this.entity.script.tweener.play(1)"
-                          onpointerdown="this.entity.script.tweener.play(2)">
+                          onclick="this.entity.script.tweener.play(2)">
                     <pc-script>
                         <pc-script-instance name="tweener" attributes='{
                             "tweens": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -66,6 +66,7 @@ import {
 
 import type { AssetElement } from './asset';
 import { AsyncElement } from './async-element';
+import { SYNTHESIZED_EVENTS } from './entity-base';
 import type { EntityBaseElement } from './entity-base';
 import type { EntityOwnerElement } from './entity-owner';
 import { LoadingBar } from './loading-bar';
@@ -73,15 +74,48 @@ import type { MaterialElement } from './material';
 import { parseBool, parseEnum, parseNumber } from './parse';
 import type { WasmElement } from './wasm';
 
-/** The pointer event types the application synthesizes on `<pc-entity>` elements via picking. */
-const pointerEventTypes = ['pointermove', 'pointerdown', 'pointerup', 'pointerenter', 'pointerleave'] as const;
-
 /**
  * The event types whose listeners make an element a hover target. Hover resolution walks past
  * elements listening for none of them, so a silent element never swallows an ancestor's
  * enter/leave pair.
  */
 const hoverEventTypes = ['pointerenter', 'pointerleave', 'pointermove'] as const;
+
+/**
+ * The canvas listeners each synthesized event type is driven by. Enter and leave are derived
+ * from move picks. A click is concluded from the down/up pair, with pointercancel discarding a
+ * press the browser takes back (for example a touch that becomes a scroll).
+ */
+const canvasEventsFor: Record<(typeof SYNTHESIZED_EVENTS)[number], readonly string[]> = {
+    pointermove: ['pointermove'],
+    pointerenter: ['pointermove'],
+    pointerleave: ['pointermove'],
+    pointerdown: ['pointerdown'],
+    pointerup: ['pointerup'],
+    click: ['pointerdown', 'pointerup', 'pointercancel']
+};
+
+/**
+ * Finds the nearest common inclusive ancestor of two picked nodes - the node a click belongs to
+ * when the press and the release picked different geometry, exactly as the DOM assigns a click
+ * whose down and up have different targets.
+ *
+ * @param a - The node the press picked, or `null`.
+ * @param b - The node the release picked, or `null`.
+ * @returns The nearest common inclusive ancestor, or `null` when there is none.
+ */
+const commonAncestor = (a: GraphNode | null, b: GraphNode | null): GraphNode | null => {
+    const ancestors = new Set<GraphNode>();
+    for (let node = a; node !== null; node = node.parent) {
+        ancestors.add(node);
+    }
+    for (let node = b; node !== null; node = node.parent) {
+        if (ancestors.has(node)) {
+            return node;
+        }
+    }
+    return null;
+};
 
 /**
  * Gives `pc-app` the sizing contract of a replaced element (`<video>`, `<img>`): a block-level
@@ -182,14 +216,6 @@ class AppElement extends AsyncElement {
 
     private _picker: Picker | null = null;
 
-    private _hasPointerListeners: Record<string, boolean> = {
-        pointerenter: false,
-        pointerleave: false,
-        pointerdown: false,
-        pointerup: false,
-        pointermove: false
-    };
-
     private _hoveredEntity: EntityBaseElement | null = null;
 
     // Identifies the newest in-flight hover pick, so out-of-order results can be discarded
@@ -198,8 +224,21 @@ class AppElement extends AsyncElement {
     private _pointerHandlers: Record<string, EventListener | null> = {
         pointermove: null,
         pointerdown: null,
-        pointerup: null
+        pointerup: null,
+        pointercancel: null
     };
+
+    /**
+     * The pick of each pointer's primary-button press, keyed by pointerId and kept while a click
+     * may still conclude it. The promise is stored rather than its result, so a release can
+     * await a press pick that has not resolved yet. Entries are removed by the matching
+     * pointerup or pointercancel, and only ever stored while some element listens for click -
+     * which is also what keeps those two canvas listeners attached.
+     */
+    private _downPicks = new Map<number, Promise<GraphNode | null>>();
+
+    /** Whether any element in the tree listens for click. Maintained by _syncCanvasListeners. */
+    private _clickListened = false;
 
     private _app: AppBase | null = null;
 
@@ -241,12 +280,12 @@ class AppElement extends AsyncElement {
     constructor() {
         super();
 
-        // Track pointer listeners being added to and removed from descendant entities.
-        // Registered once here rather than on every boot - the handlers no-op while there is no
-        // canvas, and a re-booted element must not stack a second set.
-        pointerEventTypes.forEach((type) => {
-            this.addEventListener(`${type}:connect`, () => this._onPointerListenerAdded(type));
-            this.addEventListener(`${type}:disconnect`, () => this._onPointerListenerRemoved(type));
+        // Track listeners for the synthesized events being added to and removed from descendant
+        // entities. Registered once here rather than on every boot - the sync no-ops while there
+        // is no canvas, and a re-booted element must not stack a second set.
+        SYNTHESIZED_EVENTS.forEach((type) => {
+            this.addEventListener(`${type}:connect`, () => this._syncCanvasListeners());
+            this.addEventListener(`${type}:disconnect`, () => this._syncCanvasListeners());
         });
     }
 
@@ -609,18 +648,14 @@ class AppElement extends AsyncElement {
         this._pointerHandlers.pointermove = listener(this._onPointerMove);
         this._pointerHandlers.pointerdown = listener(this._onPointerDown);
         this._pointerHandlers.pointerup = listener(this._onPointerUp);
+        this._pointerHandlers.pointercancel = (event: Event) => {
+            this._downPicks.delete((event as PointerEvent).pointerId);
+        };
 
-        // Attach canvas handlers for listeners registered before this boot (e.g. handlers
-        // created from onpointer* attributes when their elements were first upgraded, or
+        // Attach canvas listeners for element listeners registered before this boot (e.g.
+        // handlers created from inline attributes when their elements were first upgraded, or
         // listeners carried over from before a re-boot)
-        pointerEventTypes.forEach((type) => {
-            const anyListeners = Array.from(
-                this.querySelectorAll<EntityBaseElement>('pc-entity, pc-model, pc-node')
-            ).some((entity) => entity._hasListeners(type));
-            if (anyListeners) {
-                this._onPointerListenerAdded(type);
-            }
-        });
+        this._syncCanvasListeners();
     }
 
     private _pickerDestroy() {
@@ -637,15 +672,11 @@ class AppElement extends AsyncElement {
         this._pointerHandlers = {
             pointermove: null,
             pointerdown: null,
-            pointerup: null
+            pointerup: null,
+            pointercancel: null
         };
-        this._hasPointerListeners = {
-            pointerenter: false,
-            pointerleave: false,
-            pointerdown: false,
-            pointerup: false,
-            pointermove: false
-        };
+        this._downPicks.clear();
+        this._clickListened = false;
     }
 
     /**
@@ -871,7 +902,17 @@ class AppElement extends AsyncElement {
     private async _onPointerDown(event: PointerEvent) {
         if (!this._picker || !this.app) return;
 
-        const node = await this._pickNode(event);
+        const pick = this._pickNode(event);
+
+        // A click concludes on the matching pointerup, which needs to know what the press
+        // picked. Primary button only - the only button a click can conclude from - and only
+        // while click is listened for, since it is the click mapping that keeps the pointerup
+        // and pointercancel listeners attached to clean the entry up again.
+        if (this._clickListened && event.button === 0) {
+            this._downPicks.set(event.pointerId, pick);
+        }
+
+        const node = await pick;
         if (!this._picker) return; // the element disconnected while the pick was in flight
 
         const entityElement = this._elementWithListener(node, 'pointerdown');
@@ -883,6 +924,11 @@ class AppElement extends AsyncElement {
     private async _onPointerUp(event: PointerEvent) {
         if (!this._picker || !this.app) return;
 
+        // The press pick this release may conclude as a click. Claimed synchronously, so the
+        // entry is gone before any other event for this pointer can be handled.
+        const downPick = this._downPicks.get(event.pointerId);
+        this._downPicks.delete(event.pointerId);
+
         const node = await this._pickNode(event);
         if (!this._picker) return; // the element disconnected while the pick was in flight
 
@@ -890,47 +936,49 @@ class AppElement extends AsyncElement {
         if (entityElement) {
             entityElement.dispatchEvent(new PointerEvent('pointerup', event));
         }
-    }
 
-    private _onPointerListenerAdded(type: string) {
-        if (!this._hasPointerListeners[type] && this._canvas) {
-            this._hasPointerListeners[type] = true;
+        // A click fires where the DOM fires it: at the nearest common inclusive ancestor of
+        // what the press and the release picked, for the primary button only. The press pick
+        // may still be in flight - a quick tap resolves in pick order, not event order.
+        if (!downPick || event.button !== 0) return;
+        const downNode = await downPick;
+        if (!this._picker) return;
 
-            // For enter/leave events, we need the move handler
-            const handler =
-                type === 'pointerenter' || type === 'pointerleave'
-                    ? this._pointerHandlers.pointermove
-                    : this._pointerHandlers[type];
-
-            if (handler) {
-                this._canvas.addEventListener(
-                    type === 'pointerenter' || type === 'pointerleave' ? 'pointermove' : type,
-                    handler
-                );
-            }
+        const clickElement = this._elementWithListener(commonAncestor(downNode, node), 'click');
+        if (clickElement) {
+            clickElement.dispatchEvent(new PointerEvent('click', event));
         }
     }
 
-    private _onPointerListenerRemoved(type: string) {
-        const hasListeners = Array.from(
-            this.querySelectorAll<EntityBaseElement>('pc-entity, pc-model, pc-node')
-        ).some((entity) => entity._hasListeners(type));
+    /**
+     * Attaches exactly the canvas listeners the tree's current element listeners need, and
+     * detaches the rest. Recomputed whenever a listener connects or disconnects anywhere under
+     * this element: several synthesized types can need the same canvas listener (enter, leave
+     * and move all ride the move pick; click rides the down/up pair), so one type's removal
+     * must not detach a listener another type still uses. Re-attaching an attached listener is
+     * a no-op by EventTarget semantics, so no attach state is kept.
+     */
+    private _syncCanvasListeners() {
+        const canvas = this._canvas;
+        if (!canvas) return; // not booted yet: _pickerCreate syncs once the handlers exist
 
-        if (!hasListeners && this._canvas) {
-            this._hasPointerListeners[type] = false;
-
-            const handler =
-                type === 'pointerenter' || type === 'pointerleave'
-                    ? this._pointerHandlers.pointermove
-                    : this._pointerHandlers[type];
-
-            if (handler) {
-                this._canvas.removeEventListener(
-                    type === 'pointerenter' || type === 'pointerleave' ? 'pointermove' : type,
-                    handler
-                );
+        const elements = Array.from(this.querySelectorAll<EntityBaseElement>('pc-entity, pc-model, pc-node'));
+        const needed = new Set<string>();
+        for (const type of SYNTHESIZED_EVENTS) {
+            if (elements.some((element) => element._hasListeners(type))) {
+                canvasEventsFor[type].forEach((canvasType) => needed.add(canvasType));
             }
         }
+        this._clickListened = elements.some((element) => element._hasListeners('click'));
+
+        Object.entries(this._pointerHandlers).forEach(([canvasType, handler]) => {
+            if (!handler) return;
+            if (needed.has(canvasType)) {
+                canvas.addEventListener(canvasType, handler);
+            } else {
+                canvas.removeEventListener(canvasType, handler);
+            }
+        });
     }
 
     /**

--- a/src/app.ts
+++ b/src/app.ts
@@ -96,6 +96,12 @@ const canvasEventsFor: Record<(typeof SYNTHESIZED_EVENTS)[number], readonly stri
 };
 
 /**
+ * How long after a click a further click on the same target still raises the click count that
+ * `detail` carries, approximating the platform's double-click time.
+ */
+const CLICK_CHAIN_MS = 500;
+
+/**
  * Finds the nearest common inclusive ancestor of two picked nodes - the node a click belongs to
  * when the press and the release picked different geometry, exactly as the DOM assigns a click
  * whose down and up have different targets.
@@ -239,6 +245,12 @@ class AppElement extends AsyncElement {
 
     /** Whether any element in the tree listens for click. Maintained by _syncCanvasListeners. */
     private _clickListened = false;
+
+    /**
+     * The previous click's target, time and count, for chaining successive clicks into the
+     * click count that `detail` carries. `null` until a click has fired.
+     */
+    private _lastClick: { element: EntityBaseElement; time: number; count: number } | null = null;
 
     private _app: AppBase | null = null;
 
@@ -677,6 +689,7 @@ class AppElement extends AsyncElement {
         };
         this._downPicks.clear();
         this._clickListened = false;
+        this._lastClick = null;
     }
 
     /**
@@ -946,7 +959,21 @@ class AppElement extends AsyncElement {
 
         const clickElement = this._elementWithListener(commonAncestor(downNode, node), 'click');
         if (clickElement) {
-            clickElement.dispatchEvent(new PointerEvent('click', event));
+            const click = new PointerEvent('click', event);
+
+            // The init above copied pointerup's `detail`, which the Pointer Events spec fixes
+            // at 0 - but click is exempt: its detail is the click count, chained here as the
+            // platform chains it (same target, within the double-click window). Overridden
+            // with defineProperty because an event instance used as an init dict cannot have
+            // single fields replaced.
+            const time = performance.now();
+            const last = this._lastClick;
+            const count =
+                last && last.element === clickElement && time - last.time <= CLICK_CHAIN_MS ? last.count + 1 : 1;
+            this._lastClick = { element: clickElement, time, count };
+            Object.defineProperty(click, 'detail', { value: count });
+
+            clickElement.dispatchEvent(click);
         }
     }
 

--- a/src/entity-base.ts
+++ b/src/entity-base.ts
@@ -4,17 +4,28 @@ import type { AppElement } from './app';
 import { AsyncElement } from './async-element';
 
 /**
- * The attribute names of the inline `onpointer*` event handlers, shared by every element that
- * fronts an engine entity. Spread into `observedAttributes` by subclasses.
+ * The event types the containing `<pc-app>` synthesizes on entity-fronting elements via picking:
+ * the `pointer*` events, plus `click` — which concludes a primary-button press and release, and
+ * is delivered as a `PointerEvent` exactly as modern browsers deliver native clicks.
  * @internal
  */
-export const POINTER_ATTRIBUTES = [
-    'onpointerenter',
-    'onpointerleave',
-    'onpointerdown',
-    'onpointerup',
-    'onpointermove'
+export const SYNTHESIZED_EVENTS = [
+    'pointerenter',
+    'pointerleave',
+    'pointerdown',
+    'pointerup',
+    'pointermove',
+    'click'
 ] as const;
+
+const SYNTHESIZED_EVENT_SET: ReadonlySet<string> = new Set(SYNTHESIZED_EVENTS);
+
+/**
+ * The attribute names of the inline event handlers (`onpointerdown`, `onclick`, ...), shared by
+ * every element that fronts an engine entity. Spread into `observedAttributes` by subclasses.
+ * @internal
+ */
+export const EVENT_ATTRIBUTES = SYNTHESIZED_EVENTS.map((type) => `on${type}`);
 
 /**
  * The base class for elements that front an engine {@link Entity}: `<pc-entity>` and
@@ -34,12 +45,13 @@ class EntityBaseElement extends AsyncElement {
     protected _appElement: AppElement | null = null;
 
     /**
-     * The pointer event listeners for the entity.
+     * The event listeners registered on the element, by type.
      */
     private _listeners: Record<string, EventListener[]> = {};
 
     /**
-     * The event types for which an inline `onpointer*` attribute is currently present.
+     * The event types for which an inline handler attribute (`onpointerdown`, `onclick`, ...)
+     * is currently present.
      */
     private _inlineHandlerTypes = new Set<string>();
 
@@ -75,7 +87,7 @@ class EntityBaseElement extends AsyncElement {
     }
 
     /**
-     * Tracks whether an inline `onpointer*` attribute is present. The browser itself compiles and
+     * Tracks whether an inline handler attribute is present. The browser itself compiles and
      * runs these attributes — they are standard `GlobalEventHandlers`, so setting one replaces
      * the previous handler and removing it removes the handler, exactly like `onclick` on any
      * HTML element. But because they bypass {@link EventTarget.addEventListener}, the connect/disconnect
@@ -105,7 +117,7 @@ class EntityBaseElement extends AsyncElement {
         }
         this._listeners[type].push(listener);
         super.addEventListener(type, listener, options);
-        if (type.startsWith('pointer')) {
+        if (SYNTHESIZED_EVENT_SET.has(type)) {
             this.dispatchEvent(new CustomEvent(`${type}:connect`, { bubbles: true }));
         }
     }
@@ -115,15 +127,15 @@ class EntityBaseElement extends AsyncElement {
             this._listeners[type] = this._listeners[type].filter((l) => l !== listener);
         }
         super.removeEventListener(type, listener, options);
-        if (type.startsWith('pointer')) {
+        if (SYNTHESIZED_EVENT_SET.has(type)) {
             this.dispatchEvent(new CustomEvent(`${type}:disconnect`, { bubbles: true }));
         }
     }
 
     /**
      * Whether the element has a listener for an event type, registered either with
-     * {@link EventTarget.addEventListener} or with the matching inline `onpointer*` attribute. Read by the
-     * containing `<pc-app>` element to gate pointer event synthesis.
+     * {@link EventTarget.addEventListener} or with the matching inline handler attribute. Read by the
+     * containing `<pc-app>` element to gate event synthesis.
      *
      * @param type - The event type.
      * @returns Whether a listener is registered.

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -1,6 +1,6 @@
 import { Vec3 } from 'playcanvas';
 
-import { POINTER_ATTRIBUTES } from './entity-base';
+import { EVENT_ATTRIBUTES } from './entity-base';
 import { buildDescendantEntities, EntityOwnerElement } from './entity-owner';
 import { parseBool, parseTags, parseVec3 } from './parse';
 
@@ -12,8 +12,8 @@ import { parseBool, parseTags, parseVec3 } from './parse';
  *
  * The pointer events below are dispatched by the containing `<pc-app>` element when the pointer
  * intersects this entity's geometry. They are only generated while the entity has a listener for
- * them, registered either with {@link EventTarget.addEventListener} or with the matching inline `onpointer*`
- * attribute.
+ * them, registered either with {@link EventTarget.addEventListener} or with the matching inline
+ * attribute (`onpointerdown`, `onclick`, ...).
  *
  * @elementSummary The `<pc-entity>` element creates an entity: a named, transformable node of the
  * scene hierarchy, and the host for component elements such as `<pc-camera>`, `<pc-light>` and
@@ -33,11 +33,16 @@ import { parseBool, parseTags, parseVec3 } from './parse';
  * entity.
  * @attribute {string} onpointerup - Script to run when a pointer button is released over the
  * entity.
+ * @attribute {string} onclick - Script to run when the entity is clicked: a primary pointer
+ * button pressed and then released over it.
  * @fires {PointerEvent} pointerenter - Fired when the pointer moves onto the entity.
  * @fires {PointerEvent} pointerleave - Fired when the pointer moves off the entity.
  * @fires {PointerEvent} pointermove - Fired when the pointer moves over the entity.
  * @fires {PointerEvent} pointerdown - Fired when a pointer button is pressed over the entity.
  * @fires {PointerEvent} pointerup - Fired when a pointer button is released over the entity.
+ * @fires {PointerEvent} click - Fired when a primary pointer button is pressed and then released
+ * over the entity. A press and release that picked different entities fires on their nearest
+ * common ancestor instead, as in the DOM.
  */
 class EntityElement extends EntityOwnerElement {
     connectedCallback() {
@@ -77,7 +82,7 @@ class EntityElement extends EntityOwnerElement {
     }
 
     static get observedAttributes() {
-        return ['enabled', 'name', 'position', 'rotation', 'scale', 'tags', ...POINTER_ATTRIBUTES];
+        return ['enabled', 'name', 'position', 'rotation', 'scale', 'tags', ...EVENT_ATTRIBUTES];
     }
 
     attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
@@ -105,6 +110,7 @@ class EntityElement extends EntityOwnerElement {
             case 'onpointerdown':
             case 'onpointerup':
             case 'onpointermove':
+            case 'onclick':
                 this._updateInlineHandler(name, newValue);
                 break;
         }

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -42,7 +42,8 @@ import { parseBool, parseTags, parseVec3 } from './parse';
  * @fires {PointerEvent} pointerup - Fired when a pointer button is released over the entity.
  * @fires {PointerEvent} click - Fired when a primary pointer button is pressed and then released
  * over the entity. A press and release that picked different entities fires on their nearest
- * common ancestor instead, as in the DOM.
+ * common ancestor instead, as in the DOM. `detail` carries the click count, so a double click
+ * arrives as a click whose `detail` is 2.
  */
 class EntityElement extends EntityOwnerElement {
     connectedCallback() {

--- a/src/model.ts
+++ b/src/model.ts
@@ -152,7 +152,8 @@ const formatHierarchy = (root: HierarchyNode, counts: ReadonlyMap<string, number
  * @fires {PointerEvent} pointerup - Fired when a pointer button is released over the model.
  * @fires {PointerEvent} click - Fired when a primary pointer button is pressed and then released
  * over the model. A press and release that picked different entities fires on their nearest
- * common ancestor instead, as in the DOM.
+ * common ancestor instead, as in the DOM. `detail` carries the click count, so a double click
+ * arrives as a click whose `detail` is 2.
  * @fires {Event} load - Fired each time a container asset finishes instantiating, including
  * re-instantiation after `asset` changes. Does not bubble — listen on this element, or use a
  * capture-phase listener on an ancestor.

--- a/src/model.ts
+++ b/src/model.ts
@@ -2,7 +2,7 @@ import type { ContainerResource, Entity, EventHandle } from 'playcanvas';
 import { Vec3 } from 'playcanvas';
 
 import { useAsset } from './asset';
-import { POINTER_ATTRIBUTES } from './entity-base';
+import { EVENT_ATTRIBUTES } from './entity-base';
 import { buildDescendantEntities, EntityOwnerElement } from './entity-owner';
 import { parseBool, parseTags, parseVec3 } from './parse';
 
@@ -143,11 +143,16 @@ const formatHierarchy = (root: HierarchyNode, counts: ReadonlyMap<string, number
  * model.
  * @attribute {string} onpointerup - Script to run when a pointer button is released over the
  * model.
+ * @attribute {string} onclick - Script to run when the model is clicked: a primary pointer
+ * button pressed and then released over it.
  * @fires {PointerEvent} pointerenter - Fired when the pointer moves onto the model.
  * @fires {PointerEvent} pointerleave - Fired when the pointer moves off the model.
  * @fires {PointerEvent} pointermove - Fired when the pointer moves over the model.
  * @fires {PointerEvent} pointerdown - Fired when a pointer button is pressed over the model.
  * @fires {PointerEvent} pointerup - Fired when a pointer button is released over the model.
+ * @fires {PointerEvent} click - Fired when a primary pointer button is pressed and then released
+ * over the model. A press and release that picked different entities fires on their nearest
+ * common ancestor instead, as in the DOM.
  * @fires {Event} load - Fired each time a container asset finishes instantiating, including
  * re-instantiation after `asset` changes. Does not bubble — listen on this element, or use a
  * capture-phase listener on an ancestor.
@@ -435,7 +440,7 @@ class ModelElement extends EntityOwnerElement {
     }
 
     static get observedAttributes() {
-        return ['asset', 'enabled', 'name', 'position', 'rotation', 'scale', 'tags', ...POINTER_ATTRIBUTES];
+        return ['asset', 'enabled', 'name', 'position', 'rotation', 'scale', 'tags', ...EVENT_ATTRIBUTES];
     }
 
     attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
@@ -466,6 +471,7 @@ class ModelElement extends EntityOwnerElement {
             case 'onpointerdown':
             case 'onpointerup':
             case 'onpointermove':
+            case 'onclick':
                 this._updateInlineHandler(name, newValue);
                 break;
         }

--- a/src/node.ts
+++ b/src/node.ts
@@ -202,7 +202,8 @@ const levenshtein = (a: string, b: string): number => {
  * @fires {PointerEvent} pointerup - Fired when a pointer button is released over the node.
  * @fires {PointerEvent} click - Fired when a primary pointer button is pressed and then released
  * over the node. A press and release that picked different entities fires on their nearest
- * common ancestor instead, as in the DOM.
+ * common ancestor instead, as in the DOM. `detail` carries the click count, so a double click
+ * arrives as a click whose `detail` is 2.
  */
 class NodeElement extends EntityBaseElement {
     private _name = '';

--- a/src/node.ts
+++ b/src/node.ts
@@ -2,7 +2,7 @@ import type { Entity, EventHandle, GraphNode, Material, MeshInstance, Quat, Rend
 import { Vec3 } from 'playcanvas';
 
 import { ComponentElement } from './components/component';
-import { EntityBaseElement, POINTER_ATTRIBUTES } from './entity-base';
+import { EntityBaseElement, EVENT_ATTRIBUTES } from './entity-base';
 import { buildDescendantEntities } from './entity-owner';
 import type { EntityOwnerElement } from './entity-owner';
 import { MaterialElement } from './material';
@@ -193,11 +193,16 @@ const levenshtein = (a: string, b: string): number => {
  * node.
  * @attribute {string} onpointerup - Script to run when a pointer button is released over the
  * node.
+ * @attribute {string} onclick - Script to run when the node is clicked: a primary pointer
+ * button pressed and then released over it.
  * @fires {PointerEvent} pointerenter - Fired when the pointer moves onto the node.
  * @fires {PointerEvent} pointerleave - Fired when the pointer moves off the node.
  * @fires {PointerEvent} pointermove - Fired when the pointer moves over the node.
  * @fires {PointerEvent} pointerdown - Fired when a pointer button is pressed over the node.
  * @fires {PointerEvent} pointerup - Fired when a pointer button is released over the node.
+ * @fires {PointerEvent} click - Fired when a primary pointer button is pressed and then released
+ * over the node. A press and release that picked different entities fires on their nearest
+ * common ancestor instead, as in the DOM.
  */
 class NodeElement extends EntityBaseElement {
     private _name = '';
@@ -933,7 +938,7 @@ class NodeElement extends EntityBaseElement {
             'rotation',
             'scale',
             'tags',
-            ...POINTER_ATTRIBUTES
+            ...EVENT_ATTRIBUTES
         ];
     }
 
@@ -982,6 +987,7 @@ class NodeElement extends EntityBaseElement {
             case 'onpointerdown':
             case 'onpointerup':
             case 'onpointermove':
+            case 'onclick':
                 this._updateInlineHandler(name, newValue);
                 break;
         }

--- a/test/elements/registration.test.ts
+++ b/test/elements/registration.test.ts
@@ -39,10 +39,11 @@ describe('customElements registration', () => {
         expect(document.createElement(tag)).toBeInstanceOf(EntityBaseElement);
     });
 
-    it.for(ENTITY_TAGS)('%s observes the onpointer* attributes', (tag) => {
+    it.for(ENTITY_TAGS)('%s observes the inline event handler attributes', (tag) => {
         const observed = (customElements.get(tag) as unknown as { observedAttributes?: string[] })?.observedAttributes;
         expect(observed).toContain('onpointerdown');
         expect(observed).toContain('onpointerenter');
+        expect(observed).toContain('onclick');
     });
 
     it.for(COMPONENT_TAGS)('%s inherits the enabled attribute from ComponentElement', (tag) => {

--- a/test/integration/pointer.test.ts
+++ b/test/integration/pointer.test.ts
@@ -601,6 +601,65 @@ describe('pc-app pointer picking', () => {
             expect(bClick).toHaveBeenCalledTimes(1);
         });
 
+        it('carries the click count in detail, chained within the double-click window', async () => {
+            // pointerup's own detail is fixed at 0 by the Pointer Events spec, but click is
+            // exempt: its detail is the click count, which consumers read for double-click
+            // detection - and to tell pointer clicks from keyboard activations, whose detail
+            // really is 0.
+            const { appElement, canvas, entity, spies } = await bootClickTarget();
+            stubPicker(appElement, [
+                [hit(entity)], [hit(entity)],
+                [hit(entity)], [hit(entity)],
+                [hit(entity)], [hit(entity)]
+            ]);
+            const nowSpy = vi.spyOn(performance, 'now');
+
+            const clickAt = async (time: number) => {
+                nowSpy.mockReturnValue(time);
+                canvas.dispatchEvent(down());
+                await flush();
+                canvas.dispatchEvent(up());
+                await flush();
+            };
+
+            await clickAt(1000); // a first click
+            await clickAt(1200); // 200ms later: chains
+            await clickAt(2000); // 800ms later: the window has passed
+
+            const details = spies.click.mock.calls.map((call) => (call[0] as PointerEvent).detail);
+            expect(details).toEqual([1, 2, 1]);
+        });
+
+        it('resets the click count when the target changes', async () => {
+            const { appElement, all } = await bootApp(`
+                <pc-entity name="camera"><pc-camera></pc-camera></pc-entity>
+                <pc-entity name="a"></pc-entity>
+                <pc-entity name="b"></pc-entity>
+            `);
+            const [a, b] = [all<EntityElement>('pc-entity')[1], all<EntityElement>('pc-entity')[2]];
+            const aClick = vi.fn();
+            const bClick = vi.fn();
+            a.addEventListener('click', aClick);
+            b.addEventListener('click', bClick);
+            const canvas = appElement.querySelector('canvas')!;
+            stubPicker(appElement, [[hit(a.entity!)], [hit(a.entity!)], [hit(b.entity!)], [hit(b.entity!)]]);
+            const nowSpy = vi.spyOn(performance, 'now');
+
+            const clickAt = async (time: number) => {
+                nowSpy.mockReturnValue(time);
+                canvas.dispatchEvent(down());
+                await flush();
+                canvas.dispatchEvent(up());
+                await flush();
+            };
+
+            await clickAt(1000);
+            await clickAt(1100); // within the window, but a different target
+
+            expect((aClick.mock.calls[0][0] as PointerEvent).detail).toBe(1);
+            expect((bClick.mock.calls[0][0] as PointerEvent).detail, 'a new target starts a new count').toBe(1);
+        });
+
         it('the inline onclick attribute alone attaches the canvas listeners', async () => {
             // The browser compiles inline handlers itself, so the attribute must feed the same
             // lazy canvas attach as addEventListener - jsdom never runs the handler, but the

--- a/test/integration/pointer.test.ts
+++ b/test/integration/pointer.test.ts
@@ -394,6 +394,234 @@ describe('pc-app pointer picking', () => {
         expect(spy).toHaveBeenCalledTimes(1);
     });
 
+    it('keeps a shared canvas listener while another event type still needs it', async () => {
+        // enter, leave and move all ride one canvas pointermove listener. Removing the tree's
+        // last pointerenter listener used to detach that shared listener even though a
+        // pointermove listener still needed it - the detach must recount by canvas listener,
+        // not by event type.
+        const { appElement, canvas, element, entity, spies } = await bootTarget();
+        const moveSpy = vi.fn();
+        element.addEventListener('pointermove', moveSpy);
+        element.removeEventListener('pointerenter', spies.pointerenter);
+        stubPicker(appElement, [[hit(entity)]]);
+
+        canvas.dispatchEvent(move(400, 300));
+        await flush();
+
+        expect(moveSpy, 'the move listener still rides the shared canvas listener').toHaveBeenCalledTimes(1);
+    });
+
+    describe('click', () => {
+        /**
+         * Boots a camera plus one target entity with click, pointerdown and pointerup spies -
+         * the three events a press/release sequence can produce.
+         *
+         * @returns The booted handle plus the element, its entity, the canvas and the spies.
+         */
+        const bootClickTarget = async () => {
+            const handle = await bootApp(`
+                <pc-entity name="camera"><pc-camera></pc-camera></pc-entity>
+                <pc-entity name="target"></pc-entity>
+            `);
+            const element = handle.get<EntityElement>('pc-entity[name="target"]');
+            const spies = { click: vi.fn(), pointerdown: vi.fn(), pointerup: vi.fn() };
+            Object.entries(spies).forEach(([type, spy]) => element.addEventListener(type, spy));
+
+            const canvas = handle.appElement.querySelector('canvas');
+            if (!canvas) throw new Error('bootClickTarget: pc-app created no canvas');
+
+            return { ...handle, element, entity: element.entity!, spies, canvas };
+        };
+
+        const down = (options: PointerEventInit = {}) =>
+            new PointerEvent('pointerdown', { clientX: 400, clientY: 300, ...options });
+        const up = (options: PointerEventInit = {}) =>
+            new PointerEvent('pointerup', { clientX: 400, clientY: 300, ...options });
+
+        it('dispatches click after pointerup when the press and release pick the same entity', async () => {
+            const { appElement, canvas, entity, spies } = await bootClickTarget();
+            stubPicker(appElement, [[hit(entity)], [hit(entity)]]);
+
+            canvas.dispatchEvent(down());
+            await flush();
+            canvas.dispatchEvent(up());
+            await flush();
+
+            expect(spies.click).toHaveBeenCalledTimes(1);
+            expect(spies.click.mock.invocationCallOrder[0], 'click concludes the release')
+                .toBeGreaterThan(spies.pointerup.mock.invocationCallOrder[0]);
+            const event = spies.click.mock.calls[0][0] as PointerEvent;
+            expect(event.type).toBe('click');
+            expect(event.clientX, 'the release event supplies the click detail').toBe(400);
+        });
+
+        it('synthesizes click for an element whose only listener is click', async () => {
+            // click alone must attach the pointerdown/pointerup canvas listeners it rides on.
+            const { appElement, get } = await bootApp(`
+                <pc-entity name="camera"><pc-camera></pc-camera></pc-entity>
+                <pc-entity name="target"></pc-entity>
+            `);
+            const element = get<EntityElement>('pc-entity[name="target"]');
+            const spy = vi.fn();
+            element.addEventListener('click', spy);
+            const canvas = appElement.querySelector('canvas')!;
+            stubPicker(appElement, [[hit(element.entity!)], [hit(element.entity!)]]);
+
+            canvas.dispatchEvent(down());
+            await flush();
+            canvas.dispatchEvent(up());
+            await flush();
+
+            expect(spy).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not dispatch click when the press and release pick different entities', async () => {
+            const { appElement, all } = await bootApp(`
+                <pc-entity name="camera"><pc-camera></pc-camera></pc-entity>
+                <pc-entity name="a"></pc-entity>
+                <pc-entity name="b"></pc-entity>
+            `);
+            const [a, b] = [all<EntityElement>('pc-entity')[1], all<EntityElement>('pc-entity')[2]];
+            const aClick = vi.fn();
+            const bClick = vi.fn();
+            a.addEventListener('click', aClick);
+            b.addEventListener('click', bClick);
+            const canvas = appElement.querySelector('canvas')!;
+            stubPicker(appElement, [[hit(a.entity!)], [hit(b.entity!)]]);
+
+            canvas.dispatchEvent(down());
+            await flush();
+            canvas.dispatchEvent(up());
+            await flush();
+
+            expect(aClick, 'the press target alone gets no click').not.toHaveBeenCalled();
+            expect(bClick, 'the release target alone gets no click').not.toHaveBeenCalled();
+        });
+
+        it('dispatches click on the nearest common ancestor of the press and release picks', async () => {
+            // The DOM assigns a click whose down and up have different targets to their nearest
+            // common inclusive ancestor - a press on one child released over its sibling clicks
+            // the parent.
+            const { appElement, get } = await bootApp(`
+                <pc-entity name="camera"><pc-camera></pc-camera></pc-entity>
+                <pc-entity name="parent">
+                    <pc-entity name="a"></pc-entity>
+                    <pc-entity name="b"></pc-entity>
+                </pc-entity>
+            `);
+            const parent = get<EntityElement>('pc-entity[name="parent"]');
+            const a = get<EntityElement>('pc-entity[name="a"]');
+            const b = get<EntityElement>('pc-entity[name="b"]');
+            const spy = vi.fn();
+            parent.addEventListener('click', spy);
+            const canvas = appElement.querySelector('canvas')!;
+            stubPicker(appElement, [[hit(a.entity!)], [hit(b.entity!)]]);
+
+            canvas.dispatchEvent(down());
+            await flush();
+            canvas.dispatchEvent(up());
+            await flush();
+
+            expect(spy).toHaveBeenCalledTimes(1);
+            expect(spy.mock.calls[0][0].target, 'the click targets the ancestor element').toBe(parent);
+        });
+
+        it('does not dispatch click for a non-primary button', async () => {
+            const { appElement, canvas, entity, spies } = await bootClickTarget();
+            stubPicker(appElement, [[hit(entity)], [hit(entity)]]);
+
+            canvas.dispatchEvent(down({ button: 2 }));
+            await flush();
+            canvas.dispatchEvent(up({ button: 2 }));
+            await flush();
+
+            expect(spies.pointerdown, 'down and up still fire for secondary buttons').toHaveBeenCalledTimes(1);
+            expect(spies.pointerup).toHaveBeenCalledTimes(1);
+            expect(spies.click).not.toHaveBeenCalled();
+        });
+
+        it('does not dispatch click when the browser cancels the press', async () => {
+            // A pointercancel (a touch claimed by scrolling, say) means the release can never
+            // conclude the press.
+            const { appElement, canvas, entity, spies } = await bootClickTarget();
+            stubPicker(appElement, [[hit(entity)], [hit(entity)]]);
+
+            canvas.dispatchEvent(down());
+            await flush();
+            canvas.dispatchEvent(new PointerEvent('pointercancel'));
+            canvas.dispatchEvent(up());
+            await flush();
+
+            expect(spies.pointerup).toHaveBeenCalledTimes(1);
+            expect(spies.click).not.toHaveBeenCalled();
+        });
+
+        it('concludes a click whose press pick resolves after the release pick', async () => {
+            // Picks resolve in GPU order, not event order: a quick tap can deliver the release
+            // pick first. The click must wait for the press pick rather than dropping the press.
+            const { appElement, canvas, entity, spies } = await bootClickTarget();
+            const pressPick = deferred<ReturnType<typeof hit>[]>();
+            const releasePick = deferred<ReturnType<typeof hit>[]>();
+            stubPicker(appElement, [pressPick.promise, releasePick.promise]);
+
+            canvas.dispatchEvent(down());
+            canvas.dispatchEvent(up());
+
+            releasePick.resolve([hit(entity)]);
+            await flush();
+            expect(spies.pointerup).toHaveBeenCalledTimes(1);
+            expect(spies.click, 'the press pick is still in flight').not.toHaveBeenCalled();
+
+            pressPick.resolve([hit(entity)]);
+            await flush();
+            expect(spies.click).toHaveBeenCalledTimes(1);
+        });
+
+        it('tracks presses per pointer', async () => {
+            const { appElement, all } = await bootApp(`
+                <pc-entity name="camera"><pc-camera></pc-camera></pc-entity>
+                <pc-entity name="a"></pc-entity>
+                <pc-entity name="b"></pc-entity>
+            `);
+            const [a, b] = [all<EntityElement>('pc-entity')[1], all<EntityElement>('pc-entity')[2]];
+            const aClick = vi.fn();
+            const bClick = vi.fn();
+            a.addEventListener('click', aClick);
+            b.addEventListener('click', bClick);
+            const canvas = appElement.querySelector('canvas')!;
+            stubPicker(appElement, [[hit(a.entity!)], [hit(b.entity!)], [hit(b.entity!)], [hit(a.entity!)]]);
+
+            canvas.dispatchEvent(down({ pointerId: 1 }));
+            canvas.dispatchEvent(down({ pointerId: 2 }));
+            canvas.dispatchEvent(up({ pointerId: 2 }));
+            canvas.dispatchEvent(up({ pointerId: 1 }));
+            await flush();
+
+            expect(aClick).toHaveBeenCalledTimes(1);
+            expect(bClick).toHaveBeenCalledTimes(1);
+        });
+
+        it('the inline onclick attribute alone attaches the canvas listeners', async () => {
+            // The browser compiles inline handlers itself, so the attribute must feed the same
+            // lazy canvas attach as addEventListener - jsdom never runs the handler, but the
+            // wiring it triggers is observable.
+            const { appElement, get } = await bootApp(`
+                <pc-entity name="camera"><pc-camera></pc-camera></pc-entity>
+                <pc-entity name="target"></pc-entity>
+            `);
+            const element = get<EntityElement>('pc-entity[name="target"]');
+            const canvas = appElement.querySelector('canvas')!;
+            const attach = vi.spyOn(canvas, 'addEventListener');
+
+            element.setAttribute('onclick', 'void 0');
+
+            const attached = attach.mock.calls.map((call) => call[0]);
+            expect(attached).toContain('pointerdown');
+            expect(attached).toContain('pointerup');
+            expect(attached).toContain('pointercancel');
+        });
+    });
+
     describe('multi-camera', () => {
         /**
          * Boots two cameras and a listening target. jsdom gives the canvas no CSS box, so unless

--- a/utils/cem/cleanup-plugin.mjs
+++ b/utils/cem/cleanup-plugin.mjs
@@ -10,9 +10,9 @@
  *   is not public API is dropped here.
  * - `src/entity.ts` dispatches internal wiring events with computed names (`` `${type}:connect` ``)
  *   that cannot be resolved statically, so whatever the analyzer makes of them is dropped.
- * - `src/app.ts` dispatches the pointer events *onto* `<pc-entity>` elements rather than onto
- *   itself, so they belong to `EntityElement` (where they are declared with `@fires`), not to
- *   `AppElement`.
+ * - `src/app.ts` dispatches the pointer and click events *onto* `<pc-entity>` elements rather
+ *   than onto itself, so they belong to `EntityElement` (where they are declared with `@fires`),
+ *   not to `AppElement`.
  * - Attributes and events declared on the `AsyncElement` and `ComponentElement` base classes are
  *   copied onto the elements that inherit them, marked with `inheritedFrom`. Without this, an
  *   element like `<pc-audio-listener>` would appear to have no attributes at all, when in fact it
@@ -24,7 +24,7 @@
  */
 
 /** Events dispatched by `AppElement` but targeted at `EntityElement`. */
-const POINTER_EVENTS = new Set(['pointerenter', 'pointerleave', 'pointermove', 'pointerdown', 'pointerup']);
+const SYNTHESIZED_EVENTS = new Set(['pointerenter', 'pointerleave', 'pointermove', 'pointerdown', 'pointerup', 'click']);
 
 const byName = (a, b) => a.name.localeCompare(b.name);
 
@@ -164,10 +164,10 @@ export const manifestCleanupPlugin = () => ({
                 continue;
             }
 
-            // Drop computed event names, and pointer events attributed to the wrong class
+            // Drop computed event names, and synthesized events attributed to the wrong class
             declaration.events = declaration.events.filter(event => event.name &&
                 !/[`$:]/.test(event.name) &&
-                !(declaration.name === 'AppElement' && POINTER_EVENTS.has(event.name)));
+                !(declaration.name === 'AppElement' && SYNTHESIZED_EVENTS.has(event.name)));
 
             // An event may be found both by `@fires` and by its `dispatchEvent` call - prefer the
             // documented one

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -264,15 +264,15 @@ if (manifest) {
 
     check(events('pc-joint').includes('break'), "pc-joint is missing the 'break' event");
 
-    const pointerEvents = ['pointerenter', 'pointerleave', 'pointermove', 'pointerdown', 'pointerup'];
+    const synthesizedEvents = ['pointerenter', 'pointerleave', 'pointermove', 'pointerdown', 'pointerup', 'click'];
     for (const tag of ENTITY_TAGS) {
-        for (const name of pointerEvents) {
+        for (const name of synthesizedEvents) {
             check(events(tag).includes(name), `${tag} is missing the '${name}' event`);
         }
     }
-    const strayPointerEvents = pointerEvents.filter(name => events('pc-app').includes(name));
-    check(strayPointerEvents.length === 0,
-        `pc-app should not declare pointer events: ${strayPointerEvents.join(', ')}`);
+    const straySynthesizedEvents = synthesizedEvents.filter(name => events('pc-app').includes(name));
+    check(straySynthesizedEvents.length === 0,
+        `pc-app should not declare synthesized events: ${straySynthesizedEvents.join(', ')}`);
 
     // Loading events are leaf-declared (ProgressEvent/ErrorEvent dispatches, not CustomEvent), so
     // they exercise the analyzer's non-CustomEvent detection - and must not leak onto other tags
@@ -310,10 +310,10 @@ if (manifest) {
     }
 
     // Over-filtering, part 1: every attribute's backing accessor is still a member. pc-entity's
-    // onpointer* attributes are exempt - they are handled by a dispatch helper rather than by
-    // accessors, so the fieldName the attributes plugin falls back to names a member that has
-    // never existed.
-    const PHANTOM_FIELDS = new Set(pointerEvents.map(name => `on${name}`));
+    // onpointer*/onclick attributes are exempt - they are handled by a dispatch helper rather
+    // than by accessors, so the fieldName the attributes plugin falls back to names a member
+    // that has never existed.
+    const PHANTOM_FIELDS = new Set(synthesizedEvents.map(name => `on${name}`));
     for (const [tag, declaration] of elements) {
         const members = new Set((declaration.members ?? []).map(member => member.name));
         for (const item of declaration.attributes ?? []) {


### PR DESCRIPTION
`<pc-entity>`, `<pc-model>` and `<pc-node>` now dispatch `click` — the sixth synthesized event alongside the five `pointer*` events.

### Why

Every HTML element already accepts `onclick` — the browser compiles the attribute like any other `GlobalEventHandlers` member — so `<pc-entity onclick="...">` has always parsed fine and silently never fired. For a library whose promise is "entities are DOM elements", `onclick` is the first thing a web developer types. Composing it from `pointerdown`/`pointerup` by hand is also subtly wrong in the ways that matter for click-to-select: `pointerup` alone fires for right-button releases and for presses that started on a different object, and `pointerdown` fires at the start of every camera drag.

### Semantics (DOM parity throughout)

- A click concludes a **primary-button** press and release. Right/middle buttons never click.
- When the press and the release picked different geometry, the click fires at their **nearest common inclusive ancestor** — dragging from one object to its sibling clicks their shared parent, and dragging off onto the background clicks nothing. Exactly how the DOM assigns a click whose down and up have different targets.
- The event is a **`PointerEvent` built from the release event**, as modern browsers deliver native clicks, and it bubbles up the element tree like the other synthesized events.
- Presses are tracked **per `pointerId`** (multi-touch safe), stored as the pick promise itself so a tap quick enough for the release pick to resolve before the press pick still concludes, and `pointercancel` discards a press the browser takes back (a touch claimed by scrolling).
- **`detail` carries the click count**, as native click does (pointer events fix `detail` at 0, but click is exempt): successive clicks on the same target within a 500 ms window chain the count, so a double click arrives as a click whose `detail` is 2, and `detail > 0` heuristics that tell pointer clicks from keyboard activations read correctly. Approximation vs. native: a fixed 500 ms window rather than the OS double-click time, and no movement-slop reset.

```html
<pc-entity name="ship" onclick="this.entity.script.selection.toggle()">
    <pc-render type="box"></pc-render>
</pc-entity>
```

Deliberately out of scope: `dblclick` (composable in userland via `detail === 2`), `contextmenu`, and any drag-slop threshold — native mouse click has no movement threshold either, so strict press/release parity is the defensible behavior.

### Implementation

- The synthesized event list moves to a single exported source of truth in `entity-base.ts` (`SYNTHESIZED_EVENTS`), from which the inline handler attribute names derive (`EVENT_ATTRIBUTES`, formerly `POINTER_ATTRIBUTES`).
- The lazy canvas attach becomes one recount over the synthesized types, mapping each type to the canvas listeners that drive it: enter/leave ride the move pick; click rides the down/up pair plus `pointercancel`. Attach state leans on `EventTarget` semantics (re-adding an identical listener is a no-op).
- **This fixes a latent detach bug**: removing the tree's last listener of one type used to detach a shared canvas listener another type still needed — removing a `pointerenter` listener could kill `pointermove` synthesis. Now pinned by a regression test.
- No extra GPU picks on release — the click reuses the `pointerup` pick. The press pick only starts being recorded while some element actually listens for `click`.
- CEM tooling extended so the manifest declares `click`/`onclick` on the three entity-fronting tags (and forbids them on `pc-app`), flowing through to the VS Code custom data and JetBrains web-types.

### Example

The Tweening example's star now spins on `onclick` instead of `onpointerdown` — the 360° spin is an activation, not press feedback, and the old wiring also spun the star on a right-button press (which `pointerdown` never distinguished).

### Testing

- 12 new vitest cases: same-target click (ordered after `pointerup`), click-only listener attach, different-target suppression, common-ancestor dispatch, non-primary suppression, `pointercancel` suppression, out-of-order pick resolution, per-pointer tracking, `detail` chaining and its reset on target change, inline-attribute wiring, and the shared-listener detach regression. Full suite: 993 passed, lint/type-check/build clean, manifest validated.
- Verified end-to-end in a real browser (WebGPU) against the built bundle with GPU picking: tap → `click` (bubbling to ancestors with the child as `target`), drag across siblings → click on the common parent only, right-button tap → nothing, drag to background → nothing, inline `onclick` attribute → runs, and rapid same-target taps arrive with `detail` 1, 2, then 1 after the window closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
