### PR TITLE
Resolve bare names to pc-model and pc-node elements too

### DIFF
--- a/examples/ar-wiener-storm.html
+++ b/examples/ar-wiener-storm.html
@@ -153,36 +153,9 @@
                 }
             }
 
-            /* The announcer */
-            #quip {
-                position: fixed;
-                bottom: calc(max(26px, env(safe-area-inset-bottom)) + 84px);
-                left: 50%;
-                transform: translate(-50%, 10px);
-                z-index: 10;
-                max-width: min(80vw, 30rem);
-                color: var(--hud-ink);
-                font-family: var(--font);
-                font-size: 15px;
-                font-style: italic;
-                text-align: center;
-                text-shadow: 0 1px 10px rgba(0, 0, 0, 0.7);
-                opacity: 0;
-                transition: opacity 0.3s ease, transform 0.3s ease;
-                pointer-events: none;
-            }
-            #quip.show {
-                opacity: 1;
-                transform: translate(-50%, 0);
-            }
-
             @media (prefers-reduced-motion: reduce) {
                 #dignity.bump {
                     animation: none;
-                }
-                #quip {
-                    transition: opacity 0.3s ease;
-                    transform: translate(-50%, 0);
                 }
             }
 
@@ -218,6 +191,7 @@
             <pc-asset src="assets/models/wiener.glb" id="wiener"></pc-asset>
             <pc-asset src="assets/models/canonical-head.glb" id="head"></pc-asset>
             <pc-asset src="assets/skies/octagon-lamps-photo-studio-2k.hdr" id="sky"></pc-asset>
+            <pc-asset src="assets/sounds/wiener-slap.mp3" id="slap"></pc-asset>
             <!-- Scene -->
             <pc-scene>
                 <!-- Sky (lighting only), kept low so it never drowns the key light -->
@@ -259,8 +233,13 @@
                         <pc-model asset="head"></pc-model>
                     </pc-entity>
                 </pc-entity>
-                <!-- The wiener cannon -->
+                <!-- The wiener cannon. Hits land with a real wet slap recording: a
+                     non-positional slot, replayed per hit with the pitch and volume set to
+                     how hard it landed -->
                 <pc-entity name="wiener-storm">
+                    <pc-sound positional="false">
+                        <pc-sound-slot name="slap" asset="slap" overlap></pc-sound-slot>
+                    </pc-sound>
                     <pc-script>
                         <pc-script-instance name="wienerStorm" wiener-asset="asset:wiener" target="entity:head-proxy" rate="2.5" template="#wiener-template"></pc-script-instance>
                     </pc-script>
@@ -342,7 +321,6 @@
 
         <!-- HUD -->
         <div id="status"><span class="status-dot"></span><span id="status-text">Loading face tracker…</span></div>
-        <div id="quip"></div>
         <div id="dignity">
             <div class="dignity-row">
                 <span class="label">DIGNITY</span>
@@ -391,50 +369,8 @@
 
             app.on('face:lost', () => {
                 dignityPill.classList.remove('active');
-                say('The wieners miss you.', 1);
                 if (!cameraError) setStatus('Show your face');
             });
-
-            // The announcer: one deadpan line at a time, important lines win
-            const quip = document.getElementById('quip');
-            let quipUntil = 0;
-            let quipPriority = 0;
-            let quipTimer = null;
-
-            function say(text, priority = 0) {
-                const now = performance.now();
-                if (now < quipUntil && priority <= quipPriority) return;
-                quipUntil = now + 2600;
-                quipPriority = priority;
-                quip.textContent = text;
-                quip.classList.add('show');
-                clearTimeout(quipTimer);
-                quipTimer = setTimeout(() => {
-                    quip.classList.remove('show');
-                    quipPriority = 0;
-                }, 2200);
-            }
-
-            const pick = lines => lines[Math.floor(Math.random() * lines.length)];
-
-            const HIT_QUIPS = [
-                'Right in the kisser.',
-                'That one had mustard on it.',
-                'The wurst is yet to come.',
-                'A direct hit. Nature is beautiful.',
-                'That’s a lot of wiener.',
-                'Frankly, uncalled for.',
-                'You took that surprisingly well.'
-            ];
-            const HARD_HIT_QUIPS = [
-                'OOF. Right in the dignity.',
-                'That one left a mark.',
-                'A meaty blow.'
-            ];
-            const GONE_QUIPS = [
-                'Dignity: gone. The wieners won.',
-                'Nothing left but shame and mustard.'
-            ];
 
             // Dignity: drains with every hit, seeps back while you keep dodging
             const dignityFill = document.getElementById('dignity-fill');
@@ -443,7 +379,6 @@
             let dignity = 100;
             let gone = false;
             let endured = 0;
-            let dodgeStreak = 0;
             let lastHitAt = 0;
 
             const renderDignity = () => {
@@ -457,7 +392,6 @@
                 if (gone && respite > 6000) {
                     gone = false;
                     dignity = 20;
-                    say('Dignity partially restored.', 1);
                     renderDignity();
                 } else if (!gone && dignity < 100 && respite > 2000) {
                     dignity = Math.min(100, dignity + 0.4);
@@ -465,78 +399,37 @@
                 }
             }, 200);
 
