### PR TITLE
Make entity references unambiguous: ids are written #id

### DIFF
--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -129,8 +129,8 @@ class ButtonComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (CSS selector, element id, or name of a `pc-entity`, `pc-model` or
-     * `pc-node`) to the entity whose image element is used for visual transitions. An exact name
+     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#id` or
+     * CSS selector) to the entity whose image element is used for visual transitions. An exact name
      * resolves against the nearest enclosing entity first, then outward, then the document.
      * Defaults to the button's own entity — inside a `<pc-model>`, that is the model's host
      * entity, so supply an explicit reference to target a UI entity instead. A non-empty

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -129,8 +129,8 @@ class ButtonComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#id` or
-     * CSS selector) to the entity whose image element is used for visual transitions. An exact name
+     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#`
+     * selector) to the entity whose image element is used for visual transitions. An exact name
      * resolves against the nearest enclosing entity first, then outward, then the document.
      * Defaults to the button's own entity — inside a `<pc-model>`, that is the model's host
      * entity, so supply an explicit reference to target a UI entity instead. A non-empty
@@ -148,7 +148,9 @@ class ButtonComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the reference to the `<pc-entity>` whose image element is used for visual transitions.
+     * Gets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#`
+     * selector) to the entity whose image element is used for visual transitions, or empty for
+     * the button's own entity.
      * @returns The image entity reference.
      */
     get image() {

--- a/src/components/joint-component.ts
+++ b/src/components/joint-component.ts
@@ -26,11 +26,11 @@ export type MotionMode = 'locked' | 'limited' | 'free';
  * about it. The constrained bodies are referenced by `entity-a` and `entity-b`, both of which need
  * a rigid body component; leaving `entity-b` empty constrains `entity-a` to a fixed point in world
  * space. A reference can name any entity-fronting element — `<pc-entity>`, `<pc-model>` or
- * `<pc-node>`, so a ragdoll can join a model's own skeleton nodes by name — and an exact name
- * resolves against the nearest enclosing entity first, then outward through the entity hierarchy,
- * then the document. A `<template>` prefab with one entity-fronting root can therefore wire its
- * joints by name and stay self-contained when cloned. The underlying engine component is in
- * alpha, so its API may change.
+ * `<pc-node>`, so a ragdoll can join a model's own skeleton nodes by name — and a name resolves
+ * against the nearest enclosing entity first, then outward through the entity hierarchy, then the
+ * document, while a `#id` or CSS selector resolves document-wide. A `<template>` prefab with one
+ * entity-fronting root can therefore wire its joints by name and stay self-contained when cloned.
+ * The underlying engine component is in alpha, so its API may change.
  *
  * @elementSummary The `<pc-joint>` element constrains two rigid bodies to each other — a hinged
  * door, a swinging chain, a sliding drawer. Its entity's transform is the joint frame, and
@@ -500,8 +500,8 @@ class JointComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (CSS selector, element id, or name of a `pc-entity`, `pc-model` or
-     * `pc-node`) to the element providing the first constrained body. An exact name resolves
+     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#id` or
+     * CSS selector) to the element providing the first constrained body. An exact name resolves
      * against the nearest enclosing entity first, then outward, then the document. The reference
      * resolves when it is set, so an entity created later is picked up by setting the attribute
      * again. A non-empty reference that does not resolve warns, naming which of the two causes it
@@ -524,8 +524,8 @@ class JointComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (CSS selector, element id, or name of a `pc-entity`, `pc-model` or
-     * `pc-node`) to the element providing the second constrained body, or empty to constrain the
+     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#id` or
+     * CSS selector) to the element providing the second constrained body, or empty to constrain the
      * first body to a fixed point in world space. An exact name resolves against the nearest
      * enclosing entity first, then outward, then the document. The reference resolves when it is
      * set, so an entity created later is picked up by setting the attribute again. A non-empty

--- a/src/components/joint-component.ts
+++ b/src/components/joint-component.ts
@@ -28,7 +28,7 @@ export type MotionMode = 'locked' | 'limited' | 'free';
  * space. A reference can name any entity-fronting element — `<pc-entity>`, `<pc-model>` or
  * `<pc-node>`, so a ragdoll can join a model's own skeleton nodes by name — and a name resolves
  * against the nearest enclosing entity first, then outward through the entity hierarchy, then the
- * document, while a `#id` or CSS selector resolves document-wide. A `<template>` prefab with one
+ * document, while a `#` selector resolves document-wide. A `<template>` prefab with one
  * entity-fronting root can therefore wire its joints by name and stay self-contained when cloned.
  * The underlying engine component is in alpha, so its API may change.
  *
@@ -500,8 +500,8 @@ class JointComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#id` or
-     * CSS selector) to the element providing the first constrained body. An exact name resolves
+     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#`
+     * selector) to the element providing the first constrained body. An exact name resolves
      * against the nearest enclosing entity first, then outward, then the document. The reference
      * resolves when it is set, so an entity created later is picked up by setting the attribute
      * again. A non-empty reference that does not resolve warns, naming which of the two causes it
@@ -516,7 +516,8 @@ class JointComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the reference to the `<pc-entity>` providing the first constrained body.
+     * Gets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#`
+     * selector) to the element providing the first constrained body.
      * @returns The first body's entity reference.
      */
     get entityA() {
@@ -524,8 +525,8 @@ class JointComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#id` or
-     * CSS selector) to the element providing the second constrained body, or empty to constrain the
+     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#`
+     * selector) to the element providing the second constrained body, or empty to constrain the
      * first body to a fixed point in world space. An exact name resolves against the nearest
      * enclosing entity first, then outward, then the document. The reference resolves when it is
      * set, so an entity created later is picked up by setting the attribute again. A non-empty
