### PR TITLE
Make ComponentElement generic and preserve component nullability

### DIFF
--- a/custom-elements-manifest.config.mjs
+++ b/custom-elements-manifest.config.mjs
@@ -3,6 +3,7 @@ import { customElementVsCodePlugin } from 'custom-element-vs-code-integration';
 
 import { attributesFromCallbackPlugin } from './utils/cem/attributes-plugin.mjs';
 import { manifestCleanupPlugin } from './utils/cem/cleanup-plugin.mjs';
+import { componentTypePlugin } from './utils/cem/component-type-plugin.mjs';
 import { elementSummaryPlugin } from './utils/cem/summary-plugin.mjs';
 
 /**
@@ -33,6 +34,10 @@ export default {
     plugins: [
         // Derives attribute metadata from each element's attributeChangedCallback
         attributesFromCallbackPlugin(),
+
+        // Restores each element's concrete `component` type, which the analyzer's inheritance
+        // step overwrites with the generic base's literal `T | null`
+        componentTypePlugin(),
 
         // Publishes each element's `@elementSummary` as its `summary`
         elementSummaryPlugin(),

--- a/src/components/anim-component.ts
+++ b/src/components/anim-component.ts
@@ -55,7 +55,7 @@ type PlaybackState = {
  *
  * @category Components
  */
