### PR TITLE
Dispatch synthesized pointer events in canvas-event order

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -253,14 +253,9 @@ class AppElement extends AsyncElement {
     private _lastClick: { element: EntityBaseElement; time: number; count: number } | null = null;
 
     /**
-     * Serializes dispatch of the discrete synthesized events - pointerdown, pointerup and click.
-     * Their picks start eagerly and resolve in GPU order, not canvas-event order, so each canvas
-     * handler appends its dispatch work here and the chain replays it in event order: a slow
-     * press pick must not deliver its pointerdown after the gesture's own pointerup, and two
-     * clicks in flight at once must not conclude in reverse. Hover needs no chain - a stale move
-     * pick is simply discarded via {@link _pickToken}, because dropping is fine for moves but
-     * not for discrete events. Replaced on teardown, so a pick that never resolves (a lost
-     * device) cannot stall the dispatches of a later boot.
+     * Serializes dispatch of the discrete synthesized events (pointerdown, pointerup, click),
+     * whose picks resolve in GPU order, not canvas-event order. Replaced on teardown, so a pick
+     * that never resolves cannot stall the dispatches of a later boot.
      */
     private _dispatchChain: Promise<void> = Promise.resolve();
 
@@ -660,10 +655,8 @@ class AppElement extends AsyncElement {
         const { width, height } = this.app!.graphicsDevice;
         this._picker = new Picker(this.app!, width, height);
 
-        // Create bound handlers but don't attach them yet. The move handler picks and dispatches
-        // asynchronously, so it is wrapped to discard the promise - a listener must not return
-        // one, and nothing awaits the result. Down and up return nothing: they start their pick
-        // and queue its dispatch on the ordering chain before returning.
+        // Create bound handlers but don't attach them yet. The move handler is async, so it is
+        // wrapped to discard the promise - a listener must not return one.
         const listener = (handler: (event: PointerEvent) => void | Promise<void>): EventListener => {
             return (event: Event) => {
                 handler.call(this, event as PointerEvent);
@@ -704,9 +697,7 @@ class AppElement extends AsyncElement {
         this._clickListened = false;
         this._lastClick = null;
 
-        // Steps still queued on the chain guard themselves against this teardown; replacing the
-        // chain is what keeps a pick that never resolves (a lost device) from wedging it, so the
-        // dispatches of a later boot never queue behind the hung step.
+        // Replace the chain: a pick that never resolves must not stall a later boot's dispatches
         this._dispatchChain = Promise.resolve();
     }
 
@@ -932,10 +923,8 @@ class AppElement extends AsyncElement {
 
     /**
      * Appends a dispatch step to {@link _dispatchChain}. Must be called synchronously from the
-     * canvas event handler: it is the order of appends that carries canvas-event order, so an
-     * append placed after an await would serialize in pick-resolution order - the disorder the
-     * chain exists to prevent. A step that rejects (a failed pick) is reported and released, so
-     * the steps queued behind it still dispatch.
+     * canvas event handler - the order of appends is what carries canvas-event order. A step
+     * that rejects is reported and released, so the steps queued behind it still dispatch.
      *
      * @param step - The dispatch work to run once every earlier step has finished.
      */
@@ -948,8 +937,7 @@ class AppElement extends AsyncElement {
     private _onPointerDown(event: PointerEvent) {
         if (!this._picker || !this.app) return;
 
-        // The pick starts now, so overlapping gestures still overlap their GPU readbacks - only
-        // the dispatch of the results is serialized.
+        // Picks stay concurrent - only the dispatch of the results is serialized
         const pick = this._pickNode(event);
 
         // A click concludes on the matching pointerup, which needs to know what the press
@@ -997,9 +985,8 @@ class AppElement extends AsyncElement {
         if (!downPick || event.button !== 0) return;
 
         this._chainDispatch(async () => {
-            // Both picks have settled: the press's and the release's own steps awaited them
-            // earlier in the chain. A rejected pick was reported by whichever of those steps
-            // awaited it, and here just means no click can conclude.
+            // A rejected pick was already reported by the press or release step that awaited it;
+            // here it just means no click can conclude.
             const picked = await Promise.all([downPick, pick]).catch(() => null);
             if (!picked || !this._picker) return;
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -252,6 +252,18 @@ class AppElement extends AsyncElement {
      */
     private _lastClick: { element: EntityBaseElement; time: number; count: number } | null = null;
 
+    /**
+     * Serializes dispatch of the discrete synthesized events - pointerdown, pointerup and click.
+     * Their picks start eagerly and resolve in GPU order, not canvas-event order, so each canvas
+     * handler appends its dispatch work here and the chain replays it in event order: a slow
+     * press pick must not deliver its pointerdown after the gesture's own pointerup, and two
+     * clicks in flight at once must not conclude in reverse. Hover needs no chain - a stale move
+     * pick is simply discarded via {@link _pickToken}, because dropping is fine for moves but
+     * not for discrete events. Replaced on teardown, so a pick that never resolves (a lost
+     * device) cannot stall the dispatches of a later boot.
+     */
+    private _dispatchChain: Promise<void> = Promise.resolve();
+
     private _app: AppBase | null = null;
 
     private _loadProgress = 0;
@@ -648,10 +660,11 @@ class AppElement extends AsyncElement {
         const { width, height } = this.app!.graphicsDevice;
         this._picker = new Picker(this.app!, width, height);
 
-        // Create bound handlers but don't attach them yet. The handlers pick asynchronously, so
-        // each is wrapped to discard the promise - a listener must not return one, and nothing
-        // awaits the result.
-        const listener = (handler: (event: PointerEvent) => Promise<void>): EventListener => {
+        // Create bound handlers but don't attach them yet. The move handler picks and dispatches
+        // asynchronously, so it is wrapped to discard the promise - a listener must not return
+        // one, and nothing awaits the result. Down and up return nothing: they start their pick
+        // and queue its dispatch on the ordering chain before returning.
+        const listener = (handler: (event: PointerEvent) => void | Promise<void>): EventListener => {
             return (event: Event) => {
                 handler.call(this, event as PointerEvent);
             };
@@ -690,6 +703,11 @@ class AppElement extends AsyncElement {
         this._downPicks.clear();
         this._clickListened = false;
         this._lastClick = null;
+
+        // Steps still queued on the chain guard themselves against this teardown; replacing the
+        // chain is what keeps a pick that never resolves (a lost device) from wedging it, so the
+        // dispatches of a later boot never queue behind the hung step.
+        this._dispatchChain = Promise.resolve();
     }
 
     /**
@@ -912,9 +930,26 @@ class AppElement extends AsyncElement {
         }
     }
 
-    private async _onPointerDown(event: PointerEvent) {
+    /**
+     * Appends a dispatch step to {@link _dispatchChain}. Must be called synchronously from the
+     * canvas event handler: it is the order of appends that carries canvas-event order, so an
+     * append placed after an await would serialize in pick-resolution order - the disorder the
+     * chain exists to prevent. A step that rejects (a failed pick) is reported and released, so
+     * the steps queued behind it still dispatch.
+     *
+     * @param step - The dispatch work to run once every earlier step has finished.
+     */
+    private _chainDispatch(step: () => Promise<void>) {
+        this._dispatchChain = this._dispatchChain.then(step).catch((error) => {
+            console.error(error);
+        });
+    }
+
+    private _onPointerDown(event: PointerEvent) {
         if (!this._picker || !this.app) return;
 
+        // The pick starts now, so overlapping gestures still overlap their GPU readbacks - only
+        // the dispatch of the results is serialized.
         const pick = this._pickNode(event);
 
         // A click concludes on the matching pointerup, which needs to know what the press
@@ -925,16 +960,18 @@ class AppElement extends AsyncElement {
             this._downPicks.set(event.pointerId, pick);
         }
 
-        const node = await pick;
-        if (!this._picker) return; // the element disconnected while the pick was in flight
+        this._chainDispatch(async () => {
+            const node = await pick;
+            if (!this._picker) return; // the element disconnected while the pick was in flight
 
-        const entityElement = this._elementWithListener(node, 'pointerdown');
-        if (entityElement) {
-            entityElement.dispatchEvent(new PointerEvent('pointerdown', event));
-        }
+            const entityElement = this._elementWithListener(node, 'pointerdown');
+            if (entityElement) {
+                entityElement.dispatchEvent(new PointerEvent('pointerdown', event));
+            }
+        });
     }
 
-    private async _onPointerUp(event: PointerEvent) {
+    private _onPointerUp(event: PointerEvent) {
         if (!this._picker || !this.app) return;
 
         // The press pick this release may conclude as a click. Claimed synchronously, so the
@@ -942,39 +979,50 @@ class AppElement extends AsyncElement {
         const downPick = this._downPicks.get(event.pointerId);
         this._downPicks.delete(event.pointerId);
 
-        const node = await this._pickNode(event);
-        if (!this._picker) return; // the element disconnected while the pick was in flight
+        const pick = this._pickNode(event);
 
-        const entityElement = this._elementWithListener(node, 'pointerup');
-        if (entityElement) {
-            entityElement.dispatchEvent(new PointerEvent('pointerup', event));
-        }
+        this._chainDispatch(async () => {
+            const node = await pick;
+            if (!this._picker) return; // the element disconnected while the pick was in flight
+
+            const entityElement = this._elementWithListener(node, 'pointerup');
+            if (entityElement) {
+                entityElement.dispatchEvent(new PointerEvent('pointerup', event));
+            }
+        });
 
         // A click fires where the DOM fires it: at the nearest common inclusive ancestor of
-        // what the press and the release picked, for the primary button only. The press pick
-        // may still be in flight - a quick tap resolves in pick order, not event order.
+        // what the press and the release picked, for the primary button only. Appended after
+        // the release's own step, so it dispatches after the pointerup that concludes it.
         if (!downPick || event.button !== 0) return;
-        const downNode = await downPick;
-        if (!this._picker) return;
 
-        const clickElement = this._elementWithListener(commonAncestor(downNode, node), 'click');
-        if (clickElement) {
-            const click = new PointerEvent('click', event);
+        this._chainDispatch(async () => {
+            // Both picks have settled: the press's and the release's own steps awaited them
+            // earlier in the chain. A rejected pick was reported by whichever of those steps
+            // awaited it, and here just means no click can conclude.
+            const picked = await Promise.all([downPick, pick]).catch(() => null);
+            if (!picked || !this._picker) return;
 
-            // The init above copied pointerup's `detail`, which the Pointer Events spec fixes
-            // at 0 - but click is exempt: its detail is the click count, chained here as the
-            // platform chains it (same target, within the double-click window). Overridden
-            // with defineProperty because an event instance used as an init dict cannot have
-            // single fields replaced.
-            const time = performance.now();
-            const last = this._lastClick;
-            const count =
-                last && last.element === clickElement && time - last.time <= CLICK_CHAIN_MS ? last.count + 1 : 1;
-            this._lastClick = { element: clickElement, time, count };
-            Object.defineProperty(click, 'detail', { value: count });
+            const [downNode, upNode] = picked;
+            const clickElement = this._elementWithListener(commonAncestor(downNode, upNode), 'click');
+            if (clickElement) {
+                const click = new PointerEvent('click', event);
 
-            clickElement.dispatchEvent(click);
-        }
+                // The init above copied pointerup's `detail`, which the Pointer Events spec fixes
+                // at 0 - but click is exempt: its detail is the click count, chained here as the
+                // platform chains it (same target, within the double-click window). Overridden
+                // with defineProperty because an event instance used as an init dict cannot have
+                // single fields replaced.
+                const time = performance.now();
+                const last = this._lastClick;
+                const count =
+                    last && last.element === clickElement && time - last.time <= CLICK_CHAIN_MS ? last.count + 1 : 1;
+                this._lastClick = { element: clickElement, time, count };
+                Object.defineProperty(click, 'detail', { value: count });
+
+                clickElement.dispatchEvent(click);
+            }
+        });
     }
 
     /**

--- a/test/integration/pointer.test.ts
+++ b/test/integration/pointer.test.ts
@@ -4,8 +4,9 @@ import { describe, expect, it, vi } from 'vitest';
 import type { AppElement } from '../../src/app';
 import type { CameraComponentElement } from '../../src/components/camera-component';
 import type { EntityElement } from '../../src/entity';
-import { bootApp } from '../helpers/app';
+import { bootApp, settle } from '../helpers/app';
 import { useGuard } from '../helpers/guard';
+import { readyWithin } from '../helpers/ready';
 
 /**
  * A stand-in for a node inside a model's instantiated hierarchy. Element resolution matches
@@ -95,7 +96,7 @@ const CONTAINER_SRC = `data:application/json,${encodeURIComponent(JSON.stringify
 }))}`;
 
 describe('pc-app pointer picking', () => {
-    useGuard();
+    const { errors } = useGuard();
 
     /**
      * Boots one pc-entity with pointer listeners attached, which is also what makes pc-app attach
@@ -558,7 +559,9 @@ describe('pc-app pointer picking', () => {
 
         it('concludes a click whose press pick resolves after the release pick', async () => {
             // Picks resolve in GPU order, not event order: a quick tap can deliver the release
-            // pick first. The click must wait for the press pick rather than dropping the press.
+            // pick first. The dispatch chain holds the release's dispatch behind the press's, so
+            // the gesture still delivers as pointerdown, pointerup, click - and the click waits
+            // for the press pick rather than dropping the press.
             const { appElement, canvas, entity, spies } = await bootClickTarget();
             const pressPick = deferred<ReturnType<typeof hit>[]>();
             const releasePick = deferred<ReturnType<typeof hit>[]>();
@@ -569,11 +572,114 @@ describe('pc-app pointer picking', () => {
 
             releasePick.resolve([hit(entity)]);
             await flush();
-            expect(spies.pointerup).toHaveBeenCalledTimes(1);
+            expect(spies.pointerup, 'the release dispatch waits for the press dispatch').not.toHaveBeenCalled();
             expect(spies.click, 'the press pick is still in flight').not.toHaveBeenCalled();
 
             pressPick.resolve([hit(entity)]);
             await flush();
+            expect(spies.pointerdown).toHaveBeenCalledTimes(1);
+            expect(spies.pointerup).toHaveBeenCalledTimes(1);
+            expect(spies.click).toHaveBeenCalledTimes(1);
+            expect(spies.pointerdown.mock.invocationCallOrder[0], 'the gesture delivers in event order')
+                .toBeLessThan(spies.pointerup.mock.invocationCallOrder[0]);
+            expect(spies.pointerup.mock.invocationCallOrder[0])
+                .toBeLessThan(spies.click.mock.invocationCallOrder[0]);
+        });
+
+        it('dispatches overlapping clicks in gesture order even when the later picks resolve first', async () => {
+            // Two press/release pairs in flight at once (touch spam, a GPU hitch): if the second
+            // gesture's picks resolve first, its click used to dispatch first - a click-to-select
+            // handler applied the clicks in reverse and ended up selecting the FIRST object
+            // clicked.
+            const { appElement, all } = await bootApp(`
+                <pc-entity name="camera"><pc-camera></pc-camera></pc-entity>
+                <pc-entity name="a"></pc-entity>
+                <pc-entity name="b"></pc-entity>
+            `);
+            const [a, b] = [all<EntityElement>('pc-entity')[1], all<EntityElement>('pc-entity')[2]];
+            const aClick = vi.fn();
+            const bClick = vi.fn();
+            a.addEventListener('click', aClick);
+            b.addEventListener('click', bClick);
+            const canvas = appElement.querySelector('canvas')!;
+            const picks = Array.from({ length: 4 }, () => deferred<ReturnType<typeof hit>[]>());
+            stubPicker(appElement, picks.map((pick) => pick.promise));
+
+            // Gesture 1 presses and releases on a, gesture 2 on b - all four picks still pending.
+            canvas.dispatchEvent(down());
+            canvas.dispatchEvent(up());
+            canvas.dispatchEvent(down());
+            canvas.dispatchEvent(up());
+
+            // The second gesture's picks resolve first.
+            picks[2].resolve([hit(b.entity!)]);
+            picks[3].resolve([hit(b.entity!)]);
+            await flush();
+            expect(bClick, "the second click waits behind the first gesture's dispatches").not.toHaveBeenCalled();
+
+            picks[0].resolve([hit(a.entity!)]);
+            picks[1].resolve([hit(a.entity!)]);
+            await flush();
+
+            expect(aClick).toHaveBeenCalledTimes(1);
+            expect(bClick).toHaveBeenCalledTimes(1);
+            expect(aClick.mock.invocationCallOrder[0], 'the clicks conclude in gesture order').toBeLessThan(
+                bClick.mock.invocationCallOrder[0]
+            );
+        });
+
+        it('keeps dispatching after a pick that rejects', async () => {
+            // A read back can fail outright (a device lost mid-read). The failed step is reported
+            // and released - it must not sever the chain and silently swallow every dispatch
+            // queued behind it.
+            const { appElement, canvas, entity, spies } = await bootClickTarget();
+            stubPicker(appElement, [
+                Promise.reject(new Error('read back failed')), // press 1
+                [hit(entity)], // release 1
+                [hit(entity)], // press 2
+                [hit(entity)] // release 2
+            ]);
+
+            canvas.dispatchEvent(down());
+            canvas.dispatchEvent(up());
+            canvas.dispatchEvent(down());
+            canvas.dispatchEvent(up());
+            await flush();
+
+            errors.expect('read back failed');
+            expect(spies.pointerdown, 'the failed press dispatches nothing').toHaveBeenCalledTimes(1);
+            expect(spies.pointerup, 'both releases still dispatch').toHaveBeenCalledTimes(2);
+            expect(spies.click, 'only the second gesture concludes').toHaveBeenCalledTimes(1);
+        });
+
+        it('a pick that never resolves does not stall the dispatches of a later boot', async () => {
+            // A lost device can leave a read back pending forever, wedging the dispatch chain
+            // behind it. Teardown replaces the chain, so removing and re-inserting the element -
+            // the documented recovery path - dispatches afresh rather than queueing behind the
+            // hung pick.
+            const { appElement, container, canvas, element, spies } = await bootClickTarget();
+            stubPicker(appElement, [deferred<ReturnType<typeof hit>[]>().promise]); // never resolves
+
+            canvas.dispatchEvent(down()); // wedges the first boot's chain
+
+            appElement.remove();
+            container.appendChild(appElement);
+            await readyWithin(appElement);
+            await settle(container);
+            appElement.app!.autoRender = false;
+
+            // The re-boot created a new canvas and new entities; the element and its listeners
+            // carried over.
+            const rebootedCanvas = appElement.querySelector('canvas');
+            if (!rebootedCanvas) throw new Error('the re-booted pc-app created no canvas');
+            stubPicker(appElement, [[hit(element.entity!)], [hit(element.entity!)]]);
+
+            rebootedCanvas.dispatchEvent(down());
+            rebootedCanvas.dispatchEvent(up());
+            await flush();
+
+            expect(spies.pointerdown, 'the re-booted chain dispatches immediately').toHaveBeenCalledTimes(1);
+            expect(spies.pointerup).toHaveBeenCalledTimes(1);
             expect(spies.click).toHaveBeenCalledTimes(1);
         });
 

--- a/test/integration/pointer.test.ts
+++ b/test/integration/pointer.test.ts
@@ -559,9 +559,7 @@ describe('pc-app pointer picking', () => {
 
         it('concludes a click whose press pick resolves after the release pick', async () => {
             // Picks resolve in GPU order, not event order: a quick tap can deliver the release
-            // pick first. The dispatch chain holds the release's dispatch behind the press's, so
-            // the gesture still delivers as pointerdown, pointerup, click - and the click waits
-            // for the press pick rather than dropping the press.
+            // pick first. The gesture must still deliver as pointerdown, pointerup, click.
             const { appElement, canvas, entity, spies } = await bootClickTarget();
             const pressPick = deferred<ReturnType<typeof hit>[]>();
             const releasePick = deferred<ReturnType<typeof hit>[]>();
@@ -587,10 +585,8 @@ describe('pc-app pointer picking', () => {
         });
 
         it('dispatches overlapping clicks in gesture order even when the later picks resolve first', async () => {
-            // Two press/release pairs in flight at once (touch spam, a GPU hitch): if the second
-            // gesture's picks resolve first, its click used to dispatch first - a click-to-select
-            // handler applied the clicks in reverse and ended up selecting the FIRST object
-            // clicked.
+            // Two press/release pairs in flight at once: if the second gesture's picks resolve
+            // first, its click used to dispatch first, applying the clicks in reverse.
             const { appElement, all } = await bootApp(`
                 <pc-entity name="camera"><pc-camera></pc-camera></pc-entity>
                 <pc-entity name="a"></pc-entity>
@@ -629,9 +625,8 @@ describe('pc-app pointer picking', () => {
         });
 
         it('keeps dispatching after a pick that rejects', async () => {
-            // A read back can fail outright (a device lost mid-read). The failed step is reported
-            // and released - it must not sever the chain and silently swallow every dispatch
-            // queued behind it.
+            // A failed read back is reported and released - it must not sever the chain and
+            // swallow every dispatch queued behind it.
             const { appElement, canvas, entity, spies } = await bootClickTarget();
             stubPicker(appElement, [
                 Promise.reject(new Error('read back failed')), // press 1
@@ -653,10 +648,8 @@ describe('pc-app pointer picking', () => {
         });
 
         it('a pick that never resolves does not stall the dispatches of a later boot', async () => {
-            // A lost device can leave a read back pending forever, wedging the dispatch chain
-            // behind it. Teardown replaces the chain, so removing and re-inserting the element -
-            // the documented recovery path - dispatches afresh rather than queueing behind the
-            // hung pick.
+            // A read back can pend forever (a lost device), wedging the chain. Teardown replaces
+            // it, so a re-inserted element dispatches afresh.
             const { appElement, container, canvas, element, spies } = await bootClickTarget();
             stubPicker(appElement, [deferred<ReturnType<typeof hit>[]>().promise]); // never resolves
 
@@ -668,8 +661,7 @@ describe('pc-app pointer picking', () => {
             await settle(container);
             appElement.app!.autoRender = false;
 
-            // The re-boot created a new canvas and new entities; the element and its listeners
-            // carried over.
+            // The re-boot created a new canvas and new entities; the listeners carried over
             const rebootedCanvas = appElement.querySelector('canvas');
             if (!rebootedCanvas) throw new Error('the re-booted pc-app created no canvas');
             stubPicker(appElement, [[hit(element.entity!)], [hit(element.entity!)]]);


### PR DESCRIPTION
Fixes #422.

Each canvas pointer handler picks asynchronously and used to dispatch its synthesized event whenever its own pick resolved. Nothing ordered those dispatches against each other, so discrete events could deliver out of canvas-event order: a slow press pick delivered its `pointerdown` after the gesture's own `pointerup`, and with two clicks in flight at once the second `click` could conclude before the first — a click-to-select handler applied the clicks in reverse.

This implements the per-canvas dispatch chain sketched in the issue:

- Picks still start eagerly at canvas-event time, so overlapping gestures keep overlapping their GPU readbacks — nothing is serialized except the dispatch of the results.
- Each handler appends its dispatch work to the chain **synchronously**, so chain order is canvas-event order. The click step is appended right after its release's own step, so per-gesture `pointerup`-before-`click` ordering falls out naturally.
- Each step keeps the existing `!this._picker` teardown guard, and `_pickerDestroy` replaces the chain, so a pick that never resolves (a lost device) cannot stall the dispatches of a later boot.
- A step that rejects (a failed read back) is reported once via `console.error` and released, so the steps queued behind it still dispatch. On `main` the same failure surfaced as two unhandled rejections.

Hover is untouched: stale move picks are still discarded via the `_pickToken` newest-wins guard, which remains the right policy for moves.

## Tests

The existing *"concludes a click whose press pick resolves after the release pick"* test encoded the old inversion — it asserted `pointerup` had fired while the press pick was still pending — and now asserts ordered delivery instead. New tests cover the cross-gesture click inversion, chain survival across a rejected pick, and the teardown reset across a re-boot. The updated test and the first two new ones fail on `main`; the re-boot one guards the chain reset itself.

All 996 tests pass, lint is clean, and the build (including the Custom Elements Manifest validation) succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