@@ -541,7 +542,9 @@ class JointComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the reference to the `<pc-entity>` providing the second constrained body.
+     * Gets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#`
+     * selector) to the element providing the second constrained body, or empty for the
+     * world-space case.
      * @returns The second body's entity reference.
      */
     get entityB() {

--- a/src/components/script-component.ts
+++ b/src/components/script-component.ts
@@ -132,9 +132,9 @@ const assetConversion: Conversion = (rest, raw) => {
 
 /**
  * Resolves an `entity:` prefix to the Entity backing a `pc-entity`, `pc-model` or `pc-node`
- * element. The reference can be a CSS selector, an element id or a name — an exact name resolves
- * against the nearest enclosing entity first, then outward, then the document. The failure
- * warning names which of the three causes ({@link unresolvedCause}) it hit.
+ * element. The reference is a name — resolved against the nearest enclosing entity first, then
+ * outward, then the document — or a document-wide `#id` or CSS selector. The failure warning
+ * names which of the three causes ({@link unresolvedCause}) it hit.
  * @param rest - The entity reference.
  * @param raw - The raw value, returned unchanged when the reference does not resolve.
  * @param from - The element the value is declared under, which scopes the reference.
@@ -145,9 +145,14 @@ const entityConversion: Conversion = (rest, raw, from) => {
     if (entity) {
         return entity;
     }
-    console.warn(
-        `Unable to resolve '${raw}' in script attributes - ${unresolvedCause(findEntityElement(rest, from))}.`
-    );
+    const element = findEntityElement(rest, from);
+    // A bare reference that names nothing but matches an element id was almost certainly meant
+    // as an id - point at the form that expresses it.
+    const hint =
+        !element && !rest.startsWith('#') && document.getElementById(rest)
+            ? ` A bare reference is a name - write 'entity:#${rest}' to reference the element with that id.`
+            : '';
+    console.warn(`Unable to resolve '${raw}' in script attributes - ${unresolvedCause(element)}.${hint}`);
     return raw;
 };
 
@@ -307,8 +312,8 @@ class ScriptComponentElement extends ComponentElement {
      * Recursively converts raw attribute data into proper PlayCanvas types. Supported conversions:
      * - "asset:id" → the Asset created by the `pc-asset` element with that id
      * - "entity:ref" → the Entity backing a `pc-entity`, `pc-model` or `pc-node` element. The
-     *   reference can be a CSS selector, an element id or a name; an exact name resolves against
-     *   this element's nearest enclosing entity first, then outward, then the document.
+     *   reference is a name, resolved against this element's nearest enclosing entity first,
+     *   then outward, then the document — or a document-wide `#id` or CSS selector.
      * - "vec2:1 2" → new Vec2(1, 2)
      * - "vec3:1 2 3" → new Vec3(1, 2, 3)
      * - "vec4:1 2 3 4" → new Vec4(1, 2, 3, 4)

--- a/src/components/script-component.ts
+++ b/src/components/script-component.ts
@@ -5,6 +5,7 @@ import { useAsset } from '../asset';
 import {
     findEntityElement,
     getEntity,
+    idHint,
     parseBool,
     parseColor,
     parseComponents,
@@ -133,8 +134,8 @@ const assetConversion: Conversion = (rest, raw) => {
 /**
  * Resolves an `entity:` prefix to the Entity backing a `pc-entity`, `pc-model` or `pc-node`
  * element. The reference is a name — resolved against the nearest enclosing entity first, then
- * outward, then the document — or a document-wide `#id` or CSS selector. The failure warning
- * names which of the three causes ({@link unresolvedCause}) it hit.
+ * outward, then the document — or a document-wide `#` selector. The failure warning names which
+ * of the three causes ({@link unresolvedCause}) it hit.
  * @param rest - The entity reference.
  * @param raw - The raw value, returned unchanged when the reference does not resolve.
  * @param from - The element the value is declared under, which scopes the reference.
@@ -146,13 +147,10 @@ const entityConversion: Conversion = (rest, raw, from) => {
         return entity;
     }
     const element = findEntityElement(rest, from);
-    // A bare reference that names nothing but matches an element id was almost certainly meant
-    // as an id - point at the form that expresses it.
-    const hint =
-        !element && !rest.startsWith('#') && document.getElementById(rest)
-            ? ` A bare reference is a name - write 'entity:#${rest}' to reference the element with that id.`
-            : '';
-    console.warn(`Unable to resolve '${raw}' in script attributes - ${unresolvedCause(element)}.${hint}`);
+    const hint = element ? '' : idHint(rest, 'entity:');
+    console.warn(
+        `Unable to resolve '${raw}' in script attributes - ${unresolvedCause(element)}.${hint ? ` ${hint}` : ''}`
+    );
     return raw;
 };
 
@@ -313,7 +311,8 @@ class ScriptComponentElement extends ComponentElement {
      * - "asset:id" → the Asset created by the `pc-asset` element with that id
      * - "entity:ref" → the Entity backing a `pc-entity`, `pc-model` or `pc-node` element. The
      *   reference is a name, resolved against this element's nearest enclosing entity first,
-     *   then outward, then the document — or a document-wide `#id` or CSS selector.
+     *   then outward, then the document — or a document-wide `#` selector (`entity:#id`). A bare
+     *   value is always a name, never an id.
      * - "vec2:1 2" → new Vec2(1, 2)
      * - "vec3:1 2 3" → new Vec3(1, 2, 3)
      * - "vec4:1 2 3 4" → new Vec4(1, 2, 3, 4)

--- a/src/components/script-instance.ts
+++ b/src/components/script-instance.ts
@@ -15,8 +15,9 @@ import { parseBool } from '../parse';
  *   Values are parsed according to the type of the attribute's current value — initially the
  *   script's declared default (numbers, booleans, strings, Vec2/3/4, Color, Quat as Euler
  *   angles) — and the `asset:`/`entity:`/`vec2:`/`vec3:`/`vec4:`/`color:` prefixes may be used
- *   to be explicit. An `entity:` reference naming an exact entity name resolves against the
- *   nearest enclosing entity first, then outward, then the document.
+ *   to be explicit. An `entity:` reference is an entity name — resolved against the nearest
+ *   enclosing entity first, then outward, then the document — or a document-wide `#` selector
+ *   (`entity:#id`); a bare value is always a name, never an element id.
  * - **The `attributes` JSON attribute**: an object supporting nested structures and attribute
  *   names that collide with reserved HTML attribute names (e.g. `title`).
  *
@@ -55,8 +56,9 @@ class ScriptInstanceElement extends AsyncElement {
     /**
      * Sets the attributes of the script as an object. Values are converted with the same rules
      * as the `attributes` attribute: `asset:`/`entity:` references and `vec2:`/`vec3:`/`vec4:`/
-     * `color:` prefixed strings are resolved (an exact entity name against the nearest enclosing
-     * entity first, then outward, then the document), and a plain numeric array is converted to
+     * `color:` prefixed strings are resolved (an entity name against the nearest enclosing
+     * entity first, then outward, then the document — or a document-wide `#` selector; a bare
+     * value is always a name, never an element id), and a plain numeric array is converted to
      * the type of the attribute it targets when that attribute currently holds a Vec2, Vec3,
      * Vec4 or Color.
      * @param value - The attributes of the script.

--- a/src/components/script-instance.ts
+++ b/src/components/script-instance.ts
@@ -33,7 +33,8 @@ import { parseBool } from '../parse';
  *
  * @elementSummary The `<pc-script-instance>` element attaches one script class, named by `name`, to
  * the entity of its parent `<pc-script>`. Its other attributes set script attributes of the same
- * name, and `attributes` takes a JSON object instead. Must be a direct child of `<pc-script>`.
+ * name, and `attributes` takes a JSON object instead. An `entity:` value is an entity name —
+ * write `entity:#id` for an element id. Must be a direct child of `<pc-script>`.
  *
  * @fires {CustomEvent} scriptattributeschange - Fired when the script's attributes change. The
  * `detail` carries the new `attributes` object. Bubbles.
@@ -74,7 +75,10 @@ class ScriptInstanceElement extends AsyncElement {
     }
 
     /**
-     * Gets the attributes of the script.
+     * Gets the attributes of the script as an object whose `asset:`, `entity:`, `vec2:`, `vec3:`,
+     * `vec4:` and `color:` prefixed values are resolved when applied — an `entity:` value being
+     * an entity name (nearest enclosing entity first, then outward, then the document) or a
+     * document-wide `#` selector (`entity:#id`), never a bare element id.
      * @returns The attributes of the script.
      */
     get scriptAttributes(): Record<string, any> {

--- a/src/components/scroll-view-component.ts
+++ b/src/components/scroll-view-component.ts
@@ -294,8 +294,8 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (CSS selector, element id, or name of a `pc-entity`, `pc-model` or
-     * `pc-node`) to the entity used as the viewport, which clips the content to the scroll view's
+     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#id` or
+     * CSS selector) to the entity used as the viewport, which clips the content to the scroll view's
      * bounds. An exact name resolves against the nearest enclosing entity first, then outward,
      * then the document. A non-empty reference that does not resolve warns and is ignored.
      * @param value - The viewport entity reference.
@@ -319,8 +319,8 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (CSS selector, element id, or name of a `pc-entity`, `pc-model` or
-     * `pc-node`) to the entity used as the content, which is moved as the scroll view is
+     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#id` or
+     * CSS selector) to the entity used as the content, which is moved as the scroll view is
      * scrolled. An exact name resolves against the nearest enclosing entity first, then outward,
      * then the document. A non-empty reference that does not resolve warns and is ignored.
      * @param value - The content entity reference.
@@ -344,8 +344,8 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (CSS selector, element id, or name of a `pc-entity`, `pc-model` or
-     * `pc-node`) to the entity containing the horizontal `<pc-scrollbar>`. An exact name resolves
+     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#id` or
+     * CSS selector) to the entity containing the horizontal `<pc-scrollbar>`. An exact name resolves
      * against the nearest enclosing entity first, then outward, then the document. A non-empty
      * reference that does not resolve warns and is ignored.
      * @param value - The horizontal scrollbar entity reference.
