### PR TITLE
Report a pc-joint entity reference that does not resolve

### DIFF
--- a/src/components/joint-component.ts
+++ b/src/components/joint-component.ts
@@ -1,7 +1,7 @@
-import type { JointComponent } from 'playcanvas';
+import type { Entity, JointComponent } from 'playcanvas';
 import { Vec2, Vec3 } from 'playcanvas';
 
-import { getEntity, parseBool, parseEnum, parseNumber, parseVec2, parseVec3 } from '../parse';
+import { findEntityElement, getEntity, parseBool, parseEnum, parseNumber, parseVec2, parseVec3 } from '../parse';
 
 import { ComponentElement } from './component';
 
@@ -210,8 +210,8 @@ class JointComponentElement extends ComponentElement {
             breakImpulse: this._breakImpulse,
             enableCollision: this._enableCollision,
             enableLimits: this._enableLimits,
-            entityA: getEntity(this._entityA),
-            entityB: getEntity(this._entityB),
+            entityA: this._resolveEntity('entity-a', this._entityA),
+            entityB: this._resolveEntity('entity-b', this._entityB),
             limits: this._limits,
             linearDamping: this._linearDamping,
             linearEquilibrium: this._linearEquilibrium,
@@ -233,6 +233,38 @@ class JointComponentElement extends ComponentElement {
 
     private _onBreak() {
         this.dispatchEvent(new CustomEvent('break', { bubbles: true, composed: true }));
+    }
+
+    /**
+     * Resolves an `entity-a`/`entity-b` reference, warning when a non-empty one does not name a
+     * live entity - otherwise the joint silently creates no constraint. The message separates the
+     * two causes because their fixes differ: nothing matching is usually a typo, while an element
+     * matching without an entity is usually timing (a `pc-node` whose asset has not loaded).
+     *
+     * An empty reference stays silent: on `entity-b` it is the documented world-space case, and on
+     * either it is the transient state of a reference yet to be assigned.
+     *
+     * @param attribute - The attribute being resolved, for the message.
+     * @param ref - The reference to resolve.
+     * @returns The resolved entity, or `null`.
+     */
+    private _resolveEntity(attribute: string, ref: string): Entity | null {
+        if (!ref) {
+            return null;
+        }
+
+        const entity = getEntity(ref);
+        if (!entity) {
+            const element = findEntityElement(ref);
+            const cause = element
+                ? `<${element.tagName.toLowerCase()}> matches it but is not backing an entity yet`
+                : 'nothing in the document matches it';
+            console.warn(
+                `pc-joint could not resolve ${attribute} '${ref}' - ${cause} - constraint not created. ` +
+                    `Assign ${attribute} again once the entity exists.`
+            );
+        }
+        return entity;
     }
 
     protected initComponent() {
@@ -497,13 +529,14 @@ class JointComponentElement extends ComponentElement {
     /**
      * Sets the reference (CSS selector, element id or entity name) to the `<pc-entity>` providing
      * the first constrained body. The reference resolves when it is set, so an entity created
-     * later is picked up by setting the attribute again.
+     * later is picked up by setting the attribute again. A non-empty reference that does not
+     * resolve warns, naming which of the two causes it hit.
      * @param value - The first body's entity reference.
      */
     set entityA(value: string) {
         this._entityA = value;
         if (this.component) {
-            this.component.entityA = getEntity(value);
+            this.component.entityA = this._resolveEntity('entity-a', value);
         }
     }
 
@@ -519,13 +552,14 @@ class JointComponentElement extends ComponentElement {
      * Sets the reference (CSS selector, element id or entity name) to the `<pc-entity>` providing
      * the second constrained body, or empty to constrain the first body to a fixed point in world
      * space. The reference resolves when it is set, so an entity created later is picked up by
-     * setting the attribute again.
+     * setting the attribute again. A non-empty reference that does not resolve warns; an empty one
+     * is the documented world-space case and stays silent.
      * @param value - The second body's entity reference.
      */
     set entityB(value: string) {
         this._entityB = value;
         if (this.component) {
-            this.component.entityB = getEntity(value);
+            this.component.entityB = this._resolveEntity('entity-b', value);
         }
     }
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -12,8 +12,10 @@
  * - `parseBool` and `parseTags` take no attribute name, because every value is valid for them and
  *   so they never warn.
  *
- * `getEntity` is the exception: it resolves a reference to a live entity rather than parsing a
- * literal, and returns `null` instead of falling back to a default.
+ * `findEntityElement` and `getEntity` are the exceptions: they resolve a reference against the
+ * document rather than parsing a literal, and return `null` instead of falling back to a default.
+ * They also do not warn - what an unresolved reference means depends on the element holding it, so
+ * reporting it is left to the caller.
  */
 
 import type { Entity } from 'playcanvas';
@@ -324,15 +326,18 @@ export const parseVec4 = <T extends Vec4 | null>(
 };
 
 /**
- * Resolves a reference string to the {@link Entity} backing a `<pc-entity>` element. The reference
- * can be a CSS selector (e.g. `#my-id`, `pc-entity[name="Foo"]`), a bare element id, or a bare
- * entity name. Returns `null` if no matching element (or backing entity) is found.
+ * Resolves a reference string to the element it names. The reference can be a CSS selector (e.g.
+ * `#my-id`, `pc-entity[name="Foo"]`), a bare element id, or a bare entity name.
+ *
+ * Separate from {@link getEntity} so a caller reporting a failure can tell the two causes apart:
+ * nothing in the document matches the reference, or something matches but is not backing an
+ * entity (yet, or ever).
  *
  * @param ref - The reference string to resolve.
- * @returns The resolved entity, or `null`.
+ * @returns The matched element, or `null`.
  * @internal
  */
-export const getEntity = (ref: string): Entity | null => {
+export const findEntityElement = (ref: string): Element | null => {
     if (!ref) {
         return null;
     }
@@ -351,5 +356,18 @@ export const getEntity = (ref: string): Entity | null => {
         element = document.getElementById(ref) ?? document.querySelector(`pc-entity[name="${ref}"]`);
     }
 
-    return (element as { entity?: Entity } | null)?.entity ?? null;
+    return element;
+};
+
+/**
+ * Resolves a reference string to the {@link Entity} backing a `<pc-entity>` element. The reference
+ * can be a CSS selector (e.g. `#my-id`, `pc-entity[name="Foo"]`), a bare element id, or a bare
+ * entity name. Returns `null` if no matching element (or backing entity) is found.
+ *
+ * @param ref - The reference string to resolve.
+ * @returns The resolved entity, or `null`.
+ * @internal
+ */
+export const getEntity = (ref: string): Entity | null => {
+    return (findEntityElement(ref) as { entity?: Entity } | null)?.entity ?? null;
 };

--- a/test/integration/components/joint-component.test.ts
+++ b/test/integration/components/joint-component.test.ts
@@ -215,14 +215,44 @@ describe('<pc-joint>', () => {
             expect(joint.component.entityA).toBeNull();
         });
 
-        it('leaves an unresolvable reference null without warning', async () => {
+        it('warns when a reference matches nothing in the document', async () => {
             const { get } = await bootApp(scene('entity-a="#nope"'));
             const joint = get<JointComponentElement>('pc-joint');
 
-            // No warning claimed here: getEntity resolves references quietly, and the guard
-            // fails the test if anything warns
+            warnings.expect("pc-joint could not resolve entity-a '#nope' - nothing in the document matches it");
             expect(joint.entityA).toBe('#nope');
             expect(joint.component.entityA).toBeNull();
+        });
+
+        it('warns differently when a reference matches an element backing no entity', async () => {
+            // Pointing at the wrong element resolves to something, so it needs its own diagnosis:
+            // the reference is fine and the target is the problem
+            const { get } = await bootApp(`<div id="not-an-entity"></div>${scene('entity-a="#not-an-entity"')}`);
+            const joint = get<JointComponentElement>('pc-joint');
+
+            warnings.expect('<div> matches it but is not backing an entity yet');
+            expect(joint.component.entityA).toBeNull();
+        });
+
+        it('warns again when a reference is reassigned and still does not resolve', async () => {
+            const { get } = await bootApp(scene('entity-a="bob"'));
+            const joint = get<JointComponentElement>('pc-joint');
+
+            joint.setAttribute('entity-a', '#still-nope');
+
+            warnings.expect("pc-joint could not resolve entity-a '#still-nope'");
+            expect(joint.component.entityA).toBeNull();
+        });
+
+        it('stays silent for an empty reference, which is the world-space case', async () => {
+            const { get } = await bootApp(scene('entity-a="bob"'));
+            const joint = get<JointComponentElement>('pc-joint');
+
+            // entity-b was never supplied, and is reassigned empty here. Neither warns: the guard
+            // fails this test if either did.
+            joint.setAttribute('entity-b', '');
+
+            expect(joint.component.entityB).toBeNull();
         });
     });
 


### PR DESCRIPTION
Fixes #389

An `entity-a` or `entity-b` that names nothing live produced no constraint and no message, so the joint simply did nothing — indistinguishable from a physics problem, and the failure most likely to bite when referencing a `pc-node`, whose entity does not exist until its container asset has loaded. The silence was deliberate and pinned by a test; this replaces it, because every neighboring element already reports the same class of mistake loudly: `pc-model` warns for an asset id that resolves to nothing, and `pc-node` warns for a name it cannot find, down to offering the closest match.

This is option (1) from the issue: warn on a non-empty reference that does not resolve, with no timing change and nothing breaking.

## What warns, and how

The two failures report differently, because they have different fixes:

- **Nothing in the document matches the reference** — usually a typo or a missing element:
  > `pc-joint could not resolve entity-a '#nope' - nothing in the document matches it - constraint not created. Assign entity-a again once the entity exists.`
- **Something matches but is not backing an entity** — usually timing (a `pc-node` whose asset has not loaded), or the wrong element entirely:
  > `pc-joint could not resolve entity-a '#shin' - <pc-node> matches it but is not backing an entity yet - constraint not created. Assign entity-a again once the entity exists.`

Telling them apart needs the matched element, so the element lookup is split out of `getEntity` as `findEntityElement` (both `@internal`). `getEntity` keeps its signature and its silence — what an unresolved reference means depends on the element holding it, so reporting stays with the caller.

## What stays silent

An empty reference. On `entity-b` it is the documented way to pin the first body to a point in world space, and on either attribute it is the transient state of an element whose reference has yet to be assigned. A test pins this.

## Scope

`pc-joint` only — the most punishing of the five reference-resolving elements, because a missing joint has no visual symptom at all. `pc-button`, `pc-scrollbar`, `pc-scrollview` and `pc-script` are left alone here.

## Test plan

- `warns when a reference matches nothing in the document` (replaces the test that pinned the silence)
- `warns differently when a reference matches an element backing no entity`
- `warns again when a reference is reassigned and still does not resolve`
- `stays silent for an empty reference, which is the world-space case`
- Full suite: 996 tests pass across 46 files; lint, type-check and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
