### PR TITLE
Prevent stale particle config loads and centralize asset binding

### DIFF
--- a/custom-elements-manifest.config.mjs
+++ b/custom-elements-manifest.config.mjs
@@ -25,7 +25,7 @@ export default {
     // None of these files declares an element, so excluding them keeps the manifest to the public
     // element surface. The base classes in async-element.ts and components/component.ts are
     // deliberately included - the elements that extend them inherit their attributes and events.
-    exclude: ['src/colors.ts', 'src/loading-bar.ts', 'src/parse.ts'],
+    exclude: ['src/asset-binding.ts', 'src/colors.ts', 'src/loading-bar.ts', 'src/parse.ts'],
 
     // dist is wiped by `prebuild` and shipped via the `files` and `exports` fields, so the
     // generated files can never go stale and never need committing

--- a/src/asset-binding.ts
+++ b/src/asset-binding.ts
@@ -13,14 +13,15 @@ import { useAsset } from './asset';
  */
 export type AssetBindingCallbacks = {
     /**
-     * Delivers the loaded asset: synchronously from {@link AssetBinding.bind} when the asset has
-     * already loaded, otherwise from its `load` event.
+     * Delivers the asset once it holds a resource: synchronously from {@link AssetBinding.bind}
+     * when the asset had already loaded one, otherwise from its `load` event.
      */
     load: (asset: Asset) => void;
 
     /**
-     * Delivers a failed load. Optional — without it, a failure leaves the binding subscribed, so
-     * an asset that is reloaded after an error still delivers.
+     * Delivers a failed load — one that fails while subscribed, or one that had already failed
+     * when {@link AssetBinding.bind} ran. Optional — without it, a failure leaves the binding
+     * subscribed, so an asset that is reloaded after an error still delivers.
      */
     error?: (err: string | Error) => void;
 };
@@ -77,8 +78,9 @@ export class AssetBinding {
     /**
      * Binds to the asset registered under `id`, superseding whatever the binding was waiting
      * for — even when `id` resolves to nothing, since the element's reference has still moved
-     * on. Resolution starts a lazy asset's load. An already-loaded asset is delivered before
-     * this returns; otherwise the binding subscribes to the asset's settlement, detaching its
+     * on. Resolution starts a lazy asset's load. An asset that has already settled is delivered
+     * before this returns — through `load` when it holds a resource, through `error` when its
+     * load failed; otherwise the binding subscribes to the asset's settlement, detaching its
      * handlers once either event delivers.
      *
      * @param id - The `id` of the `<pc-asset>` element to bind to.
@@ -95,9 +97,21 @@ export class AssetBinding {
             return undefined;
         }
 
+        const { error } = callbacks;
+
         if (asset.loaded) {
-            callbacks.load(asset);
-            return asset;
+            // The engine marks a failed load `loaded` too - the flag means settled, not that a
+            // resource arrived. A settled failure must not deliver `load` with an empty
+            // resource: it reports through `error` where requested, and otherwise falls through
+            // to wait for a reload, exactly like a failure that happens while subscribed.
+            if (asset.resource != null) {
+                callbacks.load(asset);
+                return asset;
+            }
+            if (error) {
+                error(`asset '${id}' failed to load`);
+                return asset;
+            }
         }
 
         // Each handler checks its generation before detaching: a stale callback (one the detach
@@ -111,7 +125,6 @@ export class AssetBinding {
             callbacks.load(asset);
         });
 
-        const { error } = callbacks;
         if (error) {
             this._errorHandle = asset.once('error', (err: string | Error) => {
                 if (generation !== this._generation) {

--- a/src/asset-binding.ts
+++ b/src/asset-binding.ts
@@ -104,6 +104,9 @@ export class AssetBinding {
             // resource arrived. A settled failure must not deliver `load` with an empty
             // resource: it reports through `error` where requested, and otherwise falls through
             // to wait for a reload, exactly like a failure that happens while subscribed.
+            // Loosely != null on purpose: `resource` indexes the asset's resources array, so a
+            // failure that never produced one reads `undefined` while an explicit clear writes
+            // `null` - and a falsy-but-real resource (a text asset's '') must still deliver.
             if (asset.resource != null) {
                 callbacks.load(asset);
                 return asset;

--- a/src/asset-binding.ts
+++ b/src/asset-binding.ts
@@ -1,0 +1,127 @@
+import type { Asset, EventHandle } from 'playcanvas';
+
+import { useAsset } from './asset';
+
+// Both declarations are exported inline: stripInternal drops an @internal declaration together
+// with an inline export, but a separate `export { ... }` statement would survive it and leave
+// the emitted .d.ts exporting names that no longer exist.
+
+/**
+ * How an {@link AssetBinding} delivers its asset's settlement.
+ *
+ * @internal
+ */
+export type AssetBindingCallbacks = {
+    /**
+     * Delivers the loaded asset: synchronously from {@link AssetBinding.bind} when the asset has
+     * already loaded, otherwise from its `load` event.
+     */
+    load: (asset: Asset) => void;
+
+    /**
+     * Delivers a failed load. Optional — without it, a failure leaves the binding subscribed, so
+     * an asset that is reloaded after an error still delivers.
+     */
+    error?: (err: string | Error) => void;
+};
+
+/**
+ * One element's subscription to the settlement of its current asset reference.
+ *
+ * Every element that consumes an asset asynchronously has the same lifecycle problem: an asset
+ * change or a disconnect supersedes a load still in flight, and the superseded load's callback
+ * must not act on state it no longer owns. The mechanics of staying safe live here — resolve
+ * through {@link useAsset} (which starts a lazy asset's load), deliver an already-loaded asset
+ * immediately, otherwise subscribe to settlement, and guarantee that a superseded or cancelled
+ * subscription never delivers. What to do with the delivered asset — instantiation, warnings,
+ * readiness, resource ownership — stays in the consumer.
+ *
+ * An element owns one binding per asset reference for its whole life: `bind` supersedes whatever
+ * the binding was waiting for, and `cancel` (typically on disconnect) leaves it waiting for
+ * nothing. Because the binding itself is stable, a delivery that synchronously starts another
+ * bind cannot orphan the newer subscription — there is no per-load handle for a resumed caller
+ * to overwrite.
+ *
+ * @internal
+ */
+export class AssetBinding {
+    /**
+     * Incremented by every bind and cancel, and captured by a subscription when it is installed.
+     * A callback whose generation has moved on abandons itself without touching the binding —
+     * any handles it would detach belong to the subscription that superseded it. Bind and cancel
+     * already detach superseded handlers; the generation holds on its own, without relying on
+     * how the engine's event emitter treats removal.
+     */
+    private _generation = 0;
+
+    private _loadHandle: EventHandle | null = null;
+
+    private _errorHandle: EventHandle | null = null;
+
+    private _detach() {
+        this._loadHandle?.off();
+        this._loadHandle = null;
+        this._errorHandle?.off();
+        this._errorHandle = null;
+    }
+
+    /**
+     * Cancels the binding: whatever it was waiting for is detached and can no longer deliver.
+     * The binding stays usable — a later {@link bind} starts a new subscription.
+     */
+    cancel() {
+        this._generation++;
+        this._detach();
+    }
+
+    /**
+     * Binds to the asset registered under `id`, superseding whatever the binding was waiting
+     * for — even when `id` resolves to nothing, since the element's reference has still moved
+     * on. Resolution starts a lazy asset's load. An already-loaded asset is delivered before
+     * this returns; otherwise the binding subscribes to the asset's settlement, detaching its
+     * handlers once either event delivers.
+     *
+     * @param id - The `id` of the `<pc-asset>` element to bind to.
+     * @param callbacks - Where settlement is delivered.
+     * @returns The resolved asset, or `undefined` — the caller owns the policy for a reference
+     * that resolves to nothing.
+     */
+    bind(id: string, callbacks: AssetBindingCallbacks): Asset | undefined {
+        const generation = ++this._generation;
+        this._detach();
+
+        const asset = useAsset(id);
+        if (!asset) {
+            return undefined;
+        }
+
+        if (asset.loaded) {
+            callbacks.load(asset);
+            return asset;
+        }
+
+        // Each handler checks its generation before detaching: a stale callback (one the detach
+        // above should already have removed) must not detach the subscription that superseded
+        // it. Whichever of load/error fires first detaches the other.
+        this._loadHandle = asset.once('load', () => {
+            if (generation !== this._generation) {
+                return;
+            }
+            this._detach();
+            callbacks.load(asset);
+        });
+
+        const { error } = callbacks;
+        if (error) {
+            this._errorHandle = asset.once('error', (err: string | Error) => {
+                if (generation !== this._generation) {
+                    return;
+                }
+                this._detach();
+                error(err);
+            });
+        }
+
+        return asset;
+    }
+}

--- a/src/asset-binding.ts
+++ b/src/asset-binding.ts
@@ -2,56 +2,55 @@ import type { Asset, EventHandle } from 'playcanvas';
 
 import { useAsset } from './asset';
 
-// Both declarations are exported inline: stripInternal drops an @internal declaration together
-// with an inline export, but a separate `export { ... }` statement would survive it and leave
-// the emitted .d.ts exporting names that no longer exist.
+// Keep `export` on these declarations. TypeScript removes the declaration and its inline export
+// when `stripInternal` is enabled. A separate `export { ... }` statement would remain in the
+// generated .d.ts file and refer to a declaration that had been removed.
 
 /**
- * How an {@link AssetBinding} delivers its asset's settlement.
+ * Functions called when an {@link AssetBinding} finishes loading an asset or encounters an
+ * error.
  *
  * @internal
  */
 export type AssetBindingCallbacks = {
     /**
-     * Delivers the asset once it holds a resource: synchronously from {@link AssetBinding.bind}
-     * when the asset had already loaded one, otherwise from its `load` event.
+     * Called when the asset has a usable resource. If it was already loaded, this can run before
+     * {@link AssetBinding.bind} returns. Otherwise it runs when the asset fires `load`.
      */
     load: (asset: Asset) => void;
 
     /**
-     * Delivers a failed load — one that fails while subscribed, or one that had already failed
-     * when {@link AssetBinding.bind} ran. Optional — without it, a failure leaves the binding
-     * subscribed, so an asset that is reloaded after an error still delivers.
+     * Called when the asset fails to load, including when it had already failed before
+     * {@link AssetBinding.bind} was called. If this is omitted, the binding keeps waiting so a
+     * later successful reload can still call `load`.
      */
     error?: (err: string | Error) => void;
 };
 
 /**
- * One element's subscription to the settlement of its current asset reference.
+ * Watches the asset currently selected by an element.
  *
- * Every element that consumes an asset asynchronously has the same lifecycle problem: an asset
- * change or a disconnect supersedes a load still in flight, and the superseded load's callback
- * must not act on state it no longer owns. The mechanics of staying safe live here — resolve
- * through {@link useAsset} (which starts a lazy asset's load), deliver an already-loaded asset
- * immediately, otherwise subscribe to settlement, and guarantee that a superseded or cancelled
- * subscription never delivers. What to do with the delivered asset — instantiation, warnings,
- * readiness, resource ownership — stays in the consumer.
+ * An element can change its asset while the old one is still loading, or disconnect before the
+ * load finishes. This class makes sure callbacks from those older loads do nothing. Calling
+ * {@link bind} stops watching the previous asset and starts watching the new one. Calling
+ * {@link cancel} stops watching altogether.
  *
- * An element owns one binding per asset reference for its whole life: `bind` supersedes whatever
- * the binding was waiting for, and `cancel` (typically on disconnect) leaves it waiting for
- * nothing. Because the binding itself is stable, a delivery that synchronously starts another
- * bind cannot orphan the newer subscription — there is no per-load handle for a resumed caller
- * to overwrite.
+ * Asset lookup goes through {@link useAsset}, so selecting a lazy asset starts its load. The
+ * caller still decides what to do with the result, such as creating scene content, reporting an
+ * error, or marking an element ready.
+ *
+ * Reuse one `AssetBinding` for each asset-valued property throughout the element's lifetime. It
+ * is safe for a callback to call `bind` again: the new asset remains active after the callback
+ * returns.
  *
  * @internal
  */
 export class AssetBinding {
     /**
-     * Incremented by every bind and cancel, and captured by a subscription when it is installed.
-     * A callback whose generation has moved on abandons itself without touching the binding —
-     * any handles it would detach belong to the subscription that superseded it. Bind and cancel
-     * already detach superseded handlers; the generation holds on its own, without relying on
-     * how the engine's event emitter treats removal.
+     * Each bind or cancel gets a new number. Event handlers remember the number they were created
+     * with and return if it is no longer current. Old listeners are normally removed as well, but
+     * this check also protects against an event that was already in progress when removal
+     * happened.
      */
     private _generation = 0;
 
@@ -67,8 +66,8 @@ export class AssetBinding {
     }
 
     /**
-     * Cancels the binding: whatever it was waiting for is detached and can no longer deliver.
-     * The binding stays usable — a later {@link bind} starts a new subscription.
+     * Stops watching the current asset and prevents its callbacks from running. The binding can
+     * be used again by calling {@link bind}.
      */
     cancel() {
         this._generation++;
@@ -76,17 +75,18 @@ export class AssetBinding {
     }
 
     /**
-     * Binds to the asset registered under `id`, superseding whatever the binding was waiting
-     * for — even when `id` resolves to nothing, since the element's reference has still moved
-     * on. Resolution starts a lazy asset's load. An asset that has already settled is delivered
-     * before this returns — through `load` when it holds a resource, through `error` when its
-     * load failed; otherwise the binding subscribes to the asset's settlement, detaching its
-     * handlers once either event delivers.
+     * Starts watching the asset registered under `id` and stops watching the previous one. A
+     * missing `id` still clears the previous binding. Looking up a lazy asset starts its load.
+     *
+     * If the asset has already loaded successfully, `load` runs before this method returns. An
+     * earlier failure calls `error` immediately when that callback is provided; without one, the
+     * binding waits for a later successful reload. Assets still loading are watched for the same
+     * two outcomes. Once an event is handled, both listeners are removed.
      *
      * @param id - The `id` of the `<pc-asset>` element to bind to.
-     * @param callbacks - Where settlement is delivered.
-     * @returns The resolved asset, or `undefined` — the caller owns the policy for a reference
-     * that resolves to nothing.
+     * @param callbacks - Functions to call when loading succeeds or fails.
+     * @returns The selected asset, or `undefined` if no asset has this `id`. The caller decides
+     * how to handle a missing asset.
      */
     bind(id: string, callbacks: AssetBindingCallbacks): Asset | undefined {
         const generation = ++this._generation;
@@ -100,13 +100,10 @@ export class AssetBinding {
         const { error } = callbacks;
 
         if (asset.loaded) {
-            // The engine marks a failed load `loaded` too - the flag means settled, not that a
-            // resource arrived. A settled failure must not deliver `load` with an empty
-            // resource: it reports through `error` where requested, and otherwise falls through
-            // to wait for a reload, exactly like a failure that happens while subscribed.
-            // Loosely != null on purpose: `resource` indexes the asset's resources array, so a
-            // failure that never produced one reads `undefined` while an explicit clear writes
-            // `null` - and a falsy-but-real resource (a text asset's '') must still deliver.
+            // PlayCanvas sets `loaded` after both success and failure, so a resource must also be
+            // present before this counts as success. Use `!= null` deliberately: `undefined` and
+            // `null` both mean there is no resource, while a valid resource can still be falsy
+            // (for example, an empty text file produces '').
             if (asset.resource != null) {
                 callbacks.load(asset);
                 return asset;
@@ -117,9 +114,10 @@ export class AssetBinding {
             }
         }
 
-        // Each handler checks its generation before detaching: a stale callback (one the detach
-        // above should already have removed) must not detach the subscription that superseded
-        // it. Whichever of load/error fires first detaches the other.
+        // Old listeners are normally removed by bind or cancel. The number check is a second
+        // safeguard for a late event. Check it before _detach so an old callback cannot remove
+        // the listeners for the current asset. Whichever current event runs first removes both
+        // listeners.
         this._loadHandle = asset.once('load', () => {
             if (generation !== this._generation) {
                 return;

--- a/src/components/particle-system-component.ts
+++ b/src/components/particle-system-component.ts
@@ -1,6 +1,7 @@
-import type { ParticleSystemComponent } from 'playcanvas';
+import type { Asset, ParticleSystemComponent } from 'playcanvas';
 
 import { useAsset } from '../asset';
+import { AssetBinding } from '../asset-binding';
 
 import { ComponentElement } from './component';
 
@@ -21,6 +22,14 @@ import { ComponentElement } from './component';
 class ParticleSystemComponentElement extends ComponentElement<ParticleSystemComponent> {
     private _asset = '';
 
+    /**
+     * The subscription to the current config asset while its load is in flight. Rebinding
+     * supersedes it and disconnect cancels it, so a superseded config — an earlier asset that
+     * finishes loading after its replacement, or a callback left behind by a previous
+     * connection — can never configure the component.
+     */
+    private _binding = new AssetBinding();
+
     /** @ignore */
     constructor() {
         super('particlesystem');
@@ -28,20 +37,30 @@ class ParticleSystemComponentElement extends ComponentElement<ParticleSystemComp
 
     protected getInitialComponentData() {
         const asset = useAsset(this._asset);
-        // A lazy config has no resource yet - _loadAsset applies it once the load completes
+        // A lazy config has no resource yet - the config binding applies it once the load
+        // completes
         if (!asset || !asset.resource) {
             return {};
         }
 
-        if ((asset.resource as any).colorMapAsset) {
-            const id = (asset.resource as any).colorMapAsset;
-            const colorMapAsset = useAsset(id)?.id;
-            if (colorMapAsset) {
-                (asset.resource as any).colorMapAsset = colorMapAsset;
-            }
-        }
-
+        this._resolveColorMap(asset.resource);
         return asset.resource;
+    }
+
+    protected initComponent() {
+        // A loaded config already arrived through getInitialComponentData - the binding is only
+        // needed for a load still in flight. Resolution here also starts a lazy config's load.
+        const asset = useAsset(this._asset);
+        if (asset && !asset.loaded) {
+            this._bindConfig();
+        }
+    }
+
+    disconnectedCallback() {
+        // The binding dies with the connection, so a config that finishes loading later cannot
+        // configure the component a reconnection creates - that connection binds afresh.
+        this._binding.cancel();
+        super.disconnectedCallback();
     }
 
     /**
@@ -53,10 +72,27 @@ class ParticleSystemComponentElement extends ComponentElement<ParticleSystemComp
         return super.component;
     }
 
+    /**
+     * Rewrites the config's `colorMapAsset` from the `pc-asset` id it is authored with to the
+     * engine asset id the component resolves, starting the texture's load if it is lazy. The
+     * rewrite is in place, so a config applied again — a host cycle, a reconnection — is already
+     * resolved and passes through unchanged.
+     */
+    private _resolveColorMap(resource: any) {
+        if (resource.colorMapAsset) {
+            const colorMapAsset = useAsset(resource.colorMapAsset)?.id;
+            if (colorMapAsset) {
+                resource.colorMapAsset = colorMapAsset;
+            }
+        }
+    }
+
     private applyConfig(resource: any) {
         if (!this.component) {
             return;
         }
+
+        this._resolveColorMap(resource);
 
         // Set all the config properties on the component
         for (const key in resource) {
@@ -66,21 +102,10 @@ class ParticleSystemComponentElement extends ComponentElement<ParticleSystemComp
         }
     }
 
-    private async _loadAsset() {
-        await this.closestApp?.ready();
-
-        const asset = useAsset(this._asset);
-        if (!asset) {
-            return;
-        }
-
-        if (asset.loaded) {
-            this.applyConfig(asset.resource);
-        } else {
-            asset.once('load', () => {
-                this.applyConfig(asset.resource);
-            });
-        }
+    private _bindConfig() {
+        this._binding.bind(this._asset, {
+            load: (asset: Asset) => this.applyConfig(asset.resource)
+        });
     }
 
     /**
@@ -90,7 +115,7 @@ class ParticleSystemComponentElement extends ComponentElement<ParticleSystemComp
     set asset(value: string) {
         this._asset = value;
         if (this.isConnected) {
-            this._loadAsset();
+            this._bindConfig();
         }
     }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,7 +1,7 @@
-import type { ContainerResource, Entity, EventHandle } from 'playcanvas';
+import type { ContainerResource, Entity } from 'playcanvas';
 import { Vec3 } from 'playcanvas';
 
-import { useAsset } from './asset';
+import { AssetBinding } from './asset-binding';
 import { EVENT_ATTRIBUTES } from './entity-base';
 import { buildDescendantEntities, EntityOwnerElement } from './entity-owner';
 import { parseBool, parseTags, parseVec3 } from './parse';
@@ -168,20 +168,19 @@ class ModelElement extends EntityOwnerElement {
 
     /**
      * Incremented on every new load, on disconnect, and when the host entity dies, and captured
-     * by a load when it starts. A load that resumes from an await or a load callback abandons
-     * itself if the value has moved on, so a superseded load can neither instantiate a second
-     * content root nor parent one under a host a newer cycle has already replaced.
+     * by a load when it starts. A load that resumes from an await abandons itself if the value
+     * has moved on, so a superseded load can neither instantiate a second content root nor
+     * parent one under a host a newer cycle has already replaced. The asset subscription itself
+     * is guarded by the binding below.
      */
     private _loadGeneration = 0;
 
     /**
-     * The pending asset subscriptions of the current load, if it is waiting for its asset. Held
-     * so that whatever supersedes the load can detach the handlers from the asset, rather than
-     * leave them registered until the asset settles (or forever, if it never does).
+     * The subscription to the current container asset while it is loading. Whatever supersedes
+     * the load — a newer load, a disconnect, the host dying — cancels it, so the asset settling
+     * later cannot deliver to a load that no longer owns the element.
      */
-    private _loadHandle: EventHandle | null = null;
-
-    private _errorHandle: EventHandle | null = null;
+    private _binding = new AssetBinding();
 
     /**
      * The root entity of the instantiated model content, parented beneath the host entity.
@@ -287,7 +286,7 @@ class ModelElement extends EntityOwnerElement {
         // resets the element. The generation guard comes first so a load suspended on an await
         // cannot resume against the torn-down element.
         this._loadGeneration++;
-        this._detachLoadHandlers();
+        this._binding.cancel();
         this._entity?.destroy();
     }
 
@@ -308,16 +307,9 @@ class ModelElement extends EntityOwnerElement {
      */
     protected override _onEntityDestroy(entity: Entity) {
         this._loadGeneration++;
-        this._detachLoadHandlers();
+        this._binding.cancel();
         this._contentEntity = null;
         super._onEntityDestroy(entity);
-    }
-
-    private _detachLoadHandlers() {
-        this._loadHandle?.off();
-        this._loadHandle = null;
-        this._errorHandle?.off();
-        this._errorHandle = null;
     }
 
     /**
@@ -350,7 +342,7 @@ class ModelElement extends EntityOwnerElement {
 
         // Supersede any load already in flight - only the newest load may instantiate
         const generation = ++this._loadGeneration;
-        this._detachLoadHandlers();
+        this._binding.cancel();
 
         // Re-arm readiness so a waiter obtained after an asset change resolves against the new
         // content. A no-op on first connection, where readiness is still pending.
@@ -383,32 +375,11 @@ class ModelElement extends EntityOwnerElement {
             return;
         }
 
-        const asset = useAsset(this._asset);
-        if (!asset) {
-            // A non-empty id that resolves to nothing is a dead end - say so rather than staying
-            // silently pending.
-            console.warn(`pc-model could not find asset '${this._asset}' - model not created`);
-            return;
-        }
-
-        if (asset.loaded) {
-            this._instantiate(asset.resource as ContainerResource);
-        } else {
-            // The generation is re-checked even though a superseded handler is detached: the
-            // detach relies on how the engine's event emitter treats removal, while the check
-            // holds on its own. Whichever of load/error fires first detaches the other.
-            this._loadHandle = asset.once('load', () => {
-                this._detachLoadHandlers();
-                if (generation !== this._loadGeneration) {
-                    return;
-                }
-                this._instantiate(asset.resource as ContainerResource);
-            });
-            this._errorHandle = asset.once('error', (err: string | Error) => {
-                this._detachLoadHandlers();
-                if (generation !== this._loadGeneration) {
-                    return;
-                }
+        // Every path that moves _loadGeneration also rebinds or cancels the binding, so a
+        // delivery below is always current - no generation re-check needed in the callbacks.
+        const asset = this._binding.bind(this._asset, {
+            load: ({ resource }) => this._instantiate(resource as ContainerResource),
+            error: (err) => {
                 // A failed load settles readiness with a null contentEntity, mirroring pc-asset:
                 // readiness means the load settled, not that it succeeded.
                 this.dispatchEvent(
@@ -417,7 +388,12 @@ class ModelElement extends EntityOwnerElement {
                     })
                 );
                 this._onReady();
-            });
+            }
+        });
+        if (!asset) {
+            // A non-empty id that resolves to nothing is a dead end - say so rather than staying
+            // silently pending.
+            console.warn(`pc-model could not find asset '${this._asset}' - model not created`);
         }
     }
 

--- a/test/integration/components/particle-system-component.test.ts
+++ b/test/integration/components/particle-system-component.test.ts
@@ -1,0 +1,200 @@
+import type { AppBase, Asset } from 'playcanvas';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AssetElement } from '../../../src/asset';
+import type { EntityElement } from '../../../src/entity';
+import { bootApp } from '../../helpers/app';
+import { useGuard } from '../../helpers/guard';
+import { readyWithin } from '../../helpers/ready';
+
+/**
+ * A particle config asset as a `data:` URI, so it loads without I/O.
+ *
+ * @param config - The config object to serialize.
+ * @returns The data: URI.
+ */
+const jsonSrc = (config: Record<string, unknown>) =>
+    `data:application/json,${encodeURIComponent(JSON.stringify(config))}`;
+
+/** The engine's ParticleSystemComponent default, proving a config was NOT applied. */
+const DEFAULT_LIFETIME = 50;
+
+/** Two lazy configs whose loads the tests park and settle in a chosen order. */
+const RACE_ASSETS = `
+    <pc-asset id="cfg-a" type="json" src="cfg-a.json" lazy></pc-asset>
+    <pc-asset id="cfg-b" type="json" src="cfg-b.json" lazy></pc-asset>
+    <pc-entity name="fx"></pc-entity>
+`;
+
+type LoaderCallback = (err: string | null, resource?: unknown) => void;
+
+/**
+ * Replaces the app's resource loader with one that parks every load until the test settles it,
+ * making settlement order a test input rather than a network accident. Settling a parked load
+ * runs the registry's own completion path, so the asset's real `load`/`error` events fire.
+ *
+ * @param app - The booted application.
+ * @returns Parked loads, keyed by the asset's file URL.
+ */
+const parkLoads = (app: AppBase) => {
+    const parked = new Map<string, LoaderCallback>();
+    vi.spyOn(app.loader, 'load').mockImplementation(((url: string, _type: string, callback: LoaderCallback) => {
+        parked.set(url, callback);
+    }) as typeof app.loader.load);
+    return parked;
+};
+
+/**
+ * The number of handlers subscribed to one of an asset's events, for asserting that a binding
+ * detached itself. Counted relative to a baseline, since the `pc-asset` element itself keeps a
+ * listener on each channel for the element's whole life.
+ *
+ * @param asset - The asset to inspect.
+ * @param name - The event name.
+ * @returns The number of subscribed handlers.
+ */
+const listenerCount = (asset: Asset, name: string) =>
+    (asset as unknown as { _callbacks: Map<string, unknown[]> })._callbacks.get(name)?.length ?? 0;
+
+/**
+ * Mounts a `<pc-particle-system>` bound to `assetId` under the booted `pc-entity` and waits for
+ * its component.
+ *
+ * @param host - The host entity element.
+ * @param assetId - The initial `asset` attribute value.
+ * @returns The ready element.
+ */
+const mountParticleSystem = async (host: EntityElement, assetId: string) => {
+    const element = document.createElement('pc-particle-system');
+    element.setAttribute('asset', assetId);
+    host.appendChild(element);
+    await readyWithin(element);
+    expect(element.component, 'the component exists').toBeTruthy();
+    return element;
+};
+
+describe('<pc-particle-system>', () => {
+    const { uncaught } = useGuard();
+
+    describe('stale config loads', () => {
+        it('applies only the newest asset when a superseded load settles later', async () => {
+            const { app, get } = await bootApp(RACE_ASSETS);
+            const parked = parkLoads(app);
+
+            const element = await mountParticleSystem(get('pc-entity'), 'cfg-a');
+            expect(parked.has('cfg-a.json'), 'binding the pending config started its load').toBe(true);
+
+            element.setAttribute('asset', 'cfg-b');
+            expect(parked.has('cfg-b.json')).toBe(true);
+
+            // B settles first, then A - the superseded config must not overwrite its replacement
+            parked.get('cfg-b.json')!(null, { lifetime: 9, rate: 3 });
+            parked.get('cfg-a.json')!(null, { lifetime: 5, rate: 7 });
+
+            expect(element.component!.lifetime, 'the superseded config did not apply').toBe(9);
+            expect(element.component!.rate).toBe(3);
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('prevents an asset cleared while pending from applying when it settles', async () => {
+            const { app, get } = await bootApp(RACE_ASSETS);
+            const parked = parkLoads(app);
+
+            const element = await mountParticleSystem(get('pc-entity'), 'cfg-a');
+
+            element.removeAttribute('asset');
+            parked.get('cfg-a.json')!(null, { lifetime: 5 });
+
+            expect(element.component!.lifetime, 'the cleared config did not apply').toBe(DEFAULT_LIFETIME);
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('detaches superseded, settled and disconnected bindings from their assets', async () => {
+            const { app, get } = await bootApp(RACE_ASSETS);
+            const parked = parkLoads(app);
+            const assetA = get<AssetElement>('pc-asset[id="cfg-a"]').asset!;
+            const assetB = get<AssetElement>('pc-asset[id="cfg-b"]').asset!;
+            const baselineA = listenerCount(assetA, 'load');
+            const baselineB = listenerCount(assetB, 'load');
+
+            const element = await mountParticleSystem(get('pc-entity'), 'cfg-a');
+            expect(listenerCount(assetA, 'load'), 'the pending binding is subscribed').toBe(baselineA + 1);
+
+            element.setAttribute('asset', 'cfg-b');
+            expect(listenerCount(assetA, 'load'), 'superseding detached the old subscription').toBe(baselineA);
+            expect(listenerCount(assetB, 'load')).toBe(baselineB + 1);
+
+            parked.get('cfg-b.json')!(null, { lifetime: 9 });
+            expect(listenerCount(assetB, 'load'), 'settling detached the subscription').toBe(baselineB);
+
+            element.setAttribute('asset', 'cfg-a');
+            element.remove();
+            expect(listenerCount(assetA, 'load'), 'disconnecting detached the subscription').toBe(baselineA);
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('does not let a load from a previous connection configure a reconnected component', async () => {
+            const { app, get } = await bootApp(RACE_ASSETS);
+            const parked = parkLoads(app);
+            const host = get<EntityElement>('pc-entity');
+
+            const element = await mountParticleSystem(host, 'cfg-a');
+            const first = element.component!;
+
+            element.remove();
+            element.setAttribute('asset', 'cfg-b');
+            host.appendChild(element);
+            await readyWithin(element);
+
+            const second = element.component!;
+            expect(second, 'reconnection created a new component').not.toBe(first);
+
+            // The old connection's config settles now - only the new connection's may configure
+            parked.get('cfg-a.json')!(null, { lifetime: 5 });
+            expect(second.lifetime, "the previous connection's load did not apply").toBe(DEFAULT_LIFETIME);
+
+            parked.get('cfg-b.json')!(null, { lifetime: 9 });
+            expect(second.lifetime, "the new connection's own binding applied its config").toBe(9);
+            expect(uncaught.seen).toEqual([]);
+        });
+    });
+
+    describe('config application', () => {
+        it('applies an already-loaded config at creation, resolving colorMapAsset', async () => {
+            const { get } = await bootApp(`
+                <pc-asset id="flame" src="flame.png" lazy></pc-asset>
+                <pc-asset id="cfg" type="json" src="${jsonSrc({ lifetime: 2.5, numParticles: 11, colorMapAsset: 'flame' })}"></pc-asset>
+                <pc-entity name="fx"><pc-particle-system asset="cfg"></pc-particle-system></pc-entity>
+            `);
+            const component = get('pc-particle-system').component!;
+            const flame = get<AssetElement>('pc-asset[id="flame"]').asset!;
+
+            expect(component.lifetime).toBe(2.5);
+            expect(component.numParticles).toBe(11);
+            expect(component.colorMapAsset, 'the pc-asset id resolved to the engine asset id').toBe(flame.id);
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('applies a lazy config once it loads, resolving colorMapAsset', async () => {
+            const { get } = await bootApp(`
+                <pc-asset id="flame" src="flame.png" lazy></pc-asset>
+                <pc-asset id="cfg" type="json" src="${jsonSrc({ lifetime: 4, colorMapAsset: 'flame' })}" lazy></pc-asset>
+                <pc-entity name="fx"><pc-particle-system asset="cfg"></pc-particle-system></pc-entity>
+            `);
+            const component = get('pc-particle-system').component!;
+            const cfg = get<AssetElement>('pc-asset[id="cfg"]').asset!;
+
+            // The element resolved its reference, which is what starts a lazy load; the data:
+            // fetch needs a macrotask, so nothing has applied yet.
+            expect(cfg.loaded).toBe(false);
+            expect(component.lifetime, 'defaults until the lazy config loads').toBe(DEFAULT_LIFETIME);
+
+            await vi.waitFor(() => expect(cfg.loaded).toBe(true));
+            expect(component.lifetime).toBe(4);
+            expect(component.colorMapAsset, 'the lazy path resolves colorMapAsset too').toBe(
+                get<AssetElement>('pc-asset[id="flame"]').asset!.id
+            );
+            expect(uncaught.seen).toEqual([]);
+        });
+    });
+});

--- a/test/integration/components/particle-system-component.test.ts
+++ b/test/integration/components/particle-system-component.test.ts
@@ -133,6 +133,30 @@ describe('<pc-particle-system>', () => {
             expect(uncaught.seen).toEqual([]);
         });
 
+        it('survives binding to a config whose load already failed, and applies a later reload', async () => {
+            // The engine marks a failed load `loaded` too, with no resource - binding to one
+            // must not apply the empty resource as a config.
+            const { app, get } = await bootApp(RACE_ASSETS);
+            const parked = parkLoads(app);
+            const assetA = get<AssetElement>('pc-asset[id="cfg-a"]').asset!;
+
+            app.assets.load(assetA);
+            parked.get('cfg-a.json')!('failed to fetch');
+            expect(assetA.loaded, 'a failed load still settles as loaded').toBe(true);
+            expect(assetA.resource ?? null).toBeNull();
+
+            const element = await mountParticleSystem(get('pc-entity'), '');
+            element.setAttribute('asset', 'cfg-a');
+            expect(element.component!.lifetime, 'the failed config did not apply').toBe(DEFAULT_LIFETIME);
+
+            // Without an error callback the binding waits for a reload, exactly as it does for
+            // a failure that happens while subscribed - a retry that succeeds still delivers.
+            app.assets.load(assetA, { force: true });
+            parked.get('cfg-a.json')!(null, { lifetime: 7 });
+            expect(element.component!.lifetime, 'the successful reload applied').toBe(7);
+            expect(uncaught.seen).toEqual([]);
+        });
+
         it('does not let a load from a previous connection configure a reconnected component', async () => {
             const { app, get } = await bootApp(RACE_ASSETS);
             const parked = parkLoads(app);

--- a/test/integration/model.test.ts
+++ b/test/integration/model.test.ts
@@ -1,4 +1,4 @@
-import { Vec3 } from 'playcanvas';
+import { Entity, Vec3 } from 'playcanvas';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { AppElement } from '../../src/app';
@@ -122,6 +122,44 @@ describe('<pc-model>', () => {
 
         expect(instantiations, 'the superseded load did not instantiate').toBe(1);
         expect(handle.get('pc-model').contentEntity, 'the surviving load produced the content').toBeTruthy();
+        expect(uncaught.seen).toEqual([]);
+    });
+
+    it('instantiates only the newest asset when a superseded load settles later', async () => {
+        // The model moves from asset A to B while both are still loading, then B settles before
+        // A. Only B may instantiate - A settling afterwards must deliver nothing, or it would
+        // replace B's content with its own.
+        const { app, appElement } = await bootApp(`
+            <pc-asset id="slow-a" type="container" src="slow-a.glb" lazy></pc-asset>
+            <pc-asset id="slow-b" type="container" src="slow-b.glb" lazy></pc-asset>
+        `);
+
+        // Park both loads so the test settles them in a chosen order. Settling a parked load
+        // runs the registry's own completion path, so the asset's real load event fires.
+        const parked = new Map<string, (err: string | null, resource?: unknown) => void>();
+        vi.spyOn(app.loader, 'load').mockImplementation(((
+            url: string,
+            _type: string,
+            callback: (err: string | null, resource?: unknown) => void
+        ) => {
+            parked.set(url, callback);
+        }) as typeof app.loader.load);
+
+        const model = document.createElement('pc-model');
+        model.setAttribute('asset', 'slow-a');
+        appElement.appendChild(model);
+        await vi.waitFor(() => expect(parked.has('slow-a.glb')).toBe(true));
+
+        model.setAttribute('asset', 'slow-b');
+        await vi.waitFor(() => expect(parked.has('slow-b.glb')).toBe(true));
+
+        const container = (name: string) => ({ instantiateRenderEntity: () => new Entity(name, app) });
+        parked.get('slow-b.glb')!(null, container('root-b'));
+        parked.get('slow-a.glb')!(null, container('root-a'));
+
+        expect(model.contentEntity!.name, 'only the newest asset instantiated').toBe('root-b');
+        expect(model.contentEntity!.parent, 'parented beneath the host').toBe(model.entity);
+        await readyWithin(model);
         expect(uncaught.seen).toEqual([]);
     });
 

--- a/test/integration/model.test.ts
+++ b/test/integration/model.test.ts
@@ -1,3 +1,4 @@
+import type { AppBase } from 'playcanvas';
 import { Entity, Vec3 } from 'playcanvas';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -28,6 +29,26 @@ const GLTF_SRC = containerSrc('model-root');
 const ASSET_TAG = `<pc-asset id="m" type="container" src="${GLTF_SRC}"></pc-asset>`;
 
 const ASSET_TAG_B = `<pc-asset id="m2" type="container" src="${containerSrc('model-root-b')}"></pc-asset>`;
+
+/**
+ * Replaces the app's resource loader with one that parks every load until the test settles it,
+ * making settlement order (and failure) a test input. Settling a parked load runs the registry's
+ * own completion path, so the asset's real `load`/`error` events fire.
+ *
+ * @param app - The booted application.
+ * @returns Parked loads, keyed by the asset's file URL.
+ */
+const parkLoads = (app: AppBase) => {
+    const parked = new Map<string, (err: string | null, resource?: unknown) => void>();
+    vi.spyOn(app.loader, 'load').mockImplementation(((
+        url: string,
+        _type: string,
+        callback: (err: string | null, resource?: unknown) => void
+    ) => {
+        parked.set(url, callback);
+    }) as typeof app.loader.load);
+    return parked;
+};
 
 describe('<pc-model>', () => {
     const { errors, uncaught, warnings } = useGuard();
@@ -134,16 +155,7 @@ describe('<pc-model>', () => {
             <pc-asset id="slow-b" type="container" src="slow-b.glb" lazy></pc-asset>
         `);
 
-        // Park both loads so the test settles them in a chosen order. Settling a parked load
-        // runs the registry's own completion path, so the asset's real load event fires.
-        const parked = new Map<string, (err: string | null, resource?: unknown) => void>();
-        vi.spyOn(app.loader, 'load').mockImplementation(((
-            url: string,
-            _type: string,
-            callback: (err: string | null, resource?: unknown) => void
-        ) => {
-            parked.set(url, callback);
-        }) as typeof app.loader.load);
+        const parked = parkLoads(app);
 
         const model = document.createElement('pc-model');
         model.setAttribute('asset', 'slow-a');
@@ -268,6 +280,34 @@ describe('<pc-model>', () => {
 
             // The engine logs the parse failure itself; the event above is the element's channel
             errors.expect(/glb/i);
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('settles with an error when bound to an asset whose load already failed', async () => {
+            // The engine marks a failed load `loaded` too, with no resource. Binding to one must
+            // not instantiate the empty resource - the selection settles through the error path,
+            // exactly as if the failure had happened while the model was waiting.
+            const { app, appElement, get } = await bootApp(
+                '<pc-asset id="broken" type="container" src="broken.glb" lazy></pc-asset>'
+            );
+            const parked = parkLoads(app);
+            const asset = get('pc-asset').asset!;
+
+            app.assets.load(asset);
+            parked.get('broken.glb')!('download failed');
+            expect(asset.loaded, 'a failed load still settles as loaded').toBe(true);
+
+            const model = document.createElement('pc-model');
+            const seen: ErrorEvent[] = [];
+            model.addEventListener('error', (event) => seen.push(event as ErrorEvent));
+            model.setAttribute('asset', 'broken');
+            appElement.appendChild(model);
+
+            await readyWithin(model);
+            expect(model.contentEntity, 'nothing was instantiated from the empty resource').toBeNull();
+            expect(model.entity, 'the host survives').not.toBeNull();
+            expect(seen).toHaveLength(1);
+            expect(seen[0].message).toBe("asset 'broken' failed to load");
             expect(uncaught.seen).toEqual([]);
         });
     });


### PR DESCRIPTION
Fixes #436

`ParticleSystemComponentElement._loadAsset()` started a new asynchronous path on every `asset` change without retaining the load handle, invalidating earlier work, or cleaning up on disconnect — so a superseded config could apply over its replacement, and a callback left behind by a previous connection could configure the component created by a later one.

## The helper

`src/asset-binding.ts` adds an internal `AssetBinding`, extracted from the protocol `ModelElement`, `SkyElement` and `AnimClipElement` each carry by hand. An element owns one binding per asset reference for its whole life:

- `bind(id, { load, error? })` resolves through `useAsset` (starting a lazy asset's load), delivers an already-loaded asset synchronously, and otherwise subscribes to settlement — superseding whatever the binding was waiting for, even when `id` resolves to nothing.
- `cancel()` (on disconnect) detaches everything; a cancelled or superseded subscription can never deliver, guarded by both handle detachment and an internal generation, mirroring the double protection the per-element implementations documented.
- Settlement detaches both handlers — whichever of load/error fires first detaches the other.
- Consumer policy stays in the consumer: `bind` returns the resolved asset (or `undefined`) so each element keeps its own warning, readiness and resource-ownership behavior.

Because the binding object is stable (no per-load handle for a resumed caller to overwrite), a delivery that synchronously starts another bind cannot orphan the newer subscription — a hazard the ad-hoc `_loadHandle` fields were one re-entrant callback away from.

## The fix

`<pc-particle-system>` now binds its config through the helper:

- `initComponent()` binds when the config's load is still in flight (loaded configs already arrive through `getInitialComponentData`), so host cycles and reconnections bind afresh under their own connection.
- The `asset` setter rebinds, superseding a pending load — changing or clearing the asset means the old config can no longer apply.
- `disconnectedCallback()` cancels, so a load settling later cannot configure a replacement component.
- `colorMapAsset` resolution now applies on the lazy path too: `applyConfig` rewrites the authored `pc-asset` id to the engine asset id exactly as the already-loaded path always did (the engine cannot resolve the raw string id).

As a side effect, a `pc-particle-system` inserted at runtime with a still-pending config now applies it at all — previously nothing subscribed on connection, so only an asset *change* while connected ever reached the lazy path.

## Migration

`ModelElement` migrates to prove the abstraction removes lifecycle code rather than adding a layer: its `_loadHandle`/`_errorHandle` fields, `_detachLoadHandlers()` and the per-callback generation re-checks collapse into the binding. Its `_loadGeneration` remains, guarding the awaits before the bind. `SkyElement` and `AnimClipElement` fit the same shape and are left for follow-up migrations to keep this change reviewable.

## Tests

New `test/integration/components/particle-system-component.test.ts` parks asset loads at the resource loader and settles them in a chosen order (through the registry's real completion path, so real `load`/`error` events fire):

- out-of-order loads: switching A→B and settling B before A applies only B;
- clearing a pending asset prevents it applying when it settles;
- superseded, settled and disconnected bindings detach their asset listeners (asserted by listener count);
- disconnect + reconnect: the previous connection's load cannot configure the new component, while the new connection's own binding still applies its config;
- already-loaded and lazy configs both apply, including `colorMapAsset` resolution on each path.

Four of the six fail against the previous implementation. A matching out-of-order test is added for `<pc-model>` to lock the migrated behavior, alongside its existing removal/re-add race coverage, and the full suite passes (1053 tests).

## Public surface

`custom-elements.json`, `vscode.html-custom-data.json`, `web-types.json`, `index.d.ts` and `index.d.cts` are byte-identical before and after (verified against a pre-change build). The helper is `@internal` — `stripInternal` reduces its emitted declaration to `export {};` (declarations are exported inline so no dangling export statement survives the strip), the module is excluded from the CEM analyzer like the other non-element modules, and a standalone `tsc` pass over both declaration trees plus `publint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