@@ -369,8 +369,8 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (CSS selector, element id, or name of a `pc-entity`, `pc-model` or
-     * `pc-node`) to the entity containing the vertical `<pc-scrollbar>`. An exact name resolves
+     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#id` or
+     * CSS selector) to the entity containing the vertical `<pc-scrollbar>`. An exact name resolves
      * against the nearest enclosing entity first, then outward, then the document. A non-empty
      * reference that does not resolve warns and is ignored.
      * @param value - The vertical scrollbar entity reference.

--- a/src/components/scroll-view-component.ts
+++ b/src/components/scroll-view-component.ts
@@ -294,8 +294,8 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#id` or
-     * CSS selector) to the entity used as the viewport, which clips the content to the scroll view's
+     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#`
+     * selector) to the entity used as the viewport, which clips the content to the scroll view's
      * bounds. An exact name resolves against the nearest enclosing entity first, then outward,
      * then the document. A non-empty reference that does not resolve warns and is ignored.
      * @param value - The viewport entity reference.
@@ -311,7 +311,8 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the reference to the `<pc-entity>` used as the viewport.
+     * Gets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#`
+     * selector) to the entity used as the viewport.
      * @returns The viewport entity reference.
      */
     get viewport() {
@@ -319,8 +320,8 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#id` or
-     * CSS selector) to the entity used as the content, which is moved as the scroll view is
+     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#`
+     * selector) to the entity used as the content, which is moved as the scroll view is
      * scrolled. An exact name resolves against the nearest enclosing entity first, then outward,
      * then the document. A non-empty reference that does not resolve warns and is ignored.
      * @param value - The content entity reference.
@@ -336,7 +337,8 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the reference to the `<pc-entity>` used as the content.
+     * Gets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#`
+     * selector) to the entity used as the content.
      * @returns The content entity reference.
      */
     get content() {
@@ -344,8 +346,8 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#id` or
-     * CSS selector) to the entity containing the horizontal `<pc-scrollbar>`. An exact name resolves
+     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#`
+     * selector) to the entity containing the horizontal `<pc-scrollbar>`. An exact name resolves
      * against the nearest enclosing entity first, then outward, then the document. A non-empty
      * reference that does not resolve warns and is ignored.
      * @param value - The horizontal scrollbar entity reference.
@@ -361,7 +363,8 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the reference to the `<pc-entity>` containing the horizontal scrollbar.
+     * Gets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#`
+     * selector) to the entity containing the horizontal scrollbar.
      * @returns The horizontal scrollbar entity reference.
      */
     get horizontalScrollbar() {
@@ -369,8 +372,8 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#id` or
-     * CSS selector) to the entity containing the vertical `<pc-scrollbar>`. An exact name resolves
+     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#`
+     * selector) to the entity containing the vertical `<pc-scrollbar>`. An exact name resolves
      * against the nearest enclosing entity first, then outward, then the document. A non-empty
      * reference that does not resolve warns and is ignored.
      * @param value - The vertical scrollbar entity reference.
@@ -386,7 +389,8 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the reference to the `<pc-entity>` containing the vertical scrollbar.
+     * Gets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#`
+     * selector) to the entity containing the vertical scrollbar.
      * @returns The vertical scrollbar entity reference.
      */
     get verticalScrollbar() {

--- a/src/components/scrollbar-component.ts
+++ b/src/components/scrollbar-component.ts
@@ -120,8 +120,8 @@ class ScrollbarComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (CSS selector, element id, or name of a `pc-entity`, `pc-model` or
-     * `pc-node`) to the entity used as the scrollbar handle. An exact name resolves against the
+     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#id` or
+     * CSS selector) to the entity used as the scrollbar handle. An exact name resolves against the
      * nearest enclosing entity first, then outward, then the document. A non-empty reference that
      * does not resolve warns and is ignored.
      * @param value - The handle entity reference.