-class AnimComponentElement extends ComponentElement {
+class AnimComponentElement extends ComponentElement<AnimComponent> {
     /**
      * Whether playback starts automatically once a clip is assigned.
      */
@@ -168,6 +168,9 @@ class AnimComponentElement extends ComponentElement {
      */
     private _applyRootBone() {
         const component = this.component;
+        if (!component) {
+            return;
+        }
 
         // A non-null root this element did not assign came through the engine API. A fresh
         // component starts at null, which is always reclaimable.
@@ -252,7 +255,7 @@ class AnimComponentElement extends ComponentElement {
      * declared `clip` selection can apply before any asset has loaded.
      */
     private _assignClip(clip: AnimClipElement) {
-        this.component.assignAnimation(clip.name, clip._track ?? AnimTrack.EMPTY, undefined, clip.speed, clip.loop);
+        this.component?.assignAnimation(clip.name, clip._track ?? AnimTrack.EMPTY, undefined, clip.speed, clip.loop);
     }
 
     /**
@@ -586,11 +589,12 @@ class AnimComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the underlying PlayCanvas anim component.
-     * @returns The anim component.
+     * Gets the underlying PlayCanvas anim component. `null` until the element is
+     * ready — see {@link ComponentElement.component}.
+     * @returns The anim component, or `null`.
      */
-    get component(): AnimComponent {
-        return super.component as AnimComponent;
+    get component(): AnimComponent | null {
+        return super.component;
     }
 
     /**

--- a/src/components/audio-listener-component.ts
+++ b/src/components/audio-listener-component.ts
@@ -16,18 +16,19 @@ import { ComponentElement } from './component';
  *
  * @category Components
  */
-class AudioListenerComponentElement extends ComponentElement {
+class AudioListenerComponentElement extends ComponentElement<AudioListenerComponent> {
     /** @ignore */
     constructor() {
         super('audiolistener');
     }
 
     /**
-     * Gets the underlying PlayCanvas audio listener component.
-     * @returns The audio listener component.
+     * Gets the underlying PlayCanvas audio listener component. `null` until the element is
+     * ready — see {@link ComponentElement.component}.
+     * @returns The audio listener component, or `null`.
      */
-    get component(): AudioListenerComponent {
-        return super.component as AudioListenerComponent;
+    get component(): AudioListenerComponent | null {
+        return super.component;
     }
 }
 

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -26,7 +26,7 @@ const transitionModes = new Map<'tint' | 'sprite', number>([
  *
  * @category Components
  */
-class ButtonComponentElement extends ComponentElement {
+class ButtonComponentElement extends ComponentElement<ButtonComponent> {
     private _active = true;
 
     private _image = '';
@@ -102,11 +102,12 @@ class ButtonComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the underlying PlayCanvas button component.
-     * @returns The button component.
+     * Gets the underlying PlayCanvas button component. `null` until the element is
+     * ready — see {@link ComponentElement.component}.
+     * @returns The button component, or `null`.
      */
-    get component(): ButtonComponent {
-        return super.component as ButtonComponent;
+    get component(): ButtonComponent | null {
+        return super.component;
     }
 
     /**

--- a/src/components/camera-component.ts
+++ b/src/components/camera-component.ts
@@ -50,7 +50,7 @@ const tonemaps = new Map<'none' | 'linear' | 'filmic' | 'hejl' | 'aces' | 'aces2
  *
  * @category Components
  */
-class CameraComponentElement extends ComponentElement {
+class CameraComponentElement extends ComponentElement<CameraComponent> {
     private _clearColor = new Color(0.75, 0.75, 0.75, 1);
 
     private _clearColorBuffer = true;
@@ -177,11 +177,12 @@ class CameraComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the underlying PlayCanvas camera component.
-     * @returns The camera component.
+     * Gets the underlying PlayCanvas camera component. `null` until the element is
+     * ready — see {@link ComponentElement.component}.
+     * @returns The camera component, or `null`.
      */
-    get component(): CameraComponent {
-        return super.component as CameraComponent;
+    get component(): CameraComponent | null {
+        return super.component;
     }
 
     /**

--- a/src/components/collision-component.ts
+++ b/src/components/collision-component.ts
@@ -25,7 +25,7 @@ import { ComponentElement } from './component';
  *
  * @category Components
  */
-class CollisionComponentElement extends ComponentElement {
+class CollisionComponentElement extends ComponentElement<CollisionComponent> {
     private _angularOffset: Quat = new Quat();
 
     private _axis = 1;
@@ -91,11 +91,12 @@ class CollisionComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the underlying PlayCanvas collision component.
-     * @returns The collision component.
+     * Gets the underlying PlayCanvas collision component. `null` until the element is
+     * ready — see {@link ComponentElement.component}.
+     * @returns The collision component, or `null`.
      */
-    get component(): CollisionComponent {
-        return super.component as CollisionComponent;
+    get component(): CollisionComponent | null {
+        return super.component;
     }
 
     set angularOffset(value: Quat) {

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -10,12 +10,12 @@ import { parseBool } from '../parse';
  *
  * @category Components
  */
-class ComponentElement extends AsyncElement {
+class ComponentElement<T extends Component = Component> extends AsyncElement {
     private _componentName: string;
 
     private _enabled = true;
 
-    private _component: Component | null = null;
+    private _component: T | null = null;
 
     private _appElement: AppElement | null = null;
 
@@ -97,7 +97,9 @@ class ComponentElement extends AsyncElement {
             return;
         }
 
-        this._component = entity.addComponent(this._componentName, this.getInitialComponentData());
+        // The name passed by the subclass selects the engine system that creates its T - a
+        // pairing the type system cannot express, so it is asserted this once
+        this._component = entity.addComponent(this._componentName, this.getInitialComponentData()) as T | null;
     }
 
     private async _addComponent() {
@@ -219,7 +221,7 @@ class ComponentElement extends AsyncElement {
      * before accessing it.
      * @returns The component instance, or `null`.
      */
-    get component(): Component | null {
+    get component(): T | null {
         return this._component;
     }
 

--- a/src/components/element-component.ts
+++ b/src/components/element-component.ts
@@ -25,7 +25,7 @@ import { ComponentElement } from './component';
  *
  * @category Components
  */
-class ElementComponentElement extends ComponentElement {
+class ElementComponentElement extends ComponentElement<ElementComponent> {
     private _anchor: Vec4 = new Vec4(0.5, 0.5, 0.5, 0.5);
 
     private _autoWidth = true;
@@ -158,11 +158,12 @@ class ElementComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the underlying PlayCanvas element component.
-     * @returns The element component.
+     * Gets the underlying PlayCanvas element component. `null` until the element is
+     * ready — see {@link ComponentElement.component}.
+     * @returns The element component, or `null`.
      */
-    get component(): ElementComponent {
-        return super.component as ElementComponent;
+    get component(): ElementComponent | null {
+        return super.component;
     }
 
     /**

--- a/src/components/gsplat-component.ts
+++ b/src/components/gsplat-component.ts
@@ -19,7 +19,7 @@ import { ComponentElement } from './component';
  *
  * @category Components
  */
-class GSplatComponentElement extends ComponentElement {
+class GSplatComponentElement extends ComponentElement<GSplatComponent> {
     private _asset = '';
 
     private _castShadows = false;
@@ -49,11 +49,12 @@ class GSplatComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the underlying PlayCanvas gsplat component.
-     * @returns The gsplat component.
+     * Gets the underlying PlayCanvas gsplat component. `null` until the element is
+     * ready — see {@link ComponentElement.component}.
+     * @returns The gsplat component, or `null`.
      */
-    get component(): GSplatComponent {
-        return super.component as GSplatComponent;
+    get component(): GSplatComponent | null {
+        return super.component;
     }
 
     /**

--- a/src/components/joint-component.ts
+++ b/src/components/joint-component.ts
@@ -45,7 +45,7 @@ export type MotionMode = 'locked' | 'limited' | 'free';
  *
  * @category Components
  */
-class JointComponentElement extends ComponentElement {
+class JointComponentElement extends ComponentElement<JointComponent> {
     /**
      * The spring damping of the joint per angular axis.
      */
@@ -254,11 +254,12 @@ class JointComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the underlying PlayCanvas joint component.
-     * @returns The joint component.
+     * Gets the underlying PlayCanvas joint component. `null` until the element is
+     * ready — see {@link ComponentElement.component}.
+     * @returns The joint component, or `null`.
      */
-    get component(): JointComponent {
-        return super.component as JointComponent;
+    get component(): JointComponent | null {
+        return super.component;
     }
 
     /**

--- a/src/components/layout-child-component.ts
+++ b/src/components/layout-child-component.ts
@@ -18,7 +18,7 @@ import { ComponentElement } from './component';
  *
  * @category Components
  */
-class LayoutChildComponentElement extends ComponentElement {
+class LayoutChildComponentElement extends ComponentElement<LayoutChildComponent> {
     private _minWidth = 0;
 
     private _minHeight = 0;
@@ -51,11 +51,12 @@ class LayoutChildComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the underlying PlayCanvas layout child component.
-     * @returns The layout child component.
+     * Gets the underlying PlayCanvas layout child component. `null` until the element is
+     * ready — see {@link ComponentElement.component}.
+     * @returns The layout child component, or `null`.
      */
-    get component(): LayoutChildComponent {
-        return super.component as LayoutChildComponent;
+    get component(): LayoutChildComponent | null {
+        return super.component;
     }
 
     /**

--- a/src/components/layout-group-component.ts
+++ b/src/components/layout-group-component.ts
@@ -40,7 +40,7 @@ const fittings = new Map<'none' | 'stretch' | 'shrink' | 'both', number>([
  *
  * @category Components
  */
-class LayoutGroupComponentElement extends ComponentElement {
+class LayoutGroupComponentElement extends ComponentElement<LayoutGroupComponent> {
     private _orientation: 'horizontal' | 'vertical' = 'horizontal';
 
     private _reverseX = false;
@@ -79,11 +79,12 @@ class LayoutGroupComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the underlying PlayCanvas layout group component.
-     * @returns The layout group component.
+     * Gets the underlying PlayCanvas layout group component. `null` until the element is
+     * ready — see {@link ComponentElement.component}.
+     * @returns The layout group component, or `null`.
      */
-    get component(): LayoutGroupComponent {
-        return super.component as LayoutGroupComponent;
+    get component(): LayoutGroupComponent | null {
+        return super.component;
     }
 
     /**

--- a/src/components/light-component.ts
+++ b/src/components/light-component.ts
@@ -45,7 +45,7 @@ const shadowTypes = new Map<
  *
  * @category Components
  */
-class LightComponentElement extends ComponentElement {
+class LightComponentElement extends ComponentElement<LightComponent> {
     private _cascadeBlend = 0;
 
     private _cascadeDistribution = 0.5;
@@ -132,11 +132,12 @@ class LightComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the underlying PlayCanvas light component.
-     * @returns The light component.
+     * Gets the underlying PlayCanvas light component. `null` until the element is
+     * ready — see {@link ComponentElement.component}.
+     * @returns The light component, or `null`.
      */
-    get component(): LightComponent {
-        return super.component as LightComponent;
+    get component(): LightComponent | null {
+        return super.component;
     }
 
     /**

--- a/src/components/particle-system-component.ts
+++ b/src/components/particle-system-component.ts
@@ -18,7 +18,7 @@ import { ComponentElement } from './component';
  *
  * @category Components
  */
-class ParticleSystemComponentElement extends ComponentElement {
+class ParticleSystemComponentElement extends ComponentElement<ParticleSystemComponent> {
     private _asset = '';
 
     /** @ignore */
@@ -45,11 +45,12 @@ class ParticleSystemComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the underlying PlayCanvas particle system component.
-     * @returns The particle system component.
+     * Gets the underlying PlayCanvas particle system component. `null` until the element is
+     * ready — see {@link ComponentElement.component}.
+     * @returns The particle system component, or `null`.
      */
-    get component(): ParticleSystemComponent {
-        return super.component as ParticleSystemComponent;
+    get component(): ParticleSystemComponent | null {
+        return super.component;
     }
 
     private applyConfig(resource: any) {

--- a/src/components/render-component.ts
+++ b/src/components/render-component.ts
@@ -24,7 +24,7 @@ import { ComponentElement } from './component';
  *
  * @category Components
  */
-class RenderComponentElement extends ComponentElement {
+class RenderComponentElement extends ComponentElement<RenderComponent> {
     private _castShadows = true;
 
     private _material = '';
@@ -48,11 +48,12 @@ class RenderComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the underlying PlayCanvas render component.
-     * @returns The render component.
+     * Gets the underlying PlayCanvas render component. `null` until the element is
+     * ready — see {@link ComponentElement.component}.
+     * @returns The render component, or `null`.
      */
-    get component(): RenderComponent {
-        return super.component as RenderComponent;
+    get component(): RenderComponent | null {
+        return super.component;
     }
 
     /**

--- a/src/components/rigid-body-component.ts
+++ b/src/components/rigid-body-component.ts
@@ -20,7 +20,7 @@ import { ComponentElement } from './component';
  *
  * @category Components
  */
-class RigidBodyComponentElement extends ComponentElement {
+class RigidBodyComponentElement extends ComponentElement<RigidBodyComponent> {
     /**
      * The angular damping of the rigidbody.
      */
@@ -86,11 +86,12 @@ class RigidBodyComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the underlying PlayCanvas rigidbody component.
-     * @returns The rigidbody component.
+     * Gets the underlying PlayCanvas rigidbody component. `null` until the element is
+     * ready — see {@link ComponentElement.component}.
+     * @returns The rigidbody component, or `null`.
      */
-    get component(): RigidBodyComponent {
-        return super.component as RigidBodyComponent;
+    get component(): RigidBodyComponent | null {
+        return super.component;
     }
 
     set angularDamping(value: number) {

--- a/src/components/screen-component.ts
+++ b/src/components/screen-component.ts
@@ -28,7 +28,7 @@ const scaleModes = new Map<'none' | 'blend', string>([
  *
  * @category Components
  */
-class ScreenComponentElement extends ComponentElement {
+class ScreenComponentElement extends ComponentElement<ScreenComponent> {
     private _screenSpace = false;
 
     private _resolution: Vec2 = new Vec2(640, 320);
@@ -58,11 +58,12 @@ class ScreenComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the underlying PlayCanvas screen component.
-     * @returns The screen component.
+     * Gets the underlying PlayCanvas screen component. `null` until the element is
+     * ready — see {@link ComponentElement.component}.
+     * @returns The screen component, or `null`.
      */
-    get component(): ScreenComponent {
-        return super.component as ScreenComponent;
+    get component(): ScreenComponent | null {
+        return super.component;
     }
 
     set priority(value: number) {

--- a/src/components/script-component.ts
+++ b/src/components/script-component.ts
@@ -266,7 +266,7 @@ export type ScriptNameChangeEvent = {
  *
  * @category Components
  */
-class ScriptComponentElement extends ComponentElement {
+class ScriptComponentElement extends ComponentElement<ScriptComponent> {
     private observer: MutationObserver;
 
     /** @ignore */
@@ -743,11 +743,12 @@ class ScriptComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the underlying PlayCanvas script component.
-     * @returns The script component.
+     * Gets the underlying PlayCanvas script component. `null` until the element is
+     * ready — see {@link ComponentElement.component}.
+     * @returns The script component, or `null`.
      */
-    get component(): ScriptComponent {
-        return super.component as ScriptComponent;
+    get component(): ScriptComponent | null {
+        return super.component;
     }
 }
 

--- a/src/components/scroll-view-component.ts
+++ b/src/components/scroll-view-component.ts
@@ -37,7 +37,7 @@ const visibilities = new Map<'always' | 'when-required', number>([
  *
  * @category Components
  */
-class ScrollViewComponentElement extends ComponentElement {
+class ScrollViewComponentElement extends ComponentElement<ScrollViewComponent> {
     private _horizontal = true;
 
     private _vertical = true;
@@ -106,11 +106,12 @@ class ScrollViewComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the underlying PlayCanvas scroll view component.
-     * @returns The scroll view component.
+     * Gets the underlying PlayCanvas scroll view component. `null` until the element is
+     * ready — see {@link ComponentElement.component}.
+     * @returns The scroll view component, or `null`.
      */
-    get component(): ScrollViewComponent {
-        return super.component as ScrollViewComponent;
+    get component(): ScrollViewComponent | null {
+        return super.component;
     }
 
     /**

--- a/src/components/scrollbar-component.ts
+++ b/src/components/scrollbar-component.ts
@@ -24,7 +24,7 @@ const orientations = new Map<'horizontal' | 'vertical', number>([
  *
  * @category Components
  */
-class ScrollbarComponentElement extends ComponentElement {
+class ScrollbarComponentElement extends ComponentElement<ScrollbarComponent> {
     private _orientation: 'horizontal' | 'vertical' = 'horizontal';
 
     private _value = 0;
@@ -54,11 +54,12 @@ class ScrollbarComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the underlying PlayCanvas scrollbar component.
-     * @returns The scrollbar component.
+     * Gets the underlying PlayCanvas scrollbar component. `null` until the element is
+     * ready — see {@link ComponentElement.component}.
+     * @returns The scrollbar component, or `null`.
      */
-    get component(): ScrollbarComponent {
-        return super.component as ScrollbarComponent;
+    get component(): ScrollbarComponent | null {
+        return super.component;
     }
 
     /**

--- a/src/components/sound-component.ts
+++ b/src/components/sound-component.ts
@@ -18,7 +18,7 @@ import { ComponentElement } from './component';
  *
  * @category Components
  */
-class SoundComponentElement extends ComponentElement {
+class SoundComponentElement extends ComponentElement<SoundComponent> {
     private _distanceModel: 'exponential' | 'inverse' | 'linear' = 'linear';
 
     private _maxDistance = 10000;
@@ -51,11 +51,12 @@ class SoundComponentElement extends ComponentElement {
     }
 
     /**
-     * Gets the underlying PlayCanvas sound component.
-     * @returns The sound component.
+     * Gets the underlying PlayCanvas sound component. `null` until the element is
+     * ready — see {@link ComponentElement.component}.
+     * @returns The sound component, or `null`.
      */
-    get component(): SoundComponent {
-        return super.component as SoundComponent;
+    get component(): SoundComponent | null {
+        return super.component;
     }
 
     /**

--- a/test/integration/components/anim-component.test.ts
+++ b/test/integration/components/anim-component.test.ts
@@ -68,7 +68,7 @@ describe('<pc-anim>', () => {
             // API - deliberately silent, like a pc-sound with no slots
             const { get } = await bootApp('<pc-entity name="e"><pc-anim></pc-anim></pc-entity>');
             const anim = get<AnimComponentElement>('pc-anim');
-            const component = anim.component;
+            const component = anim.component!;
 
             expect(component).toBeDefined();
             expect(component.activate).toBe(true);
@@ -86,8 +86,8 @@ describe('<pc-anim>', () => {
             );
             const anim = get<AnimComponentElement>('pc-anim');
 
-            expect(anim.component.activate).toBe(false);
-            expect(anim.component.speed).toBe(2);
+            expect(anim.component!.activate).toBe(false);
+            expect(anim.component!.speed).toBe(2);
             expect(anim.transitionTime).toBe(0.5);
         });
 
@@ -99,8 +99,8 @@ describe('<pc-anim>', () => {
             anim.setAttribute('speed', '3');
             anim.setAttribute('transition-time', '0.25');
 
-            expect(anim.component.activate).toBe(false);
-            expect(anim.component.speed).toBe(3);
+            expect(anim.component!.activate).toBe(false);
+            expect(anim.component!.speed).toBe(3);
             expect(anim.transitionTime).toBe(0.25);
         });
 
@@ -117,8 +117,8 @@ describe('<pc-anim>', () => {
             anim.removeAttribute('transition-time');
             anim.removeAttribute('clip');
 
-            expect(anim.component.activate).toBe(true);
-            expect(anim.component.speed).toBe(1);
+            expect(anim.component!.activate).toBe(true);
+            expect(anim.component!.speed).toBe(1);
             expect(anim.transitionTime).toBe(0);
             expect(anim.clip).toBe('');
         });
@@ -132,7 +132,7 @@ describe('<pc-anim>', () => {
             warnings.expect("Invalid value 'fast' for attribute 'speed'. Expected a finite number. Using '1'.");
             warnings.expect("Invalid value 'soon' for attribute 'transition-time'. Expected a finite number. Using '0'.");
 
-            expect(anim.component.speed).toBe(1);
+            expect(anim.component!.speed).toBe(1);
             expect(anim.transitionTime).toBe(0);
         });
     });
@@ -146,7 +146,7 @@ describe('<pc-anim>', () => {
             const anim = get<AnimComponentElement>('pc-anim');
 
             await vi.waitFor(() => expect(anim.clips).toEqual(['Walk', 'Run', 'Idle']));
-            expect(anim.component.playing).toBe(true);
+            expect(anim.component!.playing).toBe(true);
 
             expect(bonePosition(app).y).toBe(0);
             step(0.5);
@@ -177,7 +177,7 @@ describe('<pc-anim>', () => {
 
             // The host's readiness cycle owns the refresh; the model-ready listener must not run
             // a second one. Each track resolving exactly once is the observable difference.
-            const assign = vi.spyOn(anim.component, 'assignAnimation');
+            const assign = vi.spyOn(anim.component!, 'assignAnimation');
 
             get<ModelElement>('pc-model').setAttribute('asset', 'm2');
 
@@ -197,7 +197,7 @@ describe('<pc-anim>', () => {
             const anim = get<AnimComponentElement>('pc-anim');
             await vi.waitFor(() => expect(anim.clips).toEqual(['Walk', 'Run', 'Idle']));
             step(0.3);
-            const layer = anim.component.baseLayer!;
+            const layer = anim.component!.baseLayer!;
             expect(layer.activeState).toBe('Run');
             const time = layer.activeStateCurrentTime;
             expect(time).toBeGreaterThan(0);
@@ -205,7 +205,7 @@ describe('<pc-anim>', () => {
             get<ModelElement>('pc-model').setAttribute('asset', 'm2');
             await vi.waitFor(() => expect(anim.clips).toEqual(['Walk', 'Run']));
 
-            const restored = anim.component.baseLayer!;
+            const restored = anim.component!.baseLayer!;
             expect(restored.activeState, 'the surviving selection is restored').toBe('Run');
             // The app ticks on rAF between the capture and this read, so the playhead has moved
             // on a little - but a dropped restore would have reset it to (near) zero.
@@ -225,7 +225,7 @@ describe('<pc-anim>', () => {
             await vi.waitFor(() => expect(anim.clips).toEqual(['Walk', 'Run', 'Idle']));
 
             const model = get<ModelElement>('pc-model');
-            expect(anim.component.entity, 'the component landed on the model host').toBe(model.entity);
+            expect(anim.component!.entity, 'the component landed on the model host').toBe(model.entity);
             expect((app.root.findByName('legacy') as Entity).anim, 'not on the wrapper').toBeUndefined();
 
             step(0.5);
@@ -259,7 +259,7 @@ describe('<pc-anim>', () => {
             const anim = get<AnimComponentElement>('pc-anim');
 
             expect(anim.clips).toEqual(['Walk', 'Run']);
-            expect(anim.component.baseLayer!.activeState === 'Walk' || anim.component.baseLayer!.activeState === 'START').toBe(true);
+            expect(anim.component!.baseLayer!.activeState === 'Walk' || anim.component!.baseLayer!.activeState === 'START').toBe(true);
 
             step(0.5);
             // Walk lifts +Y; Run would push +X
@@ -279,7 +279,7 @@ describe('<pc-anim>', () => {
             `);
             const anim = get<AnimComponentElement>('pc-anim');
 
-            expect(anim.component.baseLayer!.activeState).toBe('Run');
+            expect(anim.component!.baseLayer!.activeState).toBe('Run');
             step(0.5);
             // Run is container index 1, so it pushes +X
             expect(bonePosition(app).x).toBeGreaterThan(0);
@@ -324,8 +324,8 @@ describe('<pc-anim>', () => {
             const anim = get<AnimComponentElement>('pc-anim');
             expect(anim.clips).toEqual(['Run']);
 
-            const assign = vi.spyOn(anim.component, 'assignAnimation');
-            const rebind = vi.spyOn(anim.component, 'rebind');
+            const assign = vi.spyOn(anim.component!, 'assignAnimation');
+            const rebind = vi.spyOn(anim.component!, 'rebind');
 
             get<ModelElement>('pc-model').setAttribute('asset', 'm2');
             await readyWithin(get<ModelElement>('pc-model'));
@@ -351,7 +351,7 @@ describe('<pc-anim>', () => {
             `);
             const anim = get<AnimComponentElement>('pc-anim');
             const model = get<ModelElement>('pc-model');
-            expect(anim.component.rootBone, 'the sole sibling model pins the root').toBe(model.entity);
+            expect(anim.component!.rootBone, 'the sole sibling model pins the root').toBe(model.entity);
 
             // A second sibling model leaves no single skeleton to pin - the stale pin must not
             // survive, or curves would keep binding against whichever model happened to be first.
@@ -360,7 +360,7 @@ describe('<pc-anim>', () => {
             model.parentElement!.appendChild(second);
             await readyWithin(second);
 
-            expect(anim.component.rootBone, 'the ambiguous source clears the pin').toBeNull();
+            expect(anim.component!.rootBone, 'the ambiguous source clears the pin').toBeNull();
         });
 
         it('leaves a binding root assigned through the engine API alone', async () => {
@@ -372,15 +372,15 @@ describe('<pc-anim>', () => {
             const anim = get<AnimComponentElement>('pc-anim');
             const model = get<ModelElement>('pc-model');
             await vi.waitFor(() => expect(anim.clips).toEqual(['Walk', 'Run', 'Idle']));
-            expect(anim.component.rootBone).toBe(model.entity);
+            expect(anim.component!.rootBone).toBe(model.entity);
 
             const custom = app.root.findByName('holder') as Entity;
-            anim.component.rootBone = custom;
+            anim.component!.rootBone = custom;
 
             model.setAttribute('asset', 'm2');
             await vi.waitFor(() => expect(anim.clips).toEqual(['Jump']));
 
-            expect(anim.component.rootBone, "the user's choice outranks the managed default").toBe(custom);
+            expect(anim.component!.rootBone, "the user's choice outranks the managed default").toBe(custom);
         });
 
         it('resolves animation and animclip typed assets', async () => {
@@ -450,7 +450,7 @@ describe('<pc-anim>', () => {
 
             anim.setAttribute('clip', 'Run');
 
-            expect(anim.component.baseLayer!.activeState).toBe('Run');
+            expect(anim.component!.baseLayer!.activeState).toBe('Run');
             step(0.5);
             expect(bonePosition(app).x).toBeGreaterThan(0);
         });
@@ -463,7 +463,7 @@ describe('<pc-anim>', () => {
             anim.setAttribute('transition-time', '0.5');
             anim.setAttribute('clip', 'Run');
 
-            const layer = anim.component.baseLayer!;
+            const layer = anim.component!.baseLayer!;
             expect(layer.activeState).toBe('Run');
             step(0.1);
             expect(layer.transitioning).toBe(true);
@@ -478,7 +478,7 @@ describe('<pc-anim>', () => {
             anim.setAttribute('clip', 'Nope');
 
             warnings.expect("pc-anim has no clip named 'Nope' - selection unchanged");
-            expect(anim.component.baseLayer!.activeState).not.toBe('Nope');
+            expect(anim.component!.baseLayer!.activeState).not.toBe('Nope');
         });
 
         it('keeps playing when the clip attribute is removed', async () => {
@@ -489,8 +489,8 @@ describe('<pc-anim>', () => {
             anim.removeAttribute('clip');
 
             expect(anim.clip).toBe('');
-            expect(anim.component.playing).toBe(true);
-            expect(anim.component.baseLayer!.activeState).toBe('Run');
+            expect(anim.component!.playing).toBe(true);
+            expect(anim.component!.baseLayer!.activeState).toBe('Run');
         });
 
         it('play and pause freeze and resume the pose', async () => {
@@ -502,7 +502,7 @@ describe('<pc-anim>', () => {
             expect(frozen).toBeGreaterThan(0);
 
             anim.pause();
-            expect(anim.component.playing).toBe(false);
+            expect(anim.component!.playing).toBe(false);
             step(0.25);
             expect(bonePosition(app).y).toBe(frozen);
 
@@ -514,7 +514,7 @@ describe('<pc-anim>', () => {
         it('play(name) hard-cuts, transition(name) cross-fades, unknown names are ignored', async () => {
             const { get, step } = await bootApp(DECLARED);
             const anim = get<AnimComponentElement>('pc-anim');
-            const layer = anim.component.baseLayer!;
+            const layer = anim.component!.baseLayer!;
             step(0.1);
 
             anim.play('Run');
@@ -542,7 +542,7 @@ describe('<pc-anim>', () => {
             `);
             const anim = get<AnimComponentElement>('pc-anim');
 
-            expect(anim.component.playing).toBe(false);
+            expect(anim.component!.playing).toBe(false);
             step(0.5);
             expect(bonePosition(app).x).toBe(0);
             expect(bonePosition(app).y).toBe(0);
@@ -572,7 +572,7 @@ describe('<pc-anim>', () => {
             // time entering the clip), so the playhead only reads non-zero from the second on
             step(0.25);
             step(0.25);
-            const layer = anim.component.baseLayer!;
+            const layer = anim.component!.baseLayer!;
             const before = layer.activeStateCurrentTime;
             expect(before).toBeGreaterThan(0);
 
@@ -637,16 +637,16 @@ describe('<pc-anim>', () => {
             step(0.25);
             step(0.25);
             anim.pause();
-            const time = anim.component.baseLayer!.activeStateCurrentTime;
+            const time = anim.component!.baseLayer!.activeStateCurrentTime;
             expect(time).toBeGreaterThan(0);
 
             // Rebuild while paused: remove the inactive clip
             (anim.children[1] as AnimClipElement).remove();
             await vi.waitFor(() => expect(anim.clips).toEqual(['Walk']));
 
-            expect(anim.component.playing).toBe(false);
-            expect(anim.component.baseLayer!.activeState).toBe('Walk');
-            expect(anim.component.baseLayer!.activeStateCurrentTime).toBeCloseTo(time, 5);
+            expect(anim.component!.playing).toBe(false);
+            expect(anim.component!.baseLayer!.activeState).toBe('Walk');
+            expect(anim.component!.baseLayer!.activeStateCurrentTime).toBeCloseTo(time, 5);
 
             const held = bonePosition(app).y;
             step(0.25);
@@ -669,13 +669,13 @@ describe('<pc-anim>', () => {
             `);
             const anim = get<AnimComponentElement>('pc-anim');
             step(0.1);
-            expect(anim.component.baseLayer!.activeState).toBe('Walk');
+            expect(anim.component!.baseLayer!.activeState).toBe('Walk');
 
             (anim.children[0] as AnimClipElement).remove();
             await vi.waitFor(() => expect(anim.clips).toEqual(['Run']));
 
             step(0.1);
-            expect(anim.component.baseLayer!.activeState).toBe('Run');
+            expect(anim.component!.baseLayer!.activeState).toBe('Run');
         });
 
         it('renames a clip in place', async () => {
@@ -703,7 +703,7 @@ describe('<pc-anim>', () => {
             const { get, step } = await bootApp(WALK_ONLY);
             const anim = get<AnimComponentElement>('pc-anim');
             const clip = anim.children[0] as AnimClipElement;
-            const layer = anim.component.baseLayer!;
+            const layer = anim.component!.baseLayer!;
             // Two steps: the first tick is consumed by the START transition
             step(0.25);
             step(0.25);
@@ -731,12 +731,12 @@ describe('<pc-anim>', () => {
             step(2);
             step(2);
 
-            const layer = anim.component.baseLayer!;
+            const layer = anim.component!.baseLayer!;
             expect(layer.activeStateCurrentTime).toBe(layer.activeStateDuration);
             expect(bonePosition(app).y).toBeCloseTo(2, 5);
 
             // The engine reports no completion: the state holds and playing stays true
-            expect(anim.component.playing).toBe(true);
+            expect(anim.component!.playing).toBe(true);
             step(2);
             expect(bonePosition(app).y).toBeCloseTo(2, 5);
         });
@@ -757,7 +757,7 @@ describe('<pc-anim>', () => {
             `);
             const anim = get<AnimComponentElement>('pc-anim');
             expect(anim.clips).toEqual(['Run']);
-            const firstComponent = anim.component;
+            const firstComponent = anim.component!;
 
             get<ModelElement>('pc-model').setAttribute('asset', 'm2');
 

--- a/test/integration/components/button-component.test.ts
+++ b/test/integration/components/button-component.test.ts
@@ -18,7 +18,7 @@ describe('<pc-button>', () => {
             const { app, get } = await bootApp('<pc-entity name="btn"><pc-button></pc-button></pc-entity>');
             const button = get<ButtonComponentElement>('pc-button');
 
-            expect(button.component.imageEntity).toBe(app.root.findByName('btn'));
+            expect(button.component!.imageEntity).toBe(app.root.findByName('btn'));
         });
 
         it('resolves an explicit reference', async () => {
@@ -28,7 +28,7 @@ describe('<pc-button>', () => {
             `);
             const button = get<ButtonComponentElement>('pc-button');
 
-            expect(button.component.imageEntity).toBe(app.root.findByName('target'));
+            expect(button.component!.imageEntity).toBe(app.root.findByName('target'));
         });
 
         it('warns when the reference does not resolve, leaving the image entity unset', async () => {
@@ -36,7 +36,7 @@ describe('<pc-button>', () => {
             const button = get<ButtonComponentElement>('pc-button');
 
             warnings.expect("pc-button could not resolve image '#nope' - nothing in the document matches it - reference ignored");
-            expect(button.component.imageEntity).toBeNull();
+            expect(button.component!.imageEntity).toBeNull();
         });
 
         it('keeps the current image entity when a reassigned reference does not resolve', async () => {
@@ -50,7 +50,7 @@ describe('<pc-button>', () => {
 
             warnings.expect("pc-button could not resolve image '#still-nope'");
             expect(button.image).toBe('#still-nope');
-            expect(button.component.imageEntity).toBe(app.root.findByName('target'));
+            expect(button.component!.imageEntity).toBe(app.root.findByName('target'));
         });
     });
 });

--- a/test/integration/components/camera-component.test.ts
+++ b/test/integration/components/camera-component.test.ts
@@ -88,7 +88,7 @@ describe('<pc-camera>', () => {
     describe('#component', () => {
         it('creates the camera component with the engine defaults', async () => {
             const { get } = await bootApp(scene());
-            const component = get<CameraComponentElement>('pc-camera').component;
+            const component = get<CameraComponentElement>('pc-camera').component!;
 
             expect(component).toBeDefined();
             expect(component.enabled).toBe(true);
@@ -105,7 +105,7 @@ describe('<pc-camera>', () => {
                 .map(([attribute, , value]) => (value === '' ? attribute : `${attribute}="${value}"`))
                 .join(' ');
             const { get } = await bootApp(scene(markup));
-            const component = get<CameraComponentElement>('pc-camera').component;
+            const component = get<CameraComponentElement>('pc-camera').component!;
 
             for (const [attribute, property, , expected] of cases) {
                 expect.soft(engineValue(component, property), attribute).toEqual(expected);
@@ -118,7 +118,7 @@ describe('<pc-camera>', () => {
 
             for (const [attribute, property, value, expected] of cases) {
                 camera.setAttribute(attribute, value);
-                expect.soft(engineValue(camera.component, property), attribute).toEqual(expected);
+                expect.soft(engineValue(camera.component!, property), attribute).toEqual(expected);
             }
         });
 
@@ -129,7 +129,7 @@ describe('<pc-camera>', () => {
             for (const [attribute, property, value, , restored] of cases) {
                 camera.setAttribute(attribute, value);
                 camera.removeAttribute(attribute);
-                expect.soft(engineValue(camera.component, property), attribute).toEqual(restored);
+                expect.soft(engineValue(camera.component!, property), attribute).toEqual(restored);
             }
         });
 
@@ -137,7 +137,7 @@ describe('<pc-camera>', () => {
             const { get } = await bootApp(
                 scene('fov="wide" projection="isometric" tonemap="reinhard" rect="0 0" clear-depth="near"')
             );
-            const component = get<CameraComponentElement>('pc-camera').component;
+            const component = get<CameraComponentElement>('pc-camera').component!;
 
             warnings.expect("Invalid value 'wide' for attribute 'fov'. Expected a finite number. Using '45'.");
             warnings.expect(
@@ -204,7 +204,7 @@ describe('<pc-camera>', () => {
             // Stubbed so the element's decision is what is measured, not a session the null device
             // could never open
             const started: string[] = [];
-            const component = camera.component;
+            const component = camera.component!;
             component.startXr = ((type: string) => {
                 started.push(type);
             }) as typeof component.startXr;

--- a/test/integration/components/component.test.ts
+++ b/test/integration/components/component.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import type { Component } from 'playcanvas';
+import { LightComponent } from 'playcanvas';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import type { CameraComponentElement } from '../../../src/components/camera-component';
+import type { ComponentElement } from '../../../src/components/component';
+import type { LightComponentElement } from '../../../src/components/light-component';
 import type { RenderComponentElement } from '../../../src/components/render-component';
+import type { EntityElement } from '../../../src/entity';
 import type { ModelElement } from '../../../src/model';
 import { bootApp } from '../../helpers/app';
 import { useGuard } from '../../helpers/guard';
@@ -43,7 +48,7 @@ describe('component hosting', () => {
             const render = get<RenderComponentElement>('pc-render');
 
             expect(render.component, 'the component exists').toBeTruthy();
-            expect(render.component.entity, 'on the model host').toBe(model.entity);
+            expect(render.component!.entity, 'on the model host').toBe(model.entity);
             expect(model.entity!.render, 'not on the content root').toBe(render.component);
             expect(model.contentEntity!.render).toBeUndefined();
         });
@@ -53,7 +58,7 @@ describe('component hosting', () => {
             const camera = get<CameraComponentElement>('pc-camera');
 
             expect(camera.component).toBeTruthy();
-            expect(camera.component.entity).toBe(get<ModelElement>('pc-model').entity);
+            expect(camera.component!.entity).toBe(get<ModelElement>('pc-model').entity);
         });
 
         it('attaches after a failed load - readiness means the selection settled', async () => {
@@ -81,13 +86,13 @@ describe('component hosting', () => {
             const { get } = await bootApp(`${ASSETS}<pc-model asset="m"><pc-render type="box"></pc-render></pc-model>`);
             const model = get<ModelElement>('pc-model');
             const render = get<RenderComponentElement>('pc-render');
-            const component = render.component;
+            const component = render.component!;
 
             model.setAttribute('asset', 'm2');
             await readyWithin(model);
 
             expect(render.component, 'the same component instance').toBe(component);
-            expect(render.component.entity, 'still on the surviving host').toBe(model.entity);
+            expect(render.component!.entity, 'still on the surviving host').toBe(model.entity);
             expect(model.contentEntity!.name, 'above the new content').toBe('content-root-b');
         });
 
@@ -100,8 +105,35 @@ describe('component hosting', () => {
                 </pc-model>
             `);
 
-            await readyWithin(get<CameraComponentElement>('pc-camera[id="second"]'));
+            const second = get<CameraComponentElement>('pc-camera[id="second"]');
+            await readyWithin(second);
+            expect(second.component, 'the skipped duplicate stays null').toBeNull();
             warnings.expect("pc-camera 'second' - 'prop' already has a 'camera' component - component not added");
+        });
+    });
+
+    describe('component nullability', () => {
+        it('is null before readiness and after disconnection, and concrete in between', async () => {
+            const { get } = await bootApp('<pc-entity name="host"></pc-entity>');
+            const host = get<EntityElement>('pc-entity');
+
+            const light = document.createElement('pc-light') as LightComponentElement;
+            expect(light.component, 'never connected').toBeNull();
+
+            host.appendChild(light);
+            expect(light.component, 'connected, readiness still pending').toBeNull();
+
+            await readyWithin(light);
+            expect(light.component).toBeInstanceOf(LightComponent);
+            expect(light.component!.entity).toBe(host.entity);
+
+            // The declarations carry the nullability: the concrete engine type on an element,
+            // plain Component on the base class.
+            expectTypeOf(light.component).toEqualTypeOf<LightComponent | null>();
+            expectTypeOf<ComponentElement['component']>().toEqualTypeOf<Component | null>();
+
+            light.remove();
+            expect(light.component, 'disconnection released the component').toBeNull();
         });
     });
 

--- a/test/integration/components/joint-component.test.ts
+++ b/test/integration/components/joint-component.test.ts
@@ -80,7 +80,7 @@ describe('<pc-joint>', () => {
     describe('#component', () => {
         it('creates the joint component with the engine defaults', async () => {
             const { get } = await bootApp(scene());
-            const component = get<JointComponentElement>('pc-joint').component;
+            const component = get<JointComponentElement>('pc-joint').component!;
 
             expect(component).toBeDefined();
 
@@ -103,7 +103,7 @@ describe('<pc-joint>', () => {
                 .map(([attribute, , value]) => (value === '' ? attribute : `${attribute}="${value}"`))
                 .join(' ');
             const { get } = await bootApp(scene(markup));
-            const component = get<JointComponentElement>('pc-joint').component;
+            const component = get<JointComponentElement>('pc-joint').component!;
 
             for (const [attribute, property, , expected] of cases) {
                 expect.soft(engineValue(component, property), attribute).toEqual(expected);
@@ -116,7 +116,7 @@ describe('<pc-joint>', () => {
 
             for (const [attribute, property, value, expected] of cases) {
                 joint.setAttribute(attribute, value);
-                expect.soft(engineValue(joint.component, property), attribute).toEqual(expected);
+                expect.soft(engineValue(joint.component!, property), attribute).toEqual(expected);
             }
         });
 
@@ -127,7 +127,7 @@ describe('<pc-joint>', () => {
             for (const [attribute, property, value, , restored] of cases) {
                 joint.setAttribute(attribute, value);
                 joint.removeAttribute(attribute);
-                expect.soft(engineValue(joint.component, property), attribute).toEqual(restored);
+                expect.soft(engineValue(joint.component!, property), attribute).toEqual(restored);
             }
         });
 
@@ -137,7 +137,7 @@ describe('<pc-joint>', () => {
                     'type="banana" break-impulse="soft" limits="1" linear-stiffness="x y z" linear-motion-y="wobbly"'
                 )
             );
-            const component = get<JointComponentElement>('pc-joint').component;
+            const component = get<JointComponentElement>('pc-joint').component!;
 
             warnings.expect(
                 "Invalid value 'banana' for attribute 'type'. Valid values: fixed, ball, hinge, slider, 6dof. Using 'fixed'."
@@ -166,20 +166,20 @@ describe('<pc-joint>', () => {
             const { get } = await bootApp(scene('type="hinge"'));
             const joint = get<JointComponentElement>('pc-joint');
 
-            expect(joint.component.type).toBe('hinge');
+            expect(joint.component!.type).toBe('hinge');
 
             joint.setAttribute('type', '6dof');
-            expect(joint.component.type).toBe('6dof');
+            expect(joint.component!.type).toBe('6dof');
 
             joint.removeAttribute('type');
-            expect(joint.component.type).toBe('fixed');
+            expect(joint.component!.type).toBe('fixed');
         });
     });
 
     describe('[entity-a] and [entity-b]', () => {
         it('resolves references by entity name and by CSS selector to live entities', async () => {
             const { app, get } = await bootApp(scene('entity-a="bob" entity-b="#anchor-id"'));
-            const component = get<JointComponentElement>('pc-joint').component;
+            const component = get<JointComponentElement>('pc-joint').component!;
 
             expect(component.entityA).toBe(app.root.findByName('bob'));
             expect(component.entityB).toBe(app.root.findByName('anchor'));
@@ -189,7 +189,7 @@ describe('<pc-joint>', () => {
             const { app, get } = await bootApp(
                 `<pc-entity name="frame"><pc-joint entity-a="bob" entity-b="anchor"></pc-joint></pc-entity>${BODIES}`
             );
-            const component = get<JointComponentElement>('pc-joint').component;
+            const component = get<JointComponentElement>('pc-joint').component!;
 
             expect(component.entityA).toBe(app.root.findByName('bob'));
             expect(component.entityB).toBe(app.root.findByName('anchor'));
@@ -211,7 +211,7 @@ describe('<pc-joint>', () => {
                 </pc-model>
             `);
 
-            expect(get<JointComponentElement>('pc-joint').component.entityA).toBe(
+            expect(get<JointComponentElement>('pc-joint').component!.entityA).toBe(
                 get<NodeElement>('pc-node').entity
             );
         });
@@ -230,12 +230,12 @@ describe('<pc-joint>', () => {
             const joint = get<JointComponentElement>('pc-joint');
             const near = get<EntityElement>('#near-anchor');
 
-            expect(joint.component.entityA, 'resolved at creation').toBe(near.entity);
+            expect(joint.component!.entityA, 'resolved at creation').toBe(near.entity);
 
             // And again through the setter path on reassignment
             joint.setAttribute('entity-a', '');
             joint.setAttribute('entity-a', 'anchor');
-            expect(joint.component.entityA, 'resolved on reassignment').toBe(near.entity);
+            expect(joint.component!.entityA, 'resolved on reassignment').toBe(near.entity);
         });
 
         it('retargets a body when the attribute changes at runtime', async () => {
@@ -247,7 +247,7 @@ describe('<pc-joint>', () => {
 
             joint.setAttribute('entity-b', '#post-id');
 
-            expect(joint.component.entityB).toBe(app.root.findByName('post'));
+            expect(joint.component!.entityB).toBe(app.root.findByName('post'));
         });
 
         it('pins the first body to a world point when entity-b is removed', async () => {
@@ -257,7 +257,7 @@ describe('<pc-joint>', () => {
             joint.removeAttribute('entity-b');
 
             expect(joint.entityB).toBe('');
-            expect(joint.component.entityB).toBeNull();
+            expect(joint.component!.entityB).toBeNull();
         });
 
         it('detaches the first body when entity-a is removed', async () => {
@@ -267,7 +267,7 @@ describe('<pc-joint>', () => {
             joint.removeAttribute('entity-a');
 
             expect(joint.entityA).toBe('');
-            expect(joint.component.entityA).toBeNull();
+            expect(joint.component!.entityA).toBeNull();
         });
 
         it('warns when a reference matches nothing in the document', async () => {
@@ -276,7 +276,7 @@ describe('<pc-joint>', () => {
 
             warnings.expect("pc-joint could not resolve entity-a '#nope' - nothing in the document matches it");
             expect(joint.entityA).toBe('#nope');
-            expect(joint.component.entityA).toBeNull();
+            expect(joint.component!.entityA).toBeNull();
         });
 
         it('warns differently when a reference matches an element that cannot back an entity', async () => {
@@ -289,7 +289,7 @@ describe('<pc-joint>', () => {
                 '<div> matches it but cannot back an entity - constraint not created. ' +
                     'Point entity-a at a pc-entity, pc-model or pc-node instead.'
             );
-            expect(joint.component.entityA).toBeNull();
+            expect(joint.component!.entityA).toBeNull();
         });
 
         it('warns again when a reference is reassigned and still does not resolve', async () => {
@@ -299,7 +299,7 @@ describe('<pc-joint>', () => {
             joint.setAttribute('entity-a', '#still-nope');
 
             warnings.expect("pc-joint could not resolve entity-a '#still-nope'");
-            expect(joint.component.entityA).toBeNull();
+            expect(joint.component!.entityA).toBeNull();
         });
 
         it('stays silent for an empty reference, which is the world-space case', async () => {
@@ -310,7 +310,7 @@ describe('<pc-joint>', () => {
             // fails this test if either did.
             joint.setAttribute('entity-b', '');
 
-            expect(joint.component.entityB).toBeNull();
+            expect(joint.component!.entityB).toBeNull();
         });
     });
 
@@ -322,7 +322,7 @@ describe('<pc-joint>', () => {
             const events: Event[] = [];
             container.addEventListener('break', event => events.push(event));
 
-            joint.component.fire('break');
+            joint.component!.fire('break');
 
             expect(events).toHaveLength(1);
             expect(events[0]).toBeInstanceOf(CustomEvent);
@@ -337,8 +337,8 @@ describe('<pc-joint>', () => {
             const events: Event[] = [];
             joint.addEventListener('break', event => events.push(event));
 
-            joint.component.fire('break');
-            joint.component.fire('break');
+            joint.component!.fire('break');
+            joint.component!.fire('break');
 
             expect(events).toHaveLength(2);
         });

--- a/test/integration/components/light-component.test.ts
+++ b/test/integration/components/light-component.test.ts
@@ -51,7 +51,7 @@ describe('<pc-light>', () => {
     describe('#component', () => {
         it('creates the light component with the engine defaults', async () => {
             const { get } = await bootApp(scene());
-            const component = get<LightComponentElement>('pc-light').component;
+            const component = get<LightComponentElement>('pc-light').component!;
 
             expect(component).toBeDefined();
             expect(component.enabled).toBe(true);
@@ -63,7 +63,7 @@ describe('<pc-light>', () => {
 
         it('matches a light the engine built itself', async () => {
             const { app, get } = await bootApp(scene());
-            const element = get<LightComponentElement>('pc-light').component;
+            const element = get<LightComponentElement>('pc-light').component!;
 
             // Every property the element writes, compared against a component built from no data
             // at all. Catches a default drifting on either side, including the properties the
@@ -86,7 +86,7 @@ describe('<pc-light>', () => {
                 .map(([attribute, , value]) => (value === '' ? attribute : `${attribute}="${value}"`))
                 .join(' ');
             const { get } = await bootApp(scene(markup));
-            const component = get<LightComponentElement>('pc-light').component;
+            const component = get<LightComponentElement>('pc-light').component!;
 
             for (const [attribute, property, , expected] of cases) {
                 expect.soft(engineValue(component, property), attribute).toEqual(expected);
@@ -99,7 +99,7 @@ describe('<pc-light>', () => {
 
             for (const [attribute, property, value, expected] of cases) {
                 light.setAttribute(attribute, value);
-                expect.soft(engineValue(light.component, property), attribute).toEqual(expected);
+                expect.soft(engineValue(light.component!, property), attribute).toEqual(expected);
             }
         });
 
@@ -110,7 +110,7 @@ describe('<pc-light>', () => {
             for (const [attribute, property, value, , restored] of cases) {
                 light.setAttribute(attribute, value);
                 light.removeAttribute(attribute);
-                expect.soft(engineValue(light.component, property), attribute).toEqual(restored);
+                expect.soft(engineValue(light.component!, property), attribute).toEqual(restored);
             }
         });
 
@@ -118,7 +118,7 @@ describe('<pc-light>', () => {
             const { get } = await bootApp(
                 scene('type="area" shadow-type="pcf7-32f" intensity="bright" shadow-bias="soft"')
             );
-            const component = get<LightComponentElement>('pc-light').component;
+            const component = get<LightComponentElement>('pc-light').component!;
 
             warnings.expect(
                 "Invalid value 'area' for attribute 'type'. Valid values: directional, omni, spot. Using 'directional'."
@@ -147,7 +147,7 @@ describe('<pc-light>', () => {
 
             const values = names.map((name) => {
                 light.setAttribute('shadow-type', name);
-                return light.component.shadowType;
+                return light.component!.shadowType;
             });
 
             expect(new Set(values).size, 'each name resolves to its own constant').toBe(names.length);
@@ -165,10 +165,10 @@ describe('<pc-light>', () => {
             // either side shows up here.
             light.setAttribute('shadow-type', 'vsm-32f');
             expect(light.shadowType, 'the element keeps the request').toBe('vsm-32f');
-            expect(light.component.shadowType, '32-bit VSM falls to 16-bit').toBe(SHADOW_VSM_16F);
+            expect(light.component!.shadowType, '32-bit VSM falls to 16-bit').toBe(SHADOW_VSM_16F);
 
             light.setAttribute('shadow-type', 'pcss-32f');
-            expect(light.component.shadowType, 'PCSS falls to PCF3').toBe(SHADOW_PCF3_32F);
+            expect(light.component!.shadowType, 'PCSS falls to PCF3').toBe(SHADOW_PCF3_32F);
         });
     });
 });

--- a/test/integration/components/scroll-view-component.test.ts
+++ b/test/integration/components/scroll-view-component.test.ts
@@ -26,10 +26,10 @@ describe('<pc-scroll-view>', () => {
         `);
         const scrollView = get<ScrollViewComponentElement>('pc-scroll-view');
 
-        expect(scrollView.component.viewportEntity).toBe(app.root.findByName('viewport'));
-        expect(scrollView.component.contentEntity).toBe(app.root.findByName('content'));
-        expect(scrollView.component.horizontalScrollbarEntity).toBe(app.root.findByName('h-scrollbar'));
-        expect(scrollView.component.verticalScrollbarEntity).toBe(app.root.findByName('v-scrollbar'));
+        expect(scrollView.component!.viewportEntity).toBe(app.root.findByName('viewport'));
+        expect(scrollView.component!.contentEntity).toBe(app.root.findByName('content'));
+        expect(scrollView.component!.horizontalScrollbarEntity).toBe(app.root.findByName('h-scrollbar'));
+        expect(scrollView.component!.verticalScrollbarEntity).toBe(app.root.findByName('v-scrollbar'));
     });
 
     it('warns once per unresolved reference, naming each attribute', async () => {
@@ -52,7 +52,7 @@ describe('<pc-scroll-view>', () => {
 
         // Unset references are the transient authoring state, not a mistake: the guard fails this
         // test if anything warns
-        expect(scrollView.component.viewportEntity).toBeNull();
-        expect(scrollView.component.contentEntity).toBeNull();
+        expect(scrollView.component!.viewportEntity).toBeNull();
+        expect(scrollView.component!.contentEntity).toBeNull();
     });
 });

--- a/test/integration/components/scrollbar-component.test.ts
+++ b/test/integration/components/scrollbar-component.test.ts
@@ -22,7 +22,7 @@ describe('<pc-scrollbar>', () => {
             `);
             const scrollbar = get<ScrollbarComponentElement>('pc-scrollbar');
 
-            expect(scrollbar.component.handleEntity).toBe(app.root.findByName('handle'));
+            expect(scrollbar.component!.handleEntity).toBe(app.root.findByName('handle'));
         });
 
         it('warns when the reference does not resolve, leaving the handle unset', async () => {
@@ -30,7 +30,7 @@ describe('<pc-scrollbar>', () => {
             const scrollbar = get<ScrollbarComponentElement>('pc-scrollbar');
 
             warnings.expect("pc-scrollbar could not resolve handle '#nope' - nothing in the document matches it - reference ignored");
-            expect(scrollbar.component.handleEntity).toBeNull();
+            expect(scrollbar.component!.handleEntity).toBeNull();
         });
 
         it('keeps the current handle when a reassigned reference does not resolve', async () => {
@@ -45,7 +45,7 @@ describe('<pc-scrollbar>', () => {
             scrollbar.setAttribute('handle', '#still-nope');
 
             warnings.expect("pc-scrollbar could not resolve handle '#still-nope'");
-            expect(scrollbar.component.handleEntity).toBe(app.root.findByName('handle'));
+            expect(scrollbar.component!.handleEntity).toBe(app.root.findByName('handle'));
         });
     });
 });

--- a/test/integration/lifecycle.test.ts
+++ b/test/integration/lifecycle.test.ts
@@ -188,10 +188,10 @@ describe('<pc-app> lifecycle', () => {
         // ...components were re-added to the recreated entity...
         const cameraElement = get<CameraComponentElement>('pc-camera');
         expect(cameraElement.component, 'the camera component is back').toBeTruthy();
-        expect(cameraElement.component.entity).toBe(entityElement.entity);
+        expect(cameraElement.component!.entity).toBe(entityElement.entity);
 
-        const soundsComponent = (get('pc-sound') as { component?: { slots: Record<string, unknown> } }).component;
-        expect(Object.keys(soundsComponent!.slots), 'the sound slot is back').toContain('blip');
+        const soundsComponent = (get('pc-sound') as { component?: { slots: Record<string, unknown> } }).component!;
+        expect(Object.keys(soundsComponent.slots), 'the sound slot is back').toContain('blip');
 
         // ...the model's host was recreated in the new application, re-registered, and its
         // content re-instantiated beneath it...
@@ -239,7 +239,7 @@ describe('<pc-app> lifecycle', () => {
         const cameraElement = handle.get<CameraComponentElement>('pc-camera');
         expect(entityElement.entity).toBeTruthy();
         expect(cameraElement.component).toBeTruthy();
-        expect(cameraElement.component.entity).toBe(entityElement.entity);
+        expect(cameraElement.component!.entity).toBe(entityElement.entity);
 
         expect(uncaught.seen).toEqual([]);
     });

--- a/test/integration/pointer.test.ts
+++ b/test/integration/pointer.test.ts
@@ -795,8 +795,8 @@ describe('pc-app pointer picking', () => {
                 <pc-entity name="camB"><pc-camera ${b}></pc-camera></pc-entity>
                 <pc-entity name="target"></pc-entity>
             `);
-            const cameraA = handle.get<CameraComponentElement>('pc-entity[name="camA"] pc-camera').component;
-            const cameraB = handle.get<CameraComponentElement>('pc-entity[name="camB"] pc-camera').component;
+            const cameraA = handle.get<CameraComponentElement>('pc-entity[name="camA"] pc-camera').component!;
+            const cameraB = handle.get<CameraComponentElement>('pc-entity[name="camB"] pc-camera').component!;
             const target = handle.get<EntityElement>('pc-entity[name="target"]');
             const enter = vi.fn();
             target.addEventListener('pointerenter', enter);

--- a/test/integration/render-material.test.ts
+++ b/test/integration/render-material.test.ts
@@ -22,7 +22,7 @@ describe('<pc-render> material', () => {
 
     it('resolves the material onto every mesh instance', async () => {
         const { get } = await bootApp(markup);
-        const component = get<RenderComponentElement>('pc-render').component;
+        const component = get<RenderComponentElement>('pc-render').component!;
 
         expect(component.meshInstances.length).toBeGreaterThan(0);
         for (const meshInstance of component.meshInstances) {
@@ -37,7 +37,7 @@ describe('<pc-render> material', () => {
         // with no material at all. The lookup is now guarded like every other reference attribute.
         const { get } = await bootApp(markup);
         const element = get<RenderComponentElement>('pc-render');
-        const component = element.component;
+        const component = element.component!;
 
         element.removeAttribute('material');
 
@@ -50,7 +50,7 @@ describe('<pc-render> material', () => {
     it('ignores a material id that resolves to nothing', async () => {
         const { get } = await bootApp(markup);
         const element = get<RenderComponentElement>('pc-render');
-        const component = element.component;
+        const component = element.component!;
 
         element.setAttribute('material', 'no-such-material');
 

--- a/test/integration/template-clone.test.ts
+++ b/test/integration/template-clone.test.ts
@@ -165,14 +165,14 @@ describe('a <template>-cloned subtree', () => {
         expect(links).toHaveLength(2);
         for (const link of links) {
             const joint = link.querySelector<JointComponentElement>('pc-joint')!;
-            expect(joint.component.entityA).toBe(link.querySelector<EntityElement>('pc-entity[name="Anchor"]')!.entity);
-            expect(joint.component.entityB).toBe(link.querySelector<EntityElement>('pc-entity[name="Bob"]')!.entity);
+            expect(joint.component!.entityA).toBe(link.querySelector<EntityElement>('pc-entity[name="Anchor"]')!.entity);
+            expect(joint.component!.entityB).toBe(link.querySelector<EntityElement>('pc-entity[name="Bob"]')!.entity);
         }
 
         // The decisive half: the second clone did not bind the first clone's entities, which is
         // what a document-wide lookup produces - it finds the first instance in document order.
         const [first, second] = links;
-        expect(second.querySelector<JointComponentElement>('pc-joint')!.component.entityA).not.toBe(
+        expect(second.querySelector<JointComponentElement>('pc-joint')!.component!.entityA).not.toBe(
             first.querySelector<EntityElement>('pc-entity[name="Anchor"]')!.entity
         );
 

--- a/utils/cem/component-type-plugin.mjs
+++ b/utils/cem/component-type-plugin.mjs
@@ -1,0 +1,62 @@
+/**
+ * Custom Elements Manifest plugin that keeps each element's `component` member concretely typed.
+ *
+ * `ComponentElement` is generic in its engine component type, and each element names its concrete
+ * type as the heritage type argument (`extends ComponentElement<LightComponent>`). The analyzer
+ * resolves neither: its inheritance step copies the base member onto every element and - by
+ * design - overwrites even an overridden member's type with the base's literal text, so every
+ * element would publish `component: T | null`. This plugin records each class's type argument
+ * during analysis and, once inheritance has been applied, restores the concrete type. The base
+ * class's own entry gets its type-parameter default for the same reason.
+ */
+
+/**
+ * @returns {object} The analyzer plugin.
+ */
+export const componentTypePlugin = () => {
+    /** @type {Map<string, string>} Concrete component type, keyed by element class name. */
+    const componentTypes = new Map();
+
+    /** The base class's type-parameter default, for its own manifest entry. */
+    let baseDefault = null;
+
+    return {
+        name: 'pwc-component-type',
+
+        analyzePhase({ ts, node }) {
+            if (!ts.isClassDeclaration(node) || !node.name) {
+                return;
+            }
+            if (node.name.text === 'ComponentElement') {
+                baseDefault = node.typeParameters?.[0]?.default?.getText() ?? null;
+                return;
+            }
+            const clause = node.heritageClauses?.find(item => item.token === ts.SyntaxKind.ExtendsKeyword);
+            const base = clause?.types.find(item => item.expression.getText() === 'ComponentElement');
+            const argument = base?.typeArguments?.[0]?.getText();
+            if (argument) {
+                componentTypes.set(node.name.text, argument);
+            }
+        },
+
+        packageLinkPhase({ customElementsManifest }) {
+            for (const module of customElementsManifest.modules ?? []) {
+                for (const declaration of module.declarations ?? []) {
+                    if (declaration.kind !== 'class') {
+                        continue;
+                    }
+                    const concrete = declaration.name === 'ComponentElement' ?
+                        baseDefault :
+                        componentTypes.get(declaration.name);
+                    if (!concrete) {
+                        continue;
+                    }
+                    const member = (declaration.members ?? []).find(item => item.name === 'component');
+                    if (member) {
+                        member.type = { text: `${concrete} | null` };
+                    }
+                }
+            }
+        }
+    };
+};

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -367,6 +367,21 @@ if (manifest) {
             `${tag} non-attribute members are [${extras.join(', ')}], expected [${expected.join(', ')}]`);
     }
 
+    // The `component` member's concrete type is manufactured by component-type-plugin.mjs: the
+    // analyzer's inheritance step overwrites even an overridden member's type with the base
+    // class's literal text, so without the plugin every element would publish `component:
+    // T | null`. One exact pin, plus the shape across every component element - a regression
+    // here ships a bare type variable to every manifest consumer.
+    const memberType = (tag, name) => (elements.get(tag)?.members ?? [])
+        .find(member => member.name === name)?.type?.text;
+    check(memberType('pc-light', 'component') === 'LightComponent | null',
+        `pc-light.component is typed ${JSON.stringify(memberType('pc-light', 'component'))}, expected "LightComponent | null"`);
+    for (const tag of COMPONENT_TAGS) {
+        const text = memberType(tag, 'component') ?? '';
+        check(/^[A-Z]\w*Component \| null$/.test(text),
+            `${tag}.component is typed ${JSON.stringify(text)}, not a concrete nullable component type`);
+    }
+
     // The base classes and whenReady sit outside the per-tag map, but their surface is
     // inherited by (or waits on) every element, so losing it would break all of them at once
     const classes = new Map();
@@ -385,6 +400,13 @@ if (manifest) {
         check(actual.join() === [...expected].sort().join(),
             `${name} members are [${actual.join(', ')}], expected [${expected.join(', ')}]`);
     }
+
+    // The base class's own `component` entry carries its type-parameter default rather than the
+    // bare `T | null` the analyzer reads from the source
+    const baseComponent = (classes.get('ComponentElement')?.members ?? [])
+        .find(member => member.name === 'component');
+    check(baseComponent?.type?.text === 'Component | null',
+        `ComponentElement.component is typed ${JSON.stringify(baseComponent?.type?.text)}, expected "Component | null"`);
     check((manifest.modules ?? []).some(module => (module.declarations ?? [])
         .some(declaration => declaration.kind === 'function' && declaration.name === 'whenReady')),
     "the manifest lost the 'whenReady' function declaration");


### PR DESCRIPTION
Fixes #434.

`ComponentElement.component` genuinely returns `null` — before readiness, after disconnection, outside an entity-fronting element, and when component creation is skipped — but all 19 concrete elements overrode the getter with a cast-only, non-null return type. The public declarations promised a component that can be absent. This corrects the TypeScript contract before 1.0, with runtime behavior unchanged.

## What changed

- `ComponentElement<T extends Component = Component>` is now generic in its engine component type. The single `addComponent` cast lives in the base; the default keeps bare `ComponentElement` references (e.g. `instanceof` checks, re-exports) working unchanged.
- All 19 element subclasses pass their concrete type as the heritage argument (`extends ComponentElement<LightComponent>`) and keep an explicit, cast-free getter typed `ConcreteComponent | null`.
- Two local guards in `AnimComponentElement` (`_applyRootBone`, `_assignClip`) whose callers guard at a distance the compiler cannot see. Every other internal use was already null-guarded — the codebase was written against a nullable component all along; only the public typings disagreed.
- Tests: extraction sites and post-readiness accesses assert with `!`; new coverage pins the null states (never connected, connected-but-pending, disconnected, skipped duplicate), the ready non-null state (`instanceof LightComponent`), and the declared types at both the base class and a concrete element via `expectTypeOf`.

## Tooling: what the pipeline actually does (measured, not assumed)

The issue asked to confirm whether CEM/TypeDoc specialize an inherited generic getter. Neither does, and the CEM half of the issue's premise was wrong in a useful way:

- **The cast-only getters never reached the manifest.** The analyzer's inheritance step overwrites even an *overridden* member's type with the base's literal text (`{...newItem, ...existing, type: newItem.type}` in `apply-inheritance.js`), so the shipped manifest already said `Component | null` for every element. With a generic base it would say literally `T | null` — even with the overrides retained.
- **TypeDoc** does not substitute type arguments into inherited accessors (`T | null`), but honors explicit overrides — which is why the concrete getters are retained rather than removed.

So this PR adds `utils/cem/component-type-plugin.mjs`: it records each class's heritage type argument during analysis and restores the concrete type after inheritance runs. The manifest now publishes `LightComponent | null` etc. — *more* precise than before this change, not merely preserved. `validate.mjs` gains pins on the member type text (previously only member names were pinned), so a regression to a bare type variable fails the build. The base class's own entry is pinned to `Component | null`.

## Breaking change (pre-1.0, deliberate)

TypeScript callers must now account for `null` when accessing `component`, unless they narrow or assert after awaiting readiness. Runtime is unchanged. Doing this after 1.0 would be semver-major; that is why it lands now.

## Verification

- `npm run build` (including CEM generation + validation with the new pins), `npm run lint`, `npm run type-check` (src + test), `npm test` (1046 passing), `npm run publint`, `npm run docs` — all clean.
- Both emitted declaration trees (`dist/index.d.ts`, `dist/index.d.cts`) compile standalone with `tsc --strict --ignoreConfig` with no errors of their own (the engine's own `.d.ts` reports pre-existing WebXR ambient-type noise that `skipLibCheck` hides in normal builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