-            app.on('wiener:missed', () => {
-                dodgeStreak += 1;
-                if (dodgeStreak === 3) say('The wieners respect you now.', 1);
-                else if (dodgeStreak === 6) say('Untouchable. Frankly.', 1);
-                else if (dodgeStreak === 10) say('Not one frank has landed. Statistically improbable.', 1);
-            });
-
-            // The storm escalates quietly - only the announcer lets on
-            const STORM_NAMES = [
-                '', 'Light wiener drizzle', 'Frankfurter front', 'Severe sausage squall',
-                'Major meat monsoon', 'CAT 5 FRANKNADO'
-            ];
-
-            app.on('storm:category', (category) => {
-                if (category > 1) say(`The storm intensifies. ${STORM_NAMES[category] ?? STORM_NAMES[5]}.`, 2);
-            });
-
-            // Hits land with a real wet slap recording. The audio context can only start
-            // from a user gesture, so hits are silent until the first tap.
-            let audio = null;
-            let slapBuffer = null;
-
-            window.addEventListener('pointerdown', () => {
-                audio = audio ?? new AudioContext();
-                audio.resume();
-                fetch('assets/sounds/wiener-slap.mp3')
-                    .then(response => response.arrayBuffer())
-                    .then(data => audio.decodeAudioData(data))
-                    .then((buffer) => {
-                        slapBuffer = buffer;
-                    })
-                    .catch(() => {}); // no sound is an acceptable fallback
-            }, { once: true });
+            // The slap slot declared on the cannon entity. The engine resumes its audio
+            // context on the first user gesture, so hits are silent until the first tap.
+            const slapSlot = document.querySelector('pc-sound-slot[name="slap"]');
 
             const slap = (speed) => {
-                if (!audio || audio.state !== 'running' || !slapBuffer) return;
+                const slot = slapSlot?.soundSlot;
+                if (!slot) return;
 
                 // How hard it landed, 0 to 1 - gentle grazes stay silent
                 const punch = Math.max(0, Math.min(1, (speed - 40) / 220));
                 if (punch <= 0) return;
 
-                // Slight pitch variation keeps the barrage from sounding machine-gunned
-                const source = audio.createBufferSource();
-                source.buffer = slapBuffer;
-                source.playbackRate.value = 0.92 + Math.random() * 0.18;
-                const gain = audio.createGain();
-                gain.gain.value = 0.1 + punch * 0.45;
-                source.connect(gain).connect(audio.destination);
-                source.start(audio.currentTime);
+                // Per-instance pitch and volume, so a new slap never bends the tail of one
+                // still playing. Slight pitch variation keeps the barrage from sounding
+                // machine-gunned.
+                const instance = slot.play();
+                if (instance) {
+                    instance.pitch = 0.92 + Math.random() * 0.18;
+                    instance.volume = 0.1 + punch * 0.45;
+                }
             };
 
             app.on('wiener:hit', (speed) => {
                 endured += 1;
                 enduredCount.textContent = endured;
-                dodgeStreak = 0;
                 lastHitAt = performance.now();
 
                 const punch = Math.max(0, Math.min(1, ((speed ?? 150) - 40) / 220));
-                const before = dignity;
                 dignity = Math.max(0, dignity - (4 + punch * 8));
-
-                if (!gone && dignity <= 0) {
+                if (dignity <= 0) {
                     gone = true;
-                    say(pick(GONE_QUIPS), 3);
-                } else if (before > 50 && dignity <= 50) {
-                    say('Half your dignity remains. Choose wisely.', 2);
-                } else if (before > 25 && dignity <= 25) {
-                    say('Dignity reserves critical.', 2);
-                } else if (punch > 0.72) {
-                    say(pick(HARD_HIT_QUIPS), 1);
-                } else if (endured % 4 === 0) {
-                    say(pick(HIT_QUIPS));
                 }
 
                 renderDignity();

--- a/examples/ar-wiener-storm.html
+++ b/examples/ar-wiener-storm.html
@@ -254,8 +254,8 @@
                         <pc-script>
                             <pc-script-instance name="headShadowCatcher" ellipsoid="false" strength="0.6"></pc-script-instance>
                         </pc-script>
-                        <!-- Becomes the catcher surface. A child, because entity: references
-                             resolve bare names against pc-entity elements only -->
+                        <!-- Becomes the catcher surface. A child, so it rides the tracked
+                             head's transform with the proxy -->
                         <pc-model asset="head"></pc-model>
                     </pc-entity>
                 </pc-entity>

--- a/examples/ar-wiener-storm.html
+++ b/examples/ar-wiener-storm.html
@@ -268,57 +268,60 @@
             </pc-scene>
         </pc-app>
 
-        <!-- One wiener: six capsule bodies linked by five 6dof flex joints whose angular
-             springs pull it back straight - a raw wiener is floppy, not a rag. Authored in
-             the model's meters; the cannon scales each clone to its own size in scene
-             units. The joints reference the segments by bare name, and names resolve
-             against the nearest enclosing entity first - so every clone's joints bind that
-             clone's own segments, which is what lets one template spawn many wieners. The
-             single root pc-entity is what keeps the names self-contained. -->
+        <!-- One wiener: the model's own B0-B5 skin bones, each decorated with a capsule
+             body, linked by five 6dof flex joints whose angular springs pull the chain
+             back straight - a raw wiener is floppy, not a rag. Physics drives the bones,
+             so the skinned mesh follows with no scripting. Each joint anchors on a small
+             entity at the junction between its bones (half the 0.023 bone spacing, in
+             bone-local meters - the model's scale carries it). Bones and joints are wired
+             by bare name, and names resolve against the nearest enclosing entity first -
+             so every clone's joints bind that clone's own bones, which is what lets one
+             template spawn many wieners. The single entity-fronting root (the pc-model)
+             is what keeps the names self-contained. -->
         <template id="wiener-template">
-            <pc-entity name="wiener">
-                <pc-entity name="seg-0" position="0 -0.0575 0">
+            <pc-model asset="wiener">
+                <pc-node name="B0">
                     <pc-collision type="capsule" radius="0.0115" height="0.027"></pc-collision>
                     <pc-rigid-body type="dynamic" mass="0.02" friction="0.4" angular-damping="0.5"></pc-rigid-body>
-                </pc-entity>
-                <pc-entity name="seg-1" position="0 -0.0345 0">
+                    <!-- Bending swings about each junction's local X and Z, twisting about
+                         Y. Five joints share the total fold, and twist is nearly locked. -->
+                    <pc-entity name="flex-0" position="0 0.0115 0">
+                        <pc-joint type="6dof" entity-a="B0" entity-b="B1" angular-motion-x="limited" angular-motion-y="limited" angular-motion-z="limited" angular-limits-x="-10 10" angular-limits-y="-1.5 1.5" angular-limits-z="-10 10" angular-stiffness="6 8 6"></pc-joint>
+                    </pc-entity>
+                </pc-node>
+                <pc-node name="B1">
                     <pc-collision type="capsule" radius="0.0115" height="0.027"></pc-collision>
                     <pc-rigid-body type="dynamic" mass="0.02" friction="0.4" angular-damping="0.5"></pc-rigid-body>
-                </pc-entity>
-                <pc-entity name="seg-2" position="0 -0.0115 0">
+                    <pc-entity name="flex-1" position="0 0.0115 0">
+                        <pc-joint type="6dof" entity-a="B1" entity-b="B2" angular-motion-x="limited" angular-motion-y="limited" angular-motion-z="limited" angular-limits-x="-10 10" angular-limits-y="-1.5 1.5" angular-limits-z="-10 10" angular-stiffness="6 8 6"></pc-joint>
+                    </pc-entity>
+                </pc-node>
+                <pc-node name="B2">
                     <pc-collision type="capsule" radius="0.0115" height="0.027"></pc-collision>
                     <pc-rigid-body type="dynamic" mass="0.02" friction="0.4" angular-damping="0.5"></pc-rigid-body>
-                </pc-entity>
-                <pc-entity name="seg-3" position="0 0.0115 0">
+                    <pc-entity name="flex-2" position="0 0.0115 0">
+                        <pc-joint type="6dof" entity-a="B2" entity-b="B3" angular-motion-x="limited" angular-motion-y="limited" angular-motion-z="limited" angular-limits-x="-10 10" angular-limits-y="-1.5 1.5" angular-limits-z="-10 10" angular-stiffness="6 8 6"></pc-joint>
+                    </pc-entity>
+                </pc-node>
+                <pc-node name="B3">
                     <pc-collision type="capsule" radius="0.0115" height="0.027"></pc-collision>
                     <pc-rigid-body type="dynamic" mass="0.02" friction="0.4" angular-damping="0.5"></pc-rigid-body>
-                </pc-entity>
-                <pc-entity name="seg-4" position="0 0.0345 0">
+                    <pc-entity name="flex-3" position="0 0.0115 0">
+                        <pc-joint type="6dof" entity-a="B3" entity-b="B4" angular-motion-x="limited" angular-motion-y="limited" angular-motion-z="limited" angular-limits-x="-10 10" angular-limits-y="-1.5 1.5" angular-limits-z="-10 10" angular-stiffness="6 8 6"></pc-joint>
+                    </pc-entity>
+                </pc-node>
+                <pc-node name="B4">
                     <pc-collision type="capsule" radius="0.0115" height="0.027"></pc-collision>
                     <pc-rigid-body type="dynamic" mass="0.02" friction="0.4" angular-damping="0.5"></pc-rigid-body>
-                </pc-entity>
-                <pc-entity name="seg-5" position="0 0.0575 0">
+                    <pc-entity name="flex-4" position="0 0.0115 0">
+                        <pc-joint type="6dof" entity-a="B4" entity-b="B5" angular-motion-x="limited" angular-motion-y="limited" angular-motion-z="limited" angular-limits-x="-10 10" angular-limits-y="-1.5 1.5" angular-limits-z="-10 10" angular-stiffness="6 8 6"></pc-joint>
+                    </pc-entity>
+                </pc-node>
+                <pc-node name="B5">
                     <pc-collision type="capsule" radius="0.0115" height="0.027"></pc-collision>
                     <pc-rigid-body type="dynamic" mass="0.02" friction="0.4" angular-damping="0.5"></pc-rigid-body>
-                </pc-entity>
-                <!-- Bending swings about each junction's local X and Z, twisting about Y.
-                     Five joints share the total fold, and twist is nearly locked. -->
-                <pc-entity name="flex-0" position="0 -0.046 0">
-                    <pc-joint type="6dof" entity-a="seg-0" entity-b="seg-1" angular-motion-x="limited" angular-motion-y="limited" angular-motion-z="limited" angular-limits-x="-10 10" angular-limits-y="-1.5 1.5" angular-limits-z="-10 10" angular-stiffness="6 8 6"></pc-joint>
-                </pc-entity>
-                <pc-entity name="flex-1" position="0 -0.023 0">
-                    <pc-joint type="6dof" entity-a="seg-1" entity-b="seg-2" angular-motion-x="limited" angular-motion-y="limited" angular-motion-z="limited" angular-limits-x="-10 10" angular-limits-y="-1.5 1.5" angular-limits-z="-10 10" angular-stiffness="6 8 6"></pc-joint>
-                </pc-entity>
-                <pc-entity name="flex-2" position="0 0 0">
-                    <pc-joint type="6dof" entity-a="seg-2" entity-b="seg-3" angular-motion-x="limited" angular-motion-y="limited" angular-motion-z="limited" angular-limits-x="-10 10" angular-limits-y="-1.5 1.5" angular-limits-z="-10 10" angular-stiffness="6 8 6"></pc-joint>
-                </pc-entity>
-                <pc-entity name="flex-3" position="0 0.023 0">
-                    <pc-joint type="6dof" entity-a="seg-3" entity-b="seg-4" angular-motion-x="limited" angular-motion-y="limited" angular-motion-z="limited" angular-limits-x="-10 10" angular-limits-y="-1.5 1.5" angular-limits-z="-10 10" angular-stiffness="6 8 6"></pc-joint>
-                </pc-entity>
-                <pc-entity name="flex-4" position="0 0.046 0">
-                    <pc-joint type="6dof" entity-a="seg-4" entity-b="seg-5" angular-motion-x="limited" angular-motion-y="limited" angular-motion-z="limited" angular-limits-x="-10 10" angular-limits-y="-1.5 1.5" angular-limits-z="-10 10" angular-stiffness="6 8 6"></pc-joint>
-                </pc-entity>
-            </pc-entity>
+                </pc-node>
+            </pc-model>
         </template>
 
         <script>

--- a/examples/assets/scripts/wiener-storm.mjs
+++ b/examples/assets/scripts/wiener-storm.mjs
@@ -1,4 +1,4 @@
-import { Quat, Script, Vec2, Vec3 } from 'playcanvas';
+import { Script, Vec2, Vec3 } from 'playcanvas';
 
 /**
  * Lobs a steady barrage of wieners at the user's head. Works in MediaPipe's camera space, as
@@ -11,16 +11,17 @@ import { Quat, Script, Vec2, Vec3 } from 'playcanvas';
  * for both), so a throw leaves the hand brisk but arrives gently - a toss, not a fastball. An
  * invisible physics proxy for the head (see the example markup) bounces them away.
  *
- * Each wiener bends like the real, raw thing: it is a chain of six capsule rigid bodies linked
- * by 6dof joints whose angular springs pull it back straight, and the model is a skinned mesh
- * whose six bones ride the segment bodies one to one. With five flex points along the length,
- * an impact folds the chain around whatever it hit in a smooth curve and the springs wobble it
- * straight again - no scripted deformation, just physics.
+ * Each wiener bends like the real, raw thing: the model's six skin bones each carry a capsule
+ * rigid body, linked by 6dof joints whose angular springs pull the chain back straight. Physics
+ * drives the bones, so the skinned mesh follows with no scripted deformation - with five flex
+ * points along the length, an impact folds the chain around whatever it hit in a smooth curve
+ * and the springs wobble it straight again.
  *
- * The chain itself is markup: `template` names a `<template>` holding one wiener, its segments
- * and joints wired by bare entity names, which resolve within each clone - one template, many
- * wieners. This script clones it per throw, scales the clone to its own random size, launches
- * the bodies once the components report ready, and rides the skin on them.
+ * The whole wiener is markup: `template` names a `<template>` whose root `pc-model` instantiates
+ * the skinned mesh while `pc-node` children decorate its bones with the bodies and joints, wired
+ * by bare names that resolve within each clone - one template, many wieners. This script clones
+ * it per throw, scales the clone to its own random size, and launches the bodies once the
+ * clone's components report ready.
  *
  * Throwing runs while a face is tracked (`face:found`/`face:lost`), which the `?sim` and
  * no-camera fallback modes of the face tracking script also report.
@@ -58,9 +59,9 @@ export class WienerStorm extends Script {
     target = null;
 
     /**
-     * A CSS selector for the `<template>` holding one wiener: a single root `pc-entity` (the
-     * scope its bare-name joint references resolve within) carrying the capsule segments and
-     * flex joints, authored in the model's meters.
+     * A CSS selector for the `<template>` holding one wiener: a single root `pc-model` (the
+     * scope its bare-name joint references resolve within) whose `pc-node` children decorate the
+     * skin bones with capsule bodies and flex joints, authored in the model's meters.
      * @type {string}
      * @attribute
      */
@@ -228,9 +229,6 @@ export class WienerStorm extends Script {
     /** @private */
     _tmpVec2 = new Vec3();
 
-    /** @private */
-    _tmpQuat = new Quat();
-
     initialize() {
         this._destroyPromise = new Promise((resolve) => {
             this._resolveDestroyed = resolve;
@@ -313,20 +311,10 @@ export class WienerStorm extends Script {
             }
         }
 
-        // Ride the skin bones on the physics segments and retire spent wieners
+        // Retire spent wieners - the skin needs no per-frame help, its bones are the bodies
         for (let i = this._live.length - 1; i >= 0; i--) {
             const wiener = this._live[i];
             wiener.age += dt;
-
-            for (let b = 0; b < wiener.bones.length; b++) {
-                const segment = wiener.segments[b];
-                const bone = wiener.bones[b];
-                const rot = segment.getRotation();
-                rot.transformVector(wiener.posOffsets[b], this._tmpVec).add(segment.getPosition());
-                this._tmpQuat.mul2(rot, wiener.rotOffsets[b]);
-                bone.setPosition(this._tmpVec);
-                bone.setRotation(this._tmpQuat);
-            }
 
             if (wiener.age > this.lifetime || wiener.segments[2].getPosition().y < -160) {
                 if (!wiener.hitHead) this.app.fire('wiener:missed');
@@ -397,19 +385,15 @@ export class WienerStorm extends Script {
         const scale = 0.9 + Math.random() * 0.22;
         const k = this.modelScale * scale;
 
-        // One wiener from the template. The root entity holds the whole wiener for lifecycle
-        // and scope - the segment bodies fly in world space regardless of their parent.
+        // One wiener from the template. The root pc-model holds the whole wiener for lifecycle
+        // and scope - the bone bodies fly in world space regardless of their parent.
         const clone = template.content.cloneNode(true);
-        const element = clone.querySelector('pc-entity');
+        const element = clone.querySelector('pc-model');
         if (!element) return;
 
-        // The template is authored in the model's meters: scale every position and capsule to
-        // this wiener's size in scene units before the clone upgrades, and stamp the dynamics
-        // that derive from script attributes.
-        for (const part of element.querySelectorAll('pc-entity')) {
-            const [x, y, z] = part.getAttribute('position').split(/\s+/).map(Number);
-            part.setAttribute('position', `${x * k} ${y * k} ${z * k}`);
-        }
+        // The model's scale carries the bone spread and the joint anchors, but physics ignores
+        // entity scale, so the capsules are sized to this wiener in scene units before the clone
+        // upgrades - along with the dynamics that derive from script attributes.
         for (const collision of element.querySelectorAll('pc-collision')) {
             collision.setAttribute('radius', Number(collision.getAttribute('radius')) * k);
             collision.setAttribute('height', Number(collision.getAttribute('height')) * k);
@@ -427,14 +411,16 @@ export class WienerStorm extends Script {
             'rotation',
             `${Math.random() * 360} ${Math.random() * 360} ${Math.random() * 360}`
         );
+        element.setAttribute('scale', `${k} ${k} ${k}`);
 
         // Pending until the launch commits, so teardown can find a half-initialized clone
         this._pending.add(element);
         this._spawnRoot.appendChild(clone);
 
-        // The entities exist as soon as appendChild returns; the components attach microtasks
-        // later. Raced against destruction, because a removed element's ready() never settles.
-        const parts = [...element.querySelectorAll('pc-collision, pc-rigid-body, pc-joint')];
+        // The model instantiates and its nodes bind behind element readiness; the components
+        // attach microtasks after that. Raced against destruction, because a removed element's
+        // ready() never settles.
+        const parts = [element, ...element.querySelectorAll('pc-collision, pc-rigid-body, pc-joint')];
         await Promise.race([Promise.all(parts.map(part => part.ready())), this._destroyPromise]);
 
         if (this._destroyed || !element.isConnected) {
@@ -446,10 +432,7 @@ export class WienerStorm extends Script {
         try {
             const wiener = {
                 element: element,
-                segments: [...element.querySelectorAll('pc-entity[name^="seg-"]')].map(seg => seg.entity),
-                bones: [],
-                posOffsets: [],
-                rotOffsets: [],
+                segments: [...element.querySelectorAll('pc-node')].map(node => node.entity),
                 age: 0,
                 hitHead: false
             };
@@ -477,24 +460,6 @@ export class WienerStorm extends Script {
                 }
             }
 
-            // The skinned model rides along: each bone copies its segment body every frame,
-            // through the offsets between them captured at this rest pose
-            const containerEntity = element.entity;
-            const model = this.wienerAsset.resource.instantiateRenderEntity();
-            model.setLocalScale(k, k, k);
-            containerEntity.addChild(model);
-
-            for (let b = 0; b < wiener.segments.length; b++) {
-                const segment = wiener.segments[b];
-                const bone = model.findByName(`B${b}`);
-                const invRot = this._tmpQuat.copy(segment.getRotation()).invert();
-                wiener.bones.push(bone);
-                wiener.posOffsets.push(
-                    invRot.transformVector(new Vec3().sub2(bone.getPosition(), segment.getPosition()))
-                );
-                wiener.rotOffsets.push(new Quat().mul2(invRot, bone.getRotation()));
-            }
-
             // Throw the chain as one rigid motion: a shared tumble plus the velocity that
             // tumble adds at each segment's offset from the middle
             const omega = new Vec3(
@@ -502,7 +467,7 @@ export class WienerStorm extends Script {
                 Math.random() * 2 - 1,
                 Math.random() * 2 - 1
             ).normalize().mulScalar(2 + Math.random() * 2.5);
-            const mid = this._tmpVec2.copy(containerEntity.getPosition());
+            const mid = this._tmpVec2.copy(element.entity.getPosition());
             for (const segment of wiener.segments) {
                 const arm = this._tmpVec.sub2(segment.getPosition(), mid);
                 const spin = new Vec3().cross(omega, arm);

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -132,10 +132,9 @@ class ButtonComponentElement extends ComponentElement {
      * Sets the reference (CSS selector, element id, or name of a `pc-entity`, `pc-model` or
      * `pc-node`) to the entity whose image element is used for visual transitions. An exact name
      * resolves against the nearest enclosing entity first, then outward, then the document.
-     * Defaults to the button's own
-     * entity — inside a `<pc-model>`, that is the model's host entity, so supply an explicit
-     * reference to target a UI entity instead. A non-empty reference that does not resolve warns
-     * and is ignored.
+     * Defaults to the button's own entity — inside a `<pc-model>`, that is the model's host
+     * entity, so supply an explicit reference to target a UI entity instead. A non-empty
+     * reference that does not resolve warns and is ignored.
      * @param value - The image entity reference.
      */
     set image(value: string) {

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -129,9 +129,10 @@ class ButtonComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (CSS selector, element id or entity name) to the `<pc-entity>` whose image
-     * element is used for visual transitions. An exact entity name resolves against the nearest
-     * enclosing entity first, then outward, then the document. Defaults to the button's own
+     * Sets the reference (CSS selector, element id, or name of a `pc-entity`, `pc-model` or
+     * `pc-node`) to the entity whose image element is used for visual transitions. An exact name
+     * resolves against the nearest enclosing entity first, then outward, then the document.
+     * Defaults to the button's own
      * entity — inside a `<pc-model>`, that is the model's host entity, so supply an explicit
      * reference to target a UI entity instead. A non-empty reference that does not resolve warns
      * and is ignored.

--- a/src/components/joint-component.ts
+++ b/src/components/joint-component.ts
@@ -25,10 +25,12 @@ export type MotionMode = 'locked' | 'limited' | 'free';
  * primary axis: a hinge rotates about it, a slider translates along it and a ball joint twists
  * about it. The constrained bodies are referenced by `entity-a` and `entity-b`, both of which need
  * a rigid body component; leaving `entity-b` empty constrains `entity-a` to a fixed point in world
- * space. An exact entity-name reference resolves against the nearest enclosing entity first, then
- * outward through the entity hierarchy, then the document — so a `<template>` prefab with one root
- * `<pc-entity>` can wire its joints by name and stay self-contained when cloned. The underlying
- * engine component is in alpha, so its API may change.
+ * space. A reference can name any entity-fronting element — `<pc-entity>`, `<pc-model>` or
+ * `<pc-node>`, so a ragdoll can join a model's own skeleton nodes by name — and an exact name
+ * resolves against the nearest enclosing entity first, then outward through the entity hierarchy,
+ * then the document. A `<template>` prefab with one entity-fronting root can therefore wire its
+ * joints by name and stay self-contained when cloned. The underlying engine component is in
+ * alpha, so its API may change.
  *
  * @elementSummary The `<pc-joint>` element constrains two rigid bodies to each other — a hinged
  * door, a swinging chain, a sliding drawer. Its entity's transform is the joint frame, and
@@ -498,11 +500,12 @@ class JointComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (CSS selector, element id or entity name) to the `<pc-entity>` providing
-     * the first constrained body. An exact entity name resolves against the nearest enclosing
-     * entity first, then outward, then the document. The reference resolves when it is set, so an
-     * entity created later is picked up by setting the attribute again. A non-empty reference
-     * that does not resolve warns, naming which of the two causes it hit.
+     * Sets the reference (CSS selector, element id, or name of a `pc-entity`, `pc-model` or
+     * `pc-node`) to the element providing the first constrained body. An exact name resolves
+     * against the nearest enclosing entity first, then outward, then the document. The reference
+     * resolves when it is set, so an entity created later is picked up by setting the attribute
+     * again. A non-empty reference that does not resolve warns, naming which of the two causes it
+     * hit.
      * @param value - The first body's entity reference.
      */
     set entityA(value: string) {
@@ -521,12 +524,13 @@ class JointComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (CSS selector, element id or entity name) to the `<pc-entity>` providing
-     * the second constrained body, or empty to constrain the first body to a fixed point in world
-     * space. An exact entity name resolves against the nearest enclosing entity first, then
-     * outward, then the document. The reference resolves when it is set, so an entity created
-     * later is picked up by setting the attribute again. A non-empty reference that does not
-     * resolve warns; an empty one is the documented world-space case and stays silent.
+     * Sets the reference (CSS selector, element id, or name of a `pc-entity`, `pc-model` or
+     * `pc-node`) to the element providing the second constrained body, or empty to constrain the
+     * first body to a fixed point in world space. An exact name resolves against the nearest
+     * enclosing entity first, then outward, then the document. The reference resolves when it is
+     * set, so an entity created later is picked up by setting the attribute again. A non-empty
+     * reference that does not resolve warns; an empty one is the documented world-space case and
+     * stays silent.
      * @param value - The second body's entity reference.
      */
     set entityB(value: string) {

--- a/src/components/script-component.ts
+++ b/src/components/script-component.ts
@@ -131,10 +131,10 @@ const assetConversion: Conversion = (rest, raw) => {
 };
 
 /**
- * Resolves an `entity:` prefix to the Entity backing a `pc-entity` element. The reference can be a
- * CSS selector, an element id or an entity name — an exact entity name resolves against the
- * nearest enclosing entity first, then outward, then the document. The failure warning names
- * which of the three causes ({@link unresolvedCause}) it hit.
+ * Resolves an `entity:` prefix to the Entity backing a `pc-entity`, `pc-model` or `pc-node`
+ * element. The reference can be a CSS selector, an element id or a name — an exact name resolves
+ * against the nearest enclosing entity first, then outward, then the document. The failure
+ * warning names which of the three causes ({@link unresolvedCause}) it hit.
  * @param rest - The entity reference.
  * @param raw - The raw value, returned unchanged when the reference does not resolve.
  * @param from - The element the value is declared under, which scopes the reference.
@@ -306,9 +306,9 @@ class ScriptComponentElement extends ComponentElement {
     /**
      * Recursively converts raw attribute data into proper PlayCanvas types. Supported conversions:
      * - "asset:id" → the Asset created by the `pc-asset` element with that id
-     * - "entity:ref" → the Entity backing a `pc-entity` element. The reference can be a CSS
-     *   selector, an element id or an entity name; an exact entity name resolves against this
-     *   element's nearest enclosing entity first, then outward, then the document.
+     * - "entity:ref" → the Entity backing a `pc-entity`, `pc-model` or `pc-node` element. The
+     *   reference can be a CSS selector, an element id or a name; an exact name resolves against
+     *   this element's nearest enclosing entity first, then outward, then the document.
      * - "vec2:1 2" → new Vec2(1, 2)
      * - "vec3:1 2 3" → new Vec3(1, 2, 3)
      * - "vec4:1 2 3 4" → new Vec4(1, 2, 3, 4)

--- a/src/components/scroll-view-component.ts
+++ b/src/components/scroll-view-component.ts
@@ -294,10 +294,10 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (CSS selector, element id or entity name) to the `<pc-entity>` used as the
-     * viewport, which clips the content to the scroll view's bounds. An exact entity name resolves
-     * against the nearest enclosing entity first, then outward, then the document. A non-empty
-     * reference that does not resolve warns and is ignored.
+     * Sets the reference (CSS selector, element id, or name of a `pc-entity`, `pc-model` or
+     * `pc-node`) to the entity used as the viewport, which clips the content to the scroll view's
+     * bounds. An exact name resolves against the nearest enclosing entity first, then outward,
+     * then the document. A non-empty reference that does not resolve warns and is ignored.
      * @param value - The viewport entity reference.
      */
     set viewport(value: string) {
@@ -319,10 +319,10 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (CSS selector, element id or entity name) to the `<pc-entity>` used as the
-     * content, which is moved as the scroll view is scrolled. An exact entity name resolves
-     * against the nearest enclosing entity first, then outward, then the document. A non-empty
-     * reference that does not resolve warns and is ignored.
+     * Sets the reference (CSS selector, element id, or name of a `pc-entity`, `pc-model` or
+     * `pc-node`) to the entity used as the content, which is moved as the scroll view is
+     * scrolled. An exact name resolves against the nearest enclosing entity first, then outward,
+     * then the document. A non-empty reference that does not resolve warns and is ignored.
      * @param value - The content entity reference.
      */
     set content(value: string) {
@@ -344,10 +344,10 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (CSS selector, element id or entity name) to the `<pc-entity>` containing
-     * the horizontal `<pc-scrollbar>`. An exact entity name resolves against the nearest enclosing
-     * entity first, then outward, then the document. A non-empty reference that does not resolve
-     * warns and is ignored.
+     * Sets the reference (CSS selector, element id, or name of a `pc-entity`, `pc-model` or
+     * `pc-node`) to the entity containing the horizontal `<pc-scrollbar>`. An exact name resolves
+     * against the nearest enclosing entity first, then outward, then the document. A non-empty
+     * reference that does not resolve warns and is ignored.
      * @param value - The horizontal scrollbar entity reference.
      */
     set horizontalScrollbar(value: string) {
@@ -369,10 +369,10 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (CSS selector, element id or entity name) to the `<pc-entity>` containing
-     * the vertical `<pc-scrollbar>`. An exact entity name resolves against the nearest enclosing
-     * entity first, then outward, then the document. A non-empty reference that does not resolve
-     * warns and is ignored.
+     * Sets the reference (CSS selector, element id, or name of a `pc-entity`, `pc-model` or
+     * `pc-node`) to the entity containing the vertical `<pc-scrollbar>`. An exact name resolves
+     * against the nearest enclosing entity first, then outward, then the document. A non-empty
+     * reference that does not resolve warns and is ignored.
      * @param value - The vertical scrollbar entity reference.
      */
     set verticalScrollbar(value: string) {

--- a/src/components/scrollbar-component.ts
+++ b/src/components/scrollbar-component.ts
@@ -120,10 +120,10 @@ class ScrollbarComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (CSS selector, element id or entity name) to the `<pc-entity>` used as the
-     * scrollbar handle. An exact entity name resolves against the nearest enclosing entity first,
-     * then outward, then the document. A non-empty reference that does not resolve warns and is
-     * ignored.
+     * Sets the reference (CSS selector, element id, or name of a `pc-entity`, `pc-model` or
+     * `pc-node`) to the entity used as the scrollbar handle. An exact name resolves against the
+     * nearest enclosing entity first, then outward, then the document. A non-empty reference that
+     * does not resolve warns and is ignored.
      * @param value - The handle entity reference.
      */
     set handle(value: string) {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -373,21 +373,28 @@ const entityOf = (element: Element | null): Entity | null => {
 };
 
 /**
- * The elements that front an entity and so act as the scopes of the lexical name lookup.
+ * The elements that front an entity: what a bare name can resolve to, and the scopes of the
+ * lexical name lookup.
  */
-const ENTITY_SCOPES = 'pc-entity, pc-model, pc-node';
+const ENTITY_KINDS = ['pc-entity', 'pc-model', 'pc-node'] as const;
+
+/**
+ * The entity-fronting elements as one selector, for the scope walk.
+ */
+const ENTITY_SCOPES = ENTITY_KINDS.join(', ');
 
 /**
  * Resolves a reference string to the element it names. The reference can be a CSS selector (e.g.
- * `#my-id`, `pc-entity[name="Foo"]`), a bare element id, or a bare entity name.
+ * `#my-id`, `pc-entity[name="Foo"]`), a bare element id, or the bare name of an entity-fronting
+ * element (`<pc-entity>`, `<pc-model>` or `<pc-node>` — for a node, the glTF node name it binds).
  *
- * When `from` is supplied, an exact entity-name match resolves lexically first: the closest
+ * When `from` is supplied, an exact name match resolves lexically first: the closest
  * entity-fronting ancestor's inclusive subtree, then each outer entity-fronting ancestor, then the
  * containing `<pc-app>`. This is what lets a `<template>` prefab reference its own entities by
  * name — every clone resolves within itself before the document-wide lookup below could reach an
- * earlier clone — provided the prefab has a single root `<pc-entity>` to be the enclosing scope.
+ * earlier clone — provided the prefab has a single entity-fronting root to be the enclosing scope.
  * Otherwise (and as the fallback) the reference is interpreted against the document as a CSS
- * selector, then an element id, then an entity name.
+ * selector, then an element id, then a name.
  *
  * Separate from {@link getEntity} so a caller reporting a failure can tell the causes apart
  * ({@link unresolvedCause} words them): nothing in the document matches the reference, or
@@ -406,7 +413,8 @@ export const findEntityElement = (ref: string, from?: Element): Element | null =
 
     // The name lands inside a quoted CSS string, so its quotes and backslashes are escaped -
     // a name like `say "hi"` must resolve, not turn the lookup into a SyntaxError.
-    const nameSelector = `pc-entity[name="${ref.replace(/["\\]/g, '\\$&')}"]`;
+    const escaped = ref.replace(/["\\]/g, '\\$&');
+    const nameSelector = ENTITY_KINDS.map(kind => `${kind}[name="${escaped}"]`).join(', ');
 
     if (from) {
         let scope = from.parentElement?.closest(ENTITY_SCOPES);
@@ -439,11 +447,12 @@ export const findEntityElement = (ref: string, from?: Element): Element | null =
 };
 
 /**
- * Resolves a reference string to the {@link Entity} backing a `<pc-entity>` element. The reference
- * can be a CSS selector (e.g. `#my-id`, `pc-entity[name="Foo"]`), a bare element id, or a bare
- * entity name — an exact entity-name match resolves lexically through the entity hierarchy first
- * when `from` is supplied ({@link findEntityElement} details the order). Returns `null` if no
- * matching element (or backing entity) is found.
+ * Resolves a reference string to the {@link Entity} backing an entity-fronting element
+ * (`<pc-entity>`, `<pc-model>` or `<pc-node>`). The reference can be a CSS selector (e.g.
+ * `#my-id`, `pc-entity[name="Foo"]`), a bare element id, or a bare name — an exact name match
+ * resolves lexically through the entity hierarchy first when `from` is supplied
+ * ({@link findEntityElement} details the order). Returns `null` if no matching element (or
+ * backing entity) is found.
  *
  * @param ref - The reference string to resolve.
  * @param from - The element resolving the reference, whose entity-fronting ancestors scope the
@@ -478,7 +487,7 @@ export const unresolvedCause = (element: Element | null): string => {
 };
 
 /**
- * Resolves a reference string to the {@link Entity} backing a `<pc-entity>` element, scoped to
+ * Resolves a reference string to the {@link Entity} backing an entity-fronting element, scoped to
  * the resolving element ({@link findEntityElement} details the order) and warning when a
  * non-empty reference does not resolve - otherwise the reference fails silently, invisible
  * except through the behavior it should have driven. The message names which of the three causes

--- a/test/integration/components/joint-component.test.ts
+++ b/test/integration/components/joint-component.test.ts
@@ -4,8 +4,19 @@ import { describe, expect, it } from 'vitest';
 
 import type { JointComponentElement } from '../../../src/components/joint-component';
 import type { EntityElement } from '../../../src/entity';
+import type { NodeElement } from '../../../src/node';
 import { bootApp } from '../../helpers/app';
 import { useGuard } from '../../helpers/guard';
+
+/** A meshless glTF with a single named node, for the reference-to-a-model-node case. */
+const STAGE_SRC = `data:application/json,${encodeURIComponent(
+    JSON.stringify({
+        asset: { version: '2.0' },
+        scene: 0,
+        scenes: [{ nodes: [0] }],
+        nodes: [{ name: 'Podium' }]
+    })
+)}`;
 
 /**
  * Two rigid bodies for the joint to reference. Without Ammo the bodies never simulate and the
@@ -182,6 +193,27 @@ describe('<pc-joint>', () => {
 
             expect(component.entityA).toBe(app.root.findByName('bob'));
             expect(component.entityB).toBe(app.root.findByName('anchor'));
+        });
+
+        it('resolves a reference to a model node by name', async () => {
+            // The ragdoll pattern, by name: a pc-node decorates one of the model's own skeleton
+            // nodes with a body, and a joint nested beneath it references that node. The joint's
+            // children build once the node binds, so the reference resolves against a live
+            // entity - the case that motivated reporting unresolved references in the first
+            // place, now wired without ids.
+            const { get } = await bootApp(`
+                <pc-asset id="stage" type="container" src="${STAGE_SRC}"></pc-asset>
+                <pc-model asset="stage">
+                    <pc-node name="Podium">
+                        <pc-rigid-body></pc-rigid-body>
+                        <pc-entity name="frame"><pc-joint entity-a="Podium"></pc-joint></pc-entity>
+                    </pc-node>
+                </pc-model>
+            `);
+
+            expect(get<JointComponentElement>('pc-joint').component.entityA).toBe(
+                get<NodeElement>('pc-node').entity
+            );
         });
 
         it('resolves a duplicated name to the nearest enclosing match', async () => {

--- a/test/integration/get-entity.test.ts
+++ b/test/integration/get-entity.test.ts
@@ -1,9 +1,21 @@
 import { describe, expect, it } from 'vitest';
 
 import type { EntityElement } from '../../src/entity';
+import type { ModelElement } from '../../src/model';
+import type { NodeElement } from '../../src/node';
 import { getEntity, resolveEntity } from '../../src/parse';
 import { bootApp } from '../helpers/app';
 import { useGuard } from '../helpers/guard';
+
+/** A meshless glTF with a single named node, for the `<pc-model>`/`<pc-node>` name cases. */
+const STAGE_SRC = `data:application/json,${encodeURIComponent(
+    JSON.stringify({
+        asset: { version: '2.0' },
+        scene: 0,
+        scenes: [{ nodes: [0] }],
+        nodes: [{ name: 'Podium' }]
+    })
+)}`;
 
 /**
  * getEntity and resolveEntity resolve references against the DOM (through findEntityElement), so
@@ -78,6 +90,20 @@ describe('entity references', () => {
             const { app } = await bootApp(`<pc-entity name='say "hi"'></pc-entity>`);
             expect(getEntity('say "hi"')).toBe(app.root.findByName('say "hi"'));
         });
+
+        it('resolves the name of a pc-model and of a bound pc-node', async () => {
+            const { get } = await bootApp(`
+                <pc-asset id="stage" type="container" src="${STAGE_SRC}"></pc-asset>
+                <pc-model name="Rig" asset="stage">
+                    <pc-node name="Podium"></pc-node>
+                </pc-model>
+            `);
+
+            // Names resolve to any entity-fronting element, not just pc-entity - what lets a
+            // joint reference a model's own skeleton nodes by name.
+            expect(getEntity('Rig')).toBe(get<ModelElement>('pc-model').entity);
+            expect(getEntity('Podium')).toBe(get<NodeElement>('pc-node').entity);
+        });
     });
 
     describe('resolveEntity', () => {
@@ -135,6 +161,31 @@ describe('entity references', () => {
                 "pc-test could not resolve target '#plain' - <div> matches it but cannot back an entity - " +
                     'reference ignored. Point target at a pc-entity instead.'
             );
+        });
+
+        it('warns with the timing cause for a pc-node matched by name before it binds', async () => {
+            const { get } = await bootApp(`
+                <pc-asset id="stage" type="container" src="${STAGE_SRC}"></pc-asset>
+                <pc-model asset="stage"></pc-model>
+            `);
+
+            // A node name the model does not contain: the element exists but never backs an
+            // entity - to a name reference, the same state a pc-node presents until its
+            // container asset loads.
+            const ghost = document.createElement('pc-node');
+            ghost.setAttribute('name', 'Ghost');
+            get<ModelElement>('pc-model').appendChild(ghost);
+            try {
+                warnings.expect("pc-node 'Ghost' not found in");
+
+                expect(resolveEntity('Ghost', caller(), 'target', 'reference ignored')).toBeNull();
+                warnings.expect(
+                    "pc-test could not resolve target 'Ghost' - <pc-node> matches it but is not backing " +
+                        'an entity yet - reference ignored. Assign target again once the entity exists.'
+                );
+            } finally {
+                ghost.remove();
+            }
         });
 
         it('warns rather than throwing for a reference the fallback selector cannot parse', async () => {
@@ -276,6 +327,22 @@ describe('entity references', () => {
             // absorb the invalid selector rather than throw.
             expect(resolveEntity('bad\nname', get('pc-test'), 'target', 'reference ignored')).toBeNull();
             warnings.expect("pc-test could not resolve target 'bad\nname' - nothing in the document matches it");
+        });
+
+        it('scopes a name to a nearer pc-node ahead of a farther pc-entity', async () => {
+            const { get } = await bootApp(`
+                <pc-asset id="stage" type="container" src="${STAGE_SRC}"></pc-asset>
+                <pc-entity name="Podium"></pc-entity>
+                <pc-model asset="stage">
+                    <pc-node name="Podium"></pc-node>
+                    <pc-test></pc-test>
+                </pc-model>
+            `);
+
+            // Every entity-fronting kind participates in the lexical phase: from inside the
+            // model, its own node wins over the document-first pc-entity.
+            expect(getEntity('Podium', get('pc-test'))).toBe(get<NodeElement>('pc-node').entity);
+            expect(getEntity('Podium')).toBe(get<EntityElement>('pc-entity[name="Podium"]').entity);
         });
 
         it('resolves a name the scoped selector must escape', async () => {


### PR DESCRIPTION
The follow-up #429 anticipated and #430 was built to compose with: a bare name now matches any entity-fronting element — `pc-entity`, `pc-model` or `pc-node` (for a node, the glTF node name it binds) — in both the lexical scoped phase and the document-wide fallback, which previously queried `pc-entity` alone. Selector and id references are untouched, and every warning string is byte-identical.

## Why

The ragdoll pattern — physics decorating a model's own skeleton nodes via `pc-node` — could only be wired with `#id` references, which are document-wide and duplicate per clone, so it could never live inside a cloneable `<template>`. With names reaching `pc-node`, a joint nested under a node resolves that node **within its own clone**. A node matched by name before its container asset loads reports the existing "not backing an entity yet" timing cause — exactly the silent failure class that motivated the unresolved-reference warnings in the first place, now diagnosable on the name path too.

## What changed

- `findEntityElement`'s name selector widens from `pc-entity[name=...]` to the union over `pc-entity`/`pc-model`/`pc-node` (one shared constant with the scope walk). No other resolution logic changes.
- Docs widen accordingly: the reference grammar on `pc-joint`/`pc-button`/`pc-scrollbar`/`pc-scroll-view` setters, the `entity:` conversion docs, and the prefab-root rule (any single entity-fronting root now scopes a prefab). The stale ar-wiener-storm comment about bare names reaching `pc-entity` only is replaced with the real reason for its nesting.

Behavior change surface: only bare names that today match nothing (or a farther element) while a `pc-model`/`pc-node` of that name exists — those now resolve to it, nearest scope first, document order within a scope. Unique names keep resolving identically; the fallback's selector→id→name precedence is unchanged.

## The example (second commit)

The AR Wiener Storm template becomes the ragdoll pattern, per clone: the root `pc-model` instantiates the skinned wiener while `pc-node` children decorate the model's own `B0`–`B5` skin bones with the capsule bodies and five 6dof flex joints, wired by bare names. Physics drives the bones, so the skinned mesh follows by itself — the per-frame bone riding, the rest-pose offset capture, the separate render instantiation, and the per-clone position rewrites are all deleted (the model scale carries the bone spread and the junction-anchored joint frames; only the capsule dimensions still need per-clone sizing, because physics ignores entity scale). Net: a fuller template, ~100 fewer script lines, and the wiener is now one self-contained declarative prefab.

Verified live in the browser (`?sim`, free-running): five concurrent clones with every joint bound to its own clone's bones and none cross-bound, all constraints created and holding the chain at authored spacing × each clone's random scale, skins bending with impacts, exactly one hit-or-miss outcome per wiener (23 hits + 1 miss from 30 thrown over 10 s), and DOM clones, engine entities and the script's live list in lockstep.

## Test plan

- `get-entity.test.ts`: a name resolves a `pc-model` and a bound `pc-node`; an unbound `pc-node` matched by name warns with the verbatim timing cause; scoped, a nearer `pc-node` beats a farther same-named `pc-entity` (with the unscoped document-order control).
- `joint-component.test.ts`: the motivating case end-to-end — a joint nested under a `pc-node` referencing that node by bare name resolves once it binds (the exact markup shape from the original silent-failure report, now working without ids).
- Full suite: 1039 tests across 49 files; lint, type-check and build (CEM validation) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