--- a/src/components/scrollbar-component.ts
+++ b/src/components/scrollbar-component.ts
@@ -120,8 +120,8 @@ class ScrollbarComponentElement extends ComponentElement {
     }
 
     /**
-     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#id` or
-     * CSS selector) to the entity used as the scrollbar handle. An exact name resolves against the
+     * Sets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#`
+     * selector) to the entity used as the scrollbar handle. An exact name resolves against the
      * nearest enclosing entity first, then outward, then the document. A non-empty reference that
      * does not resolve warns and is ignored.
      * @param value - The handle entity reference.
@@ -137,7 +137,8 @@ class ScrollbarComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the reference to the `<pc-entity>` used as the scrollbar handle.
+     * Gets the reference (a `pc-entity`, `pc-model` or `pc-node` name, or a document-wide `#`
+     * selector) to the entity used as the scrollbar handle.
      * @returns The handle entity reference.
      */
     get handle() {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -13,11 +13,12 @@
  *   so they never warn.
  *
  * `findEntityElement` and `getEntity` are the exceptions: they resolve a reference rather than
- * parsing a literal, and return `null` instead of falling back to a default. An exact entity-name
- * match resolves lexically through the entity hierarchy first; otherwise the reference is
- * interpreted against the document as a CSS selector, element id or entity name. They also do not
- * warn - what an unresolved reference means depends on the element holding it - so elements
- * report through `resolveEntity`, which takes that meaning as parameters.
+ * parsing a literal, and return `null` instead of falling back to a default. A reference
+ * beginning with `#` is a document-wide element id; anything else is an entity name, resolved
+ * lexically through the entity hierarchy first and against the document after, with explicitly
+ * written CSS selectors as the document-wide last interpretation. They also do not warn - what
+ * an unresolved reference means depends on the element holding it - so elements report through
+ * `resolveEntity`, which takes that meaning as parameters.
  */
 
 import type { Entity } from 'playcanvas';
@@ -384,17 +385,23 @@ const ENTITY_KINDS = ['pc-entity', 'pc-model', 'pc-node'] as const;
 const ENTITY_SCOPES = ENTITY_KINDS.join(', ');
 
 /**
- * Resolves a reference string to the element it names. The reference can be a CSS selector (e.g.
- * `#my-id`, `pc-entity[name="Foo"]`), a bare element id, or the bare name of an entity-fronting
- * element (`<pc-entity>`, `<pc-model>` or `<pc-node>` — for a node, the glTF node name it binds).
+ * Resolves a reference string to the element it names. The grammar is unambiguous about which
+ * form a reference takes:
  *
- * When `from` is supplied, an exact name match resolves lexically first: the closest
- * entity-fronting ancestor's inclusive subtree, then each outer entity-fronting ancestor, then the
- * containing `<pc-app>`. This is what lets a `<template>` prefab reference its own entities by
- * name — every clone resolves within itself before the document-wide lookup below could reach an
- * earlier clone — provided the prefab has a single entity-fronting root to be the enclosing scope.
- * Otherwise (and as the fallback) the reference is interpreted against the document as a CSS
- * selector, then an element id, then a name.
+ * - A reference beginning with `#` is an element id (or any id-rooted CSS selector), resolved
+ *   document-wide. It is authoritative: the name lookup never runs for it, so an unusually named
+ *   entity cannot shadow it.
+ * - Any other reference is the name of an entity-fronting element (`<pc-entity>`, `<pc-model>` or
+ *   `<pc-node>` — for a node, the glTF node name it binds), falling back to interpretation as a
+ *   document-wide CSS selector for explicitly written selectors (e.g. `pc-entity[name="Foo"]`).
+ *   A bare reference never resolves an element id — write `#id` for that.
+ *
+ * When `from` is supplied, a name resolves lexically first: the closest entity-fronting
+ * ancestor's inclusive subtree, then each outer entity-fronting ancestor, then the containing
+ * `<pc-app>`, then the document. This is what lets a `<template>` prefab reference its own
+ * entities by name — every clone resolves within itself before a document-wide lookup could reach
+ * an earlier clone — provided the prefab has a single entity-fronting root to be the enclosing
+ * scope.
  *
  * Separate from {@link getEntity} so a caller reporting a failure can tell the causes apart
  * ({@link unresolvedCause} words them): nothing in the document matches the reference, or
@@ -402,13 +409,19 @@ const ENTITY_SCOPES = ENTITY_KINDS.join(', ');
  *
  * @param ref - The reference string to resolve.
  * @param from - The element resolving the reference, whose entity-fronting ancestors scope the
- * name lookup. Omitted, the lookup is document-wide only.
+ * name lookup. Omitted, the name lookup is document-wide only.
  * @returns The matched element, or `null`.
  * @internal
  */
 export const findEntityElement = (ref: string, from?: Element): Element | null => {
     if (!ref) {
         return null;
+    }
+
+    // An explicit id reference is document-wide and bypasses the name lookup entirely - an
+    // entity named '#body' must never shadow the element whose id is 'body'.
+    if (ref.startsWith('#')) {
+        return query(ref);
     }
 
     // The name lands inside a quoted CSS string, so its quotes and backslashes are escaped -
@@ -435,28 +448,22 @@ export const findEntityElement = (ref: string, from?: Element): Element | null =
         }
     }
 
-    // Try the reference as a CSS selector. An invalid selector (e.g. a bare name containing
-    // spaces) falls through to the id/name lookups below.
-    let element = query(ref);
-
-    if (!element) {
-        element = document.getElementById(ref) ?? query(nameSelector);
-    }
-
-    return element;
+    // Document-wide fallback: the name first - a bare reference denotes a name, never an element
+    // id - then the reference as an explicitly written CSS selector. An invalid selector (e.g. a
+    // name containing spaces) fails to null inside query.
+    return query(nameSelector) ?? query(ref);
 };
 
 /**
  * Resolves a reference string to the {@link Entity} backing an entity-fronting element
- * (`<pc-entity>`, `<pc-model>` or `<pc-node>`). The reference can be a CSS selector (e.g.
- * `#my-id`, `pc-entity[name="Foo"]`), a bare element id, or a bare name — an exact name match
- * resolves lexically through the entity hierarchy first when `from` is supplied
- * ({@link findEntityElement} details the order). Returns `null` if no matching element (or
- * backing entity) is found.
+ * (`<pc-entity>`, `<pc-model>` or `<pc-node>`). The reference is a name — resolved lexically
+ * through the entity hierarchy first when `from` is supplied — or a document-wide `#id` or CSS
+ * selector ({@link findEntityElement} details the grammar and order). Returns `null` if no
+ * matching element (or backing entity) is found.
  *
  * @param ref - The reference string to resolve.
  * @param from - The element resolving the reference, whose entity-fronting ancestors scope the
- * name lookup. Omitted, the lookup is document-wide only.
+ * name lookup. Omitted, the name lookup is document-wide only.
  * @returns The resolved entity, or `null`.
  * @internal
  */
@@ -511,10 +518,14 @@ export const resolveEntity = (ref: string, from: Element, attribute: string, con
     const element = findEntityElement(ref, from);
     const entity = entityOf(element);
     if (!entity) {
-        const advice =
-            element && !('entity' in element)
-                ? `Point ${attribute} at a pc-entity instead.`
-                : `Assign ${attribute} again once the entity exists.`;
+        let advice = `Assign ${attribute} again once the entity exists.`;
+        if (element && !('entity' in element)) {
+            advice = `Point ${attribute} at a pc-entity instead.`;
+        } else if (!element && !ref.startsWith('#') && document.getElementById(ref)) {
+            // A bare reference that names nothing but matches an element id was almost
+            // certainly meant as an id - point at the form that expresses it.
+            advice = `A bare reference is a name - write '#${ref}' to reference the element with that id.`;
+        }
         console.warn(
             `${from.tagName.toLowerCase()} could not resolve ${attribute} '${ref}' - ${unresolvedCause(element)} - ${consequence}. ${advice}`
         );

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -14,10 +14,10 @@
  *
  * `findEntityElement` and `getEntity` are the exceptions: they resolve a reference rather than
  * parsing a literal, and return `null` instead of falling back to a default. A reference
- * beginning with `#` is a document-wide element id; anything else is an entity name, resolved
- * lexically through the entity hierarchy first and against the document after, with explicitly
- * written CSS selectors as the document-wide last interpretation. They also do not warn - what
- * an unresolved reference means depends on the element holding it - so elements report through
+ * beginning with `#` is a document-wide selector (an element id, or any selector rooted in one);
+ * anything else is an entity name, resolved lexically through the entity hierarchy first and
+ * against the document after — never as a selector or an id. They also do not warn - what an
+ * unresolved reference means depends on the element holding it - so elements report through
  * `resolveEntity`, which takes that meaning as parameters.
  */
 
@@ -385,16 +385,16 @@ const ENTITY_KINDS = ['pc-entity', 'pc-model', 'pc-node'] as const;
 const ENTITY_SCOPES = ENTITY_KINDS.join(', ');
 
 /**
- * Resolves a reference string to the element it names. The grammar is unambiguous about which
- * form a reference takes:
+ * Resolves a reference string to the element it names. The grammar is closed — every reference
+ * has exactly one interpretation:
  *
- * - A reference beginning with `#` is an element id (or any id-rooted CSS selector), resolved
- *   document-wide. It is authoritative: the name lookup never runs for it, so an unusually named
- *   entity cannot shadow it.
+ * - A reference beginning with `#` is a document-wide CSS selector — an element id (`#body`), or
+ *   any selector rooted in one (`#hud pc-entity`). It is authoritative: the name lookup never
+ *   runs for it, so an unusually named entity cannot shadow it.
  * - Any other reference is the name of an entity-fronting element (`<pc-entity>`, `<pc-model>` or
- *   `<pc-node>` — for a node, the glTF node name it binds), falling back to interpretation as a
- *   document-wide CSS selector for explicitly written selectors (e.g. `pc-entity[name="Foo"]`).
- *   A bare reference never resolves an element id — write `#id` for that.
+ *   `<pc-node>` — for a node, the glTF node name it binds), and nothing else. A bare reference is
+ *   never interpreted as a selector or an element id, so adding or renaming elements can never
+ *   change which form it takes.
  *
  * When `from` is supplied, a name resolves lexically first: the closest entity-fronting
  * ancestor's inclusive subtree, then each outer entity-fronting ancestor, then the containing
@@ -418,8 +418,8 @@ export const findEntityElement = (ref: string, from?: Element): Element | null =
         return null;
     }
 
-    // An explicit id reference is document-wide and bypasses the name lookup entirely - an
-    // entity named '#body' must never shadow the element whose id is 'body'.
+    // A '#' reference is document-wide and bypasses the name lookup entirely - an entity named
+    // '#body' must never shadow the element whose id is 'body'.
     if (ref.startsWith('#')) {
         return query(ref);
     }
@@ -448,18 +448,15 @@ export const findEntityElement = (ref: string, from?: Element): Element | null =
         }
     }
 
-    // Document-wide fallback: the name first - a bare reference denotes a name, never an element
-    // id - then the reference as an explicitly written CSS selector. An invalid selector (e.g. a
-    // name containing spaces) fails to null inside query.
-    return query(nameSelector) ?? query(ref);
+    return query(nameSelector);
 };
 
 /**
  * Resolves a reference string to the {@link Entity} backing an entity-fronting element
  * (`<pc-entity>`, `<pc-model>` or `<pc-node>`). The reference is a name — resolved lexically
- * through the entity hierarchy first when `from` is supplied — or a document-wide `#id` or CSS
- * selector ({@link findEntityElement} details the grammar and order). Returns `null` if no
- * matching element (or backing entity) is found.
+ * through the entity hierarchy first when `from` is supplied — or a document-wide `#` selector
+ * ({@link findEntityElement} details the grammar and order). Returns `null` if no matching
+ * element (or backing entity) is found.
  *
  * @param ref - The reference string to resolve.
  * @param from - The element resolving the reference, whose entity-fronting ancestors scope the
@@ -494,6 +491,26 @@ export const unresolvedCause = (element: Element | null): string => {
 };
 
 /**
+ * Builds the migration pointer for a bare reference that names nothing but matches the id of an
+ * entity-fronting element - it was almost certainly meant as an id, so point at the form that
+ * expresses it, escaped so the suggestion actually parses as a selector (an id like `a:b` must
+ * be written `#a\:b`). Empty when the reference is already a `#` form, matches no id, or the id
+ * belongs to an element that could never back an entity - suggesting it would only trade this
+ * warning for the wrong-target one.
+ *
+ * @param ref - The unresolved reference.
+ * @param prefix - Text the suggested form must carry in the caller's syntax (e.g. `entity:`).
+ * @returns The advice sentence, or an empty string.
+ * @internal
+ */
+export const idHint = (ref: string, prefix = ''): string => {
+    const match = !ref.startsWith('#') && document.getElementById(ref);
+    return match && 'entity' in match
+        ? `A bare reference is a name - write '${prefix}#${CSS.escape(ref)}' to reference the element with that id.`
+        : '';
+};
+
+/**
  * Resolves a reference string to the {@link Entity} backing an entity-fronting element, scoped to
  * the resolving element ({@link findEntityElement} details the order) and warning when a
  * non-empty reference does not resolve - otherwise the reference fails silently, invisible
@@ -520,11 +537,12 @@ export const resolveEntity = (ref: string, from: Element, attribute: string, con
     if (!entity) {
         let advice = `Assign ${attribute} again once the entity exists.`;
         if (element && !('entity' in element)) {
-            advice = `Point ${attribute} at a pc-entity instead.`;
-        } else if (!element && !ref.startsWith('#') && document.getElementById(ref)) {
-            // A bare reference that names nothing but matches an element id was almost
-            // certainly meant as an id - point at the form that expresses it.
-            advice = `A bare reference is a name - write '#${ref}' to reference the element with that id.`;
+            advice = `Point ${attribute} at a pc-entity, pc-model or pc-node instead.`;
+        } else if (!element) {
+            const hint = idHint(ref);
+            if (hint) {
+                advice = hint;
+            }
         }
         console.warn(
             `${from.tagName.toLowerCase()} could not resolve ${attribute} '${ref}' - ${unresolvedCause(element)} - ${consequence}. ${advice}`

--- a/test/integration/components/button-component.test.ts
+++ b/test/integration/components/button-component.test.ts
@@ -23,7 +23,7 @@ describe('<pc-button>', () => {
 
         it('resolves an explicit reference', async () => {
             const { app, get } = await bootApp(`
-                <pc-entity name="btn"><pc-button image="target-id"></pc-button></pc-entity>
+                <pc-entity name="btn"><pc-button image="#target-id"></pc-button></pc-entity>
                 <pc-entity id="target-id" name="target"></pc-entity>
             `);
             const button = get<ButtonComponentElement>('pc-button');
@@ -41,7 +41,7 @@ describe('<pc-button>', () => {
 
         it('keeps the current image entity when a reassigned reference does not resolve', async () => {
             const { app, get } = await bootApp(`
-                <pc-entity name="btn"><pc-button image="target-id"></pc-button></pc-entity>
+                <pc-entity name="btn"><pc-button image="#target-id"></pc-button></pc-entity>
                 <pc-entity id="target-id" name="target"></pc-entity>
             `);
             const button = get<ButtonComponentElement>('pc-button');

--- a/test/integration/components/joint-component.test.ts
+++ b/test/integration/components/joint-component.test.ts
@@ -287,7 +287,7 @@ describe('<pc-joint>', () => {
 
             warnings.expect(
                 '<div> matches it but cannot back an entity - constraint not created. ' +
-                    'Point entity-a at a pc-entity instead.'
+                    'Point entity-a at a pc-entity, pc-model or pc-node instead.'
             );
             expect(joint.component.entityA).toBeNull();
         });

--- a/test/integration/components/joint-component.test.ts
+++ b/test/integration/components/joint-component.test.ts
@@ -245,7 +245,7 @@ describe('<pc-joint>', () => {
             );
             const joint = get<JointComponentElement>('pc-joint');
 
-            joint.setAttribute('entity-b', 'post-id');
+            joint.setAttribute('entity-b', '#post-id');
 
             expect(joint.component.entityB).toBe(app.root.findByName('post'));
         });

--- a/test/integration/components/script-component.test.ts
+++ b/test/integration/components/script-component.test.ts
@@ -163,11 +163,25 @@ describe('<pc-script>', () => {
 
         it('resolves an entity: reference to the live entity', async () => {
             const { app, script } = await bootReference(
-                'entity:target-id',
+                'entity:#target-id',
                 '<pc-entity id="target-id" name="target"></pc-entity>'
             );
 
             expect(script.target).toBe(app.root.findByName('target'));
+        });
+
+        it('suggests the #id form when a bare entity: reference only matches an element id', async () => {
+            const { script } = await bootReference(
+                'entity:plain-id',
+                '<pc-entity id="plain-id" name="Plain"></pc-entity>'
+            );
+
+            warnings.expect(
+                "Unable to resolve 'entity:plain-id' in script attributes - nothing in the document " +
+                    "matches it. A bare reference is a name - write 'entity:#plain-id' to reference " +
+                    'the element with that id.'
+            );
+            expect(script.target).toBe('entity:plain-id');
         });
 
         it('resolves an entity: reference against the enclosing scope first', async () => {

--- a/test/integration/components/scroll-view-component.test.ts
+++ b/test/integration/components/scroll-view-component.test.ts
@@ -15,8 +15,8 @@ describe('<pc-scroll-view>', () => {
     it('resolves all four entity references', async () => {
         const { app, get } = await bootApp(`
             <pc-entity name="sv">
-                <pc-scroll-view viewport="viewport-id" content="content-id"
-                    horizontal-scrollbar="h-scrollbar-id" vertical-scrollbar="v-scrollbar-id"></pc-scroll-view>
+                <pc-scroll-view viewport="#viewport-id" content="#content-id"
+                    horizontal-scrollbar="#h-scrollbar-id" vertical-scrollbar="#v-scrollbar-id"></pc-scroll-view>
                 <pc-entity id="viewport-id" name="viewport">
                     <pc-entity id="content-id" name="content"></pc-entity>
                 </pc-entity>

--- a/test/integration/components/scrollbar-component.test.ts
+++ b/test/integration/components/scrollbar-component.test.ts
@@ -16,7 +16,7 @@ describe('<pc-scrollbar>', () => {
         it('resolves the handle reference', async () => {
             const { app, get } = await bootApp(`
                 <pc-entity name="track">
-                    <pc-scrollbar handle="handle-id"></pc-scrollbar>
+                    <pc-scrollbar handle="#handle-id"></pc-scrollbar>
                     <pc-entity id="handle-id" name="handle"></pc-entity>
                 </pc-entity>
             `);
@@ -36,7 +36,7 @@ describe('<pc-scrollbar>', () => {
         it('keeps the current handle when a reassigned reference does not resolve', async () => {
             const { app, get } = await bootApp(`
                 <pc-entity name="track">
-                    <pc-scrollbar handle="handle-id"></pc-scrollbar>
+                    <pc-scrollbar handle="#handle-id"></pc-scrollbar>
                     <pc-entity id="handle-id" name="handle"></pc-entity>
                 </pc-entity>
             `);

--- a/test/integration/get-entity.test.ts
+++ b/test/integration/get-entity.test.ts
@@ -38,9 +38,18 @@ describe('entity references', () => {
             expect(getEntity('#cube-id')).toBe(app.root.findByName('Cube'));
         });
 
-        it('resolves an attribute selector', async () => {
-            const { app } = await bootApp(markup);
-            expect(getEntity('pc-entity[name="Cube"]')).toBe(app.root.findByName('Cube'));
+        it('resolves any selector written behind #, not just a bare id', async () => {
+            const { app } = await bootApp('<pc-entity id="wrap"><pc-entity name="inner"></pc-entity></pc-entity>');
+            expect(getEntity('#wrap pc-entity')).toBe(app.root.findByName('inner'));
+        });
+
+        it('never interprets a bare reference as a selector', async () => {
+            await bootApp(markup);
+            // Both are valid selectors that would match - a type selector and an attribute
+            // selector - but a bare reference is a name and nothing else, so neither can be
+            // silently retargeted by elements matching it as a selector.
+            expect(getEntity('pc-entity')).toBeNull();
+            expect(getEntity('pc-entity[name="Cube"]')).toBeNull();
         });
 
         it('does not resolve a bare reference that only matches an element id', async () => {
@@ -143,6 +152,28 @@ describe('entity references', () => {
             );
         });
 
+        it('escapes the suggested #id so it parses as a selector', async () => {
+            // getElementById accepts ids no unescaped selector can express - the suggestion must
+            // be the form that actually works in one
+            await bootApp('<pc-entity id="a:b" name="Colon"></pc-entity>');
+            expect(resolveEntity('a:b', caller(), 'target', 'reference ignored')).toBeNull();
+            warnings.expect(
+                "pc-test could not resolve target 'a:b' - nothing in the document matches it - " +
+                    "reference ignored. A bare reference is a name - write '#a\\:b' to reference " +
+                    'the element with that id.'
+            );
+        });
+
+        it('keeps the generic advice when the same-spelled id is not entity-fronting', async () => {
+            // Suggesting the # form here would only trade this warning for the wrong-target one
+            await bootApp('<div id="plain-block"></div>');
+            expect(resolveEntity('plain-block', caller(), 'target', 'reference ignored')).toBeNull();
+            warnings.expect(
+                "pc-test could not resolve target 'plain-block' - nothing in the document matches it - " +
+                    'reference ignored. Assign target again once the entity exists.'
+            );
+        });
+
         it('warns with the timing cause when the matched element is not backing an entity yet', async () => {
             await bootApp(markup);
 
@@ -170,7 +201,7 @@ describe('entity references', () => {
             expect(resolveEntity('#plain', caller(), 'target', 'reference ignored')).toBeNull();
             warnings.expect(
                 "pc-test could not resolve target '#plain' - <div> matches it but cannot back an entity - " +
-                    'reference ignored. Point target at a pc-entity instead.'
+                    'reference ignored. Point target at a pc-entity, pc-model or pc-node instead.'
             );
         });
 
@@ -282,7 +313,7 @@ describe('entity references', () => {
             expect(getEntity('dup')).toBe(far.entity);
         });
 
-        it('resolves selector and id references document-wide from inside a scope', async () => {
+        it('resolves a # reference document-wide from inside a scope', async () => {
             const { get } = await bootApp(`
                 <pc-entity name="first">
                     <pc-entity id="first-dup" name="dup"></pc-entity>
@@ -294,10 +325,8 @@ describe('entity references', () => {
             `);
             const far = get<EntityElement>('#first-dup');
 
-            // No entity is *named* the reference text, so the lexical phase misses and the
-            // document resolver interprets the reference - selectors and ids keep their
-            // document-wide meaning even from inside a scope.
-            expect(getEntity('pc-entity[name="dup"]', get('pc-test'))).toBe(far.entity);
+            // The '#' form is document-global by definition - a nearer same-named entity does
+            // not enter into it.
             expect(getEntity('#first-dup', get('pc-test'))).toBe(far.entity);
         });
 

--- a/test/integration/get-entity.test.ts
+++ b/test/integration/get-entity.test.ts
@@ -43,23 +43,22 @@ describe('entity references', () => {
             expect(getEntity('pc-entity[name="Cube"]')).toBe(app.root.findByName('Cube'));
         });
 
-        it('resolves a bare element id', async () => {
-            const { app } = await bootApp(markup);
-            expect(getEntity('cube-id')).toBe(app.root.findByName('Cube'));
+        it('does not resolve a bare reference that only matches an element id', async () => {
+            await bootApp(markup);
+            // A bare reference is a name - the element whose id is 'cube-id' is written '#cube-id'
+            expect(getEntity('cube-id')).toBeNull();
         });
 
-        it('falls back to a name lookup for a valid selector that matches nothing', async () => {
+        it('resolves a name containing a space, which no selector interpretation could', async () => {
             const { app } = await bootApp(markup);
-            // 'Spaced Name' is a *valid* descendant selector, so querySelector returns null rather
-            // than throwing, and the id/name fallback is what resolves it. This path does not
-            // exercise the try/catch - see the malformed-selector test below for that.
             expect(getEntity('Spaced Name')).toBe(app.root.findByName('Spaced Name'));
         });
 
-        it('falls back to a name lookup for a malformed selector, exercising the try/catch', async () => {
+        it('resolves a name that is itself a malformed selector', async () => {
             const { app } = await bootApp('<pc-entity name="pc-entity["></pc-entity>');
-            // An unclosed attribute selector makes querySelector throw, which is the only way into
-            // getEntity's catch block.
+            // The unclosed attribute selector is escaped safely into the name lookup; the raw
+            // reference would make querySelector throw, which the selector fallback absorbs
+            // (the warning tests below drive a ref through that catch).
             expect(getEntity('pc-entity[')).toBe(app.root.findByName('pc-entity['));
         });
 
@@ -78,12 +77,14 @@ describe('entity references', () => {
             expect(getEntity('#plain')).toBeNull();
         });
 
-        it('prefers an id match over a name match', async () => {
+        it('resolves a bare reference as a name even when a same-spelled id exists', async () => {
             const { app } = await bootApp(`
                 <pc-entity id="target" name="ById"></pc-entity>
                 <pc-entity name="target"></pc-entity>
             `);
-            expect(getEntity('target')).toBe(app.root.findByName('ById'));
+            // The two forms never compete: the bare spelling is the name, the '#' spelling the id
+            expect(getEntity('target')).toBe(app.root.findByName('target'));
+            expect(getEntity('#target')).toBe(app.root.findByName('ById'));
         });
 
         it('resolves a name containing a quote through the escaped fallback selector', async () => {
@@ -129,6 +130,16 @@ describe('entity references', () => {
             warnings.expect(
                 "pc-test could not resolve target '#nope' - nothing in the document matches it - " +
                     'reference ignored. Assign target again once the entity exists.'
+            );
+        });
+
+        it('suggests the #id form for a bare reference that only matches an element id', async () => {
+            await bootApp(markup);
+            expect(resolveEntity('cube-id', caller(), 'target', 'reference ignored')).toBeNull();
+            warnings.expect(
+                "pc-test could not resolve target 'cube-id' - nothing in the document matches it - " +
+                    "reference ignored. A bare reference is a name - write '#cube-id' to reference " +
+                    'the element with that id.'
             );
         });
 
@@ -260,14 +271,15 @@ describe('entity references', () => {
             }
         });
 
-        it('prefers an in-scope entity name over a document id match', async () => {
-            const { app, get } = await bootApp(`<pc-entity id="dup" name="ById"></pc-entity>${DUPLICATES}`);
+        it('resolves a bare reference as a name regardless of a same-spelled document id', async () => {
+            const { get } = await bootApp(`<pc-entity id="dup" name="ById"></pc-entity>${DUPLICATES}`);
             const near = get<EntityElement>('pc-entity[name="second"] > pc-entity[name="dup"]');
+            const far = get<EntityElement>('pc-entity[name="first"] > pc-entity[name="dup"]');
 
-            // Unscoped, the id lookup wins (pinned above); scoped, the lexical name phase runs
-            // first, so a page-level id cannot shadow a prefab's internal wiring.
-            expect(getEntity('dup')).toBe(app.root.findByName('ById'));
+            // The bare spelling is a name in both phases - the page-level id never competes, so
+            // it cannot shadow a prefab's internal wiring (nor divert the unscoped lookup).
             expect(getEntity('dup', get('pc-test'))).toBe(near.entity);
+            expect(getEntity('dup')).toBe(far.entity);
         });
 
         it('resolves selector and id references document-wide from inside a scope', async () => {
@@ -287,6 +299,20 @@ describe('entity references', () => {
             // document-wide meaning even from inside a scope.
             expect(getEntity('pc-entity[name="dup"]', get('pc-test'))).toBe(far.entity);
             expect(getEntity('#first-dup', get('pc-test'))).toBe(far.entity);
+        });
+
+        it('resolves a #id document-wide even when an in-scope entity is named like it', async () => {
+            const { get } = await bootApp(`
+                <pc-entity id="target" name="ById"></pc-entity>
+                <pc-entity name="outer">
+                    <pc-entity name="#target"></pc-entity>
+                    <pc-test></pc-test>
+                </pc-entity>
+            `);
+
+            // The '#' form is authoritative: it bypasses the name lookup entirely, so an
+            // unusually named entity can never shadow the element with that id.
+            expect(getEntity('#target', get('pc-test'))).toBe(get<EntityElement>('#target').entity);
         });
 
         it('does not skip a nearer name match that backs no entity yet', async () => {
@@ -317,7 +343,7 @@ describe('entity references', () => {
             const cube = app.root.findByName('Cube');
 
             expect(getEntity('#cube-id', get('pc-test')), 'a connected caller').toBe(cube);
-            expect(getEntity('cube-id', document.createElement('div')), 'a disconnected one').toBe(cube);
+            expect(getEntity('Cube', document.createElement('div')), 'a disconnected one').toBe(cube);
         });
 
         it('warns without throwing for a reference no CSS string can express, from inside a scope', async () => {


### PR DESCRIPTION
Fixes #432

After #430/#431 a bare reference had two possible meanings — a lexically scoped entity name, or a document-wide element id via the legacy `getElementById` fallback — so adding an in-scope entity could silently retarget a reference that previously resolved by id, and neither authors nor tooling could tell which form markup intended. The grammar is now **closed**: every reference has exactly one interpretation, and no change elsewhere in the document can flip which form it takes.

| Form | Meaning | Scope |
| --- | --- | --- |
| `body` | Entity-fronting element name — and nothing else | Lexically scoped, then document name fallback |
| `#body`, `#hud pc-entity` | Document-wide CSS selector rooted in an id | Document-wide, authoritative |

## What changed

- **The bare `getElementById` fallback is removed.** A bare value denotes a name, never an id.
- **A bare value is never interpreted as a selector either.** The old trailing `querySelector(ref)` pass meant `entity-a="pc-entity"` was the entity *named* `pc-entity` if one existed, and otherwise silently the first `<pc-entity>` via type selector — the same retargeting hazard in another spelling. Selector power now lives entirely behind `#`: any selector rooted in an id works (`#hud pc-entity`), which also closes the old trap where a name colliding with an HTML tag (`head`, `body`) matched the page element. An explicit `selector:` form can be added later, non-breakingly, if arbitrary un-rooted selectors ever prove needed.
- **`#...` references bypass the name lookup entirely** — resolved document-wide before any scoped phase runs, so an unusually named entity (`name="#body"`) can never shadow the element whose id is `body`.
- **Migration pointer, correct by construction:** a bare reference that names nothing but matches the id of an *entity-fronting* element warns with the escaped replacement to write — `write '#a\:b' to reference the element with that id` (`CSS.escape`, so the suggestion actually parses as a selector; `getElementById` accepts ids no unescaped selector can express). A same-spelled id on a non-entity element keeps the generic advice — suggesting `#` there would only trade this warning for the wrong-target one. The `entity:` script surface shares the helper and suggests the prefixed spelling (`entity:#id`).
- **The grammar reaches the published metadata.** The CEM analyzer sources member descriptions from getters, so the eight reference getters now carry the same grammar parenthetical as their setters — verified in the rebuilt `custom-elements.json` and `vscode.html-custom-data.json`. `pc-script-instance`'s class and `scriptAttributes` docs state the id rule for `entity:` values, and the wrong-target advice names all three entity-fronting kinds (`Point x at a pc-entity, pc-model or pc-node instead.`).

## Compatibility

Pre-1.0 hard change, per the issue's preference. Markup relying on a bare id stops resolving and warns with the exact replacement to write; markup relying on bare selector interpretation stops resolving with the standard diagnostics. All shipped examples were audited for both: every reference is a name or a `#id` — nothing relied on either removed fallback. The repo's own fixtures that used bare ids (button/scrollbar/scroll-view/joint/script suites) migrated to `#id`, keeping the id form covered through every element.

## Tests

Following the issue's list, plus the closure pins:
- a bare value resolves a scoped name and never falls through to a same-spelled id (scoped and unscoped; the old id-over-name precedence pin is inverted into the new contract);
- a bare value matching only an element id does not resolve, and **a bare value is never interpreted as a selector** — `pc-entity` and `pc-entity[name="Cube"]` resolve nothing even with matching elements present;
- `#id` resolves the document element, is not shadowed by an in-scope entity literally named `#id`, stays document-wide from inside a scope, and **any `#`-rooted compound selector works** (`#wrap pc-entity`);
- the unresolved bare-id diagnostic suggests the hash form — pinned verbatim for `resolveEntity` and `entity:` script attributes, including the **escaped** suggestion for an id like `a:b` and the **non-entity id** case keeping generic advice;
- names containing spaces, names that are malformed selectors, and the newline/timing/wrong-target diagnostics keep their behavior.

Full suite: 1045 tests across 49 files; lint, type-check and build (CEM validation) clean. Live smoke of the AR Wiener Storm example (`?sim`): clones still self-wire by name with zero resolution warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
