### PR TITLE
Migrate the remaining stale-safe asset consumers to AssetBinding

### DIFF
--- a/src/components/anim-clip.ts
+++ b/src/components/anim-clip.ts
@@ -1,7 +1,8 @@
-import type { Asset, EventHandle } from 'playcanvas';
+import type { Asset } from 'playcanvas';
 import { AnimTrack } from 'playcanvas';
 
-import { AssetElement, useAsset } from '../asset';
+import { AssetElement } from '../asset';
+import { AssetBinding } from '../asset-binding';
 import { AsyncElement } from '../async-element';
 import { ModelElement } from '../model';
 import { parseBool, parseNumber } from '../parse';
@@ -40,6 +41,12 @@ class AnimClipElement extends AsyncElement {
     private _asset = '';
 
     /**
+     * Watches the current source asset while it loads. Starting a new resolution or
+     * disconnecting cancels it, so a superseded source can never hand its track to the parent.
+     */
+    private _binding = new AssetBinding();
+
+    /**
      * Incremented on every connect and disconnect, and captured by connectedCallback on entry —
      * a resume from an await abandons itself if the value has moved on, so a stale callback can
      * neither act on a torn-down tree nor register its clip alongside a re-inserted element's
@@ -47,21 +54,13 @@ class AnimClipElement extends AsyncElement {
      */
     private _connectionGeneration = 0;
 
-    private _errorHandle: EventHandle | null = null;
-
     /**
      * Incremented on every track resolution and on disconnect, and captured by a resolution when
-     * it starts. A resolution that resumes from an await or an asset callback abandons itself if
-     * the value has moved on, so a superseded resolution cannot hand a stale track to the parent.
+     * it starts. A resolution that resumes from an await abandons itself if the value has moved
+     * on, so a superseded resolution cannot hand a stale track to the parent. The asset
+     * subscription itself is guarded by the binding above.
      */
     private _loadGeneration = 0;
-
-    /**
-     * The pending asset subscriptions of the current resolution, if it is waiting for its asset.
-     * Held so that whatever supersedes the resolution can detach the handlers from the asset,
-     * rather than leave them registered until the asset settles (or forever, if it never does).
-     */
-    private _loadHandle: EventHandle | null = null;
 
     private _loop = true;
 
@@ -112,7 +111,7 @@ class AnimClipElement extends AsyncElement {
         // Invalidate any connectedCallback or track resolution still suspended on an await
         this._connectionGeneration++;
         this._loadGeneration++;
-        this._detachLoadHandlers();
+        this._binding.cancel();
 
         // Uses the cached parent rather than a fresh lookup, since parentElement is already null
         // by now. The component itself is null if the whole <pc-app> is being torn down —
@@ -133,13 +132,6 @@ class AnimClipElement extends AsyncElement {
         }
 
         return animElement;
-    }
-
-    private _detachLoadHandlers() {
-        this._loadHandle?.off();
-        this._loadHandle = null;
-        this._errorHandle?.off();
-        this._errorHandle = null;
     }
 
     /**
@@ -169,35 +161,20 @@ class AnimClipElement extends AsyncElement {
         this._animElement = animElement;
 
         const generation = ++this._loadGeneration;
-        this._detachLoadHandlers();
+        this._binding.cancel();
 
         if (this._asset) {
-            const asset = useAsset(this._asset);
+            // Every path that moves _loadGeneration also rebinds or cancels the binding, so a
+            // delivery below is always current.
+            const asset = this._binding.bind(this._asset, {
+                load: (loaded) => this._extractTrack(loaded, `asset '${this._asset}'`),
+                error: () => {
+                    this._warnSource(`pc-anim-clip '${this._name}' - asset '${this._asset}' failed to load - clip not assigned`);
+                }
+            });
             if (!asset) {
                 this._warnSource(`pc-anim-clip '${this._name}' could not find asset '${this._asset}' - clip not assigned`);
-                return;
             }
-            if (asset.loaded) {
-                this._extractTrack(asset, `asset '${this._asset}'`);
-                return;
-            }
-            // Whichever of load/error fires first detaches the other. The generation is
-            // re-checked even though a superseded handler is detached: the detach relies on how
-            // the engine's event emitter treats removal, while the check holds on its own.
-            this._loadHandle = asset.once('load', () => {
-                this._detachLoadHandlers();
-                if (generation !== this._loadGeneration) {
-                    return;
-                }
-                this._extractTrack(asset, `asset '${this._asset}'`);
-            });
-            this._errorHandle = asset.once('error', () => {
-                this._detachLoadHandlers();
-                if (generation !== this._loadGeneration) {
-                    return;
-                }
-                this._warnSource(`pc-anim-clip '${this._name}' - asset '${this._asset}' failed to load - clip not assigned`);
-            });
             return;
         }
 

--- a/src/material.ts
+++ b/src/material.ts
@@ -23,10 +23,10 @@ import {
     StandardMaterial,
     Vec2
 } from 'playcanvas';
-import type { EventHandle, Texture } from 'playcanvas';
+import type { Texture } from 'playcanvas';
 
 import type { AppElement } from './app';
-import { useAsset } from './asset';
+import { AssetBinding } from './asset-binding';
 import { parseBool, parseColor, parseEnum, parseNumber, parseVec2 } from './parse';
 
 /** The blend modes for a material. */
@@ -318,11 +318,12 @@ class MaterialElement extends HTMLElement {
     private _useTonemap = true;
 
     /**
-     * Pending `load` handlers, one per texture slot. A slot's handler is torn down when the slot is
-     * reassigned or the element disconnects, so a late-arriving asset can never write a texture the
-     * element no longer wants.
+     * One asset binding per texture slot, created on first use and kept for the element's
+     * lifetime. A slot's binding is superseded when the slot is reassigned and cancelled when the
+     * element disconnects, so a late-arriving asset can never write a texture the element no
+     * longer wants.
      */
-    private _mapHandles = new Map<TextureSlot, EventHandle>();
+    private _mapBindings = new Map<TextureSlot, AssetBinding>();
 
     private _updateScheduled = false;
 
@@ -461,10 +462,9 @@ class MaterialElement extends HTMLElement {
     }
 
     disconnectedCallback() {
-        for (const handle of this._mapHandles.values()) {
-            handle.off();
+        for (const binding of this._mapBindings.values()) {
+            binding.cancel();
         }
-        this._mapHandles.clear();
 
         if (this.material) {
             this.material.destroy();
@@ -518,16 +518,24 @@ class MaterialElement extends HTMLElement {
     }
 
     /**
-     * Points a texture slot at the resource of a `pc-asset`, waiting for the asset to load when it
-     * has not already. An empty id clears the slot.
+     * Points a texture slot at the resource of a `pc-asset`, waiting for the asset to load when
+     * it has not already. An empty id clears the slot; a slot keeps its current texture while
+     * the new asset loads, and also across a failed load - a later reload can still deliver.
      *
      * @param id - The id of the `pc-asset`, or an empty string to clear the slot.
      * @param slot - The material property to write.
      */
     private _setMap(id: string, slot: TextureSlot) {
-        // Drop any load still pending for this slot - its texture is no longer the one we want
-        this._mapHandles.get(slot)?.off();
-        this._mapHandles.delete(slot);
+        let binding = this._mapBindings.get(slot);
+        if (!binding) {
+            binding = new AssetBinding();
+            this._mapBindings.set(slot, binding);
+        }
+
+        // Drop any load still pending for this slot - its texture is no longer the one we want.
+        // Cancelled here rather than left to the bind below, which the material-less and
+        // clear-slot returns never reach.
+        binding.cancel();
 
         if (!this.material) return;
 
@@ -537,21 +545,9 @@ class MaterialElement extends HTMLElement {
             return;
         }
 
-        const asset = useAsset(id);
-        if (!asset) return;
-
-        if (asset.loaded) {
-            this._applyMap(slot, asset.resource as Texture);
-            return;
-        }
-
-        this._mapHandles.set(
-            slot,
-            asset.once('load', () => {
-                this._mapHandles.delete(slot);
-                this._applyMap(slot, asset.resource as Texture);
-            })
-        );
+        binding.bind(id, {
+            load: (asset) => this._applyMap(slot, asset.resource as Texture)
+        });
     }
 
     /**

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -1,8 +1,9 @@
-import type { Asset, EventHandle, Scene, Texture } from 'playcanvas';
+import type { Asset, Scene, Texture } from 'playcanvas';
 import { EnvLighting, LAYERID_SKYBOX, Quat, Vec3 } from 'playcanvas';
 
 import type { AppElement } from './app';
 import { useAsset } from './asset';
+import { AssetBinding } from './asset-binding';
 import { AsyncElement } from './async-element';
 import { parseBool, parseEnum, parseNumber, parseVec3 } from './parse';
 
@@ -38,17 +39,17 @@ class SkyElement extends AsyncElement {
 
     /**
      * Incremented on every new load and on disconnect, and captured by a load when it starts. A
-     * load that resumes from an await or a load callback abandons itself if the value has moved
-     * on, so a superseded load cannot generate a skybox for a scene it no longer configures.
+     * load that resumes from an await abandons itself if the value has moved on, so a superseded
+     * load cannot generate a skybox for a scene it no longer configures. The asset subscription
+     * itself is guarded by the binding below.
      */
     private _loadGeneration = 0;
 
     /**
-     * The pending asset-load subscription of the current load, if it is waiting for its asset.
-     * Held so that whatever supersedes the load can detach the handler from the asset, rather
-     * than leave it registered until the asset loads (or forever, if it never does).
+     * Watches the current texture asset while it loads. Starting a new load or disconnecting
+     * cancels it, so a superseded texture can never generate the skybox.
      */
-    private _loadHandle: EventHandle | null = null;
+    private _binding = new AssetBinding();
 
     connectedCallback() {
         this._loadSkybox();
@@ -57,15 +58,10 @@ class SkyElement extends AsyncElement {
 
     disconnectedCallback() {
         this._loadGeneration++;
-        this._detachLoadHandler();
+        this._binding.cancel();
         this._unloadSkybox();
         this._appElement = null;
         this._resetReady();
-    }
-
-    private _detachLoadHandler() {
-        this._loadHandle?.off();
-        this._loadHandle = null;
     }
 
     private _generateSkybox(asset: Asset) {
@@ -104,7 +100,7 @@ class SkyElement extends AsyncElement {
     private async _loadSkybox() {
         // Supersede any load already in flight - only the newest load may generate the skybox
         const generation = ++this._loadGeneration;
-        this._detachLoadHandler();
+        this._binding.cancel();
 
         const appElement = await this.closestApp?.ready();
 
@@ -120,27 +116,20 @@ class SkyElement extends AsyncElement {
 
         this._appElement = appElement;
 
-        const asset = useAsset(this._asset);
-        if (!asset) {
+        // The scene is only adopted once the reference resolves: an unresolved id must leave the
+        // scene untouched, or this element's teardown would destroy a skybox it never created.
+        // The bind below repeats the resolution, which useAsset documents as free - it cannot
+        // happen after the bind, because a loaded asset delivers before bind returns and
+        // _generateSkybox needs the scene by then.
+        if (!useAsset(this._asset)) {
             return;
         }
 
         this._scene = app.scene;
 
-        if (asset.loaded) {
-            this._generateSkybox(asset);
-        } else {
-            // The generation is re-checked even though a superseded handler is detached: the
-            // detach relies on how the engine's event emitter treats removal, while the check
-            // holds on its own.
-            this._loadHandle = asset.once('load', () => {
-                this._loadHandle = null;
-                if (generation !== this._loadGeneration) {
-                    return;
-                }
-                this._generateSkybox(asset);
-            });
-        }
+        this._binding.bind(this._asset, {
+            load: (asset) => this._generateSkybox(asset)
+        });
     }
 
     private _unloadSkybox() {

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -1,4 +1,5 @@
 export { bootApp, settle, type BootedApp, type BootOptions } from './app';
 export { assertDocumentClean, mount, type Mounted } from './dom';
 export { currentGuard, useGuard, type Guard } from './guard';
+export { parkLoads, type ParkedLoadCallback } from './loader';
 export { describeElement, expectNeverReady, readyOrder, readyWithin, NEVER_READY_WINDOW, READY_TIMEOUT } from './ready';

--- a/test/helpers/loader.ts
+++ b/test/helpers/loader.ts
@@ -1,0 +1,25 @@
+import type { AppBase } from 'playcanvas';
+import { vi } from 'vitest';
+
+/** Completes a parked load: `callback(null, resource)` succeeds, `callback('reason')` fails. */
+export type ParkedLoadCallback = (err: string | null, resource?: unknown) => void;
+
+/**
+ * Replaces the app's resource loader with one that parks every load until the test settles it,
+ * making settlement order (and failure) a test input rather than a network accident. Settling a
+ * parked load runs the registry's own completion path, so the asset's real `load`/`error` events
+ * fire.
+ *
+ * Install after boot: a parked load never completes on its own, so any non-lazy asset would stall
+ * the app's preload.
+ *
+ * @param app - The booted application.
+ * @returns Parked loads, keyed by the asset's file URL.
+ */
+export const parkLoads = (app: AppBase) => {
+    const parked = new Map<string, ParkedLoadCallback>();
+    vi.spyOn(app.loader, 'load').mockImplementation(((url: string, _type: string, callback: ParkedLoadCallback) => {
+        parked.set(url, callback);
+    }) as typeof app.loader.load);
+    return parked;
+};

--- a/test/integration/components/anim-component.test.ts
+++ b/test/integration/components/anim-component.test.ts
@@ -8,6 +8,7 @@ import type { AnimComponentElement } from '../../../src/components/anim-componen
 import type { ModelElement } from '../../../src/model';
 import { bootApp } from '../../helpers/app';
 import { useGuard } from '../../helpers/guard';
+import { parkLoads } from '../../helpers/loader';
 import { expectNeverReady, readyWithin } from '../../helpers/ready';
 
 /**
@@ -824,6 +825,60 @@ describe('<pc-anim>', () => {
             warnings.expect("pc-anim-clip 'Walk' - an earlier clip already uses this name - clip not assigned");
             expect(anim.clips).toEqual(['Walk']);
             await expectNeverReady(duplicate);
+        });
+    });
+
+    describe('clip source races', () => {
+        it("assigns only the newest source's track when a superseded load settles later", async () => {
+            const { app, get } = await bootApp(`
+                <pc-asset id="clip-a" type="animclip" src="clip-a.json" lazy></pc-asset>
+                <pc-asset id="clip-b" type="animclip" src="clip-b.json" lazy></pc-asset>
+                <pc-entity name="e"><pc-anim activate="false"></pc-anim></pc-entity>
+            `);
+            const parked = parkLoads(app);
+            const anim = get<AnimComponentElement>('pc-anim');
+
+            const clip = document.createElement('pc-anim-clip');
+            clip.setAttribute('name', 'Move');
+            clip.setAttribute('asset', 'clip-a');
+            anim.appendChild(clip);
+            await settleTask();
+            expect(parked.has('clip-a.json'), 'the pending source started its load').toBe(true);
+
+            clip.setAttribute('asset', 'clip-b');
+            expect(parked.has('clip-b.json')).toBe(true);
+
+            // B settles first, then A - the superseded source must not hand over its track
+            const assign = vi.spyOn(anim.component!, 'assignAnimation');
+            parked.get('clip-b.json')!(null, new AnimTrack('TrackB', 1, [], [], []));
+            await readyWithin(clip);
+            const afterB = assign.mock.calls.length;
+            expect(afterB).toBeGreaterThan(0);
+            expect((assign.mock.calls[afterB - 1][1] as AnimTrack).name, 'the newest source supplied the track').toBe('TrackB');
+
+            parked.get('clip-a.json')!(null, new AnimTrack('TrackA', 1, [], [], []));
+            expect(assign.mock.calls.length, 'the superseded source assigned nothing').toBe(afterB);
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('warns without throwing for a source whose load already failed', async () => {
+            const { get } = await bootApp(`
+                <pc-asset id="broken" type="container" src="broken.glb" lazy></pc-asset>
+                <pc-entity name="e"><pc-anim></pc-anim></pc-entity>
+            `);
+            // The failed shape: the engine marks a failed load `loaded` with no resource
+            get<AssetElement>('pc-asset').asset!.loaded = true;
+
+            const anim = get<AnimComponentElement>('pc-anim');
+            const clip = document.createElement('pc-anim-clip');
+            clip.setAttribute('name', 'Walk');
+            clip.setAttribute('asset', 'broken');
+            anim.appendChild(clip);
+            await settleTask();
+
+            warnings.expect("pc-anim-clip 'Walk' - asset 'broken' failed to load - clip not assigned");
+            await expectNeverReady(clip);
+            expect(uncaught.seen).toEqual([]);
         });
     });
 

--- a/test/integration/components/particle-system-component.test.ts
+++ b/test/integration/components/particle-system-component.test.ts
@@ -1,10 +1,11 @@
-import type { AppBase, Asset } from 'playcanvas';
+import type { Asset } from 'playcanvas';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { AssetElement } from '../../../src/asset';
 import type { EntityElement } from '../../../src/entity';
 import { bootApp } from '../../helpers/app';
 import { useGuard } from '../../helpers/guard';
+import { parkLoads } from '../../helpers/loader';
 import { readyWithin } from '../../helpers/ready';
 
 /**
@@ -25,24 +26,6 @@ const RACE_ASSETS = `
     <pc-asset id="cfg-b" type="json" src="cfg-b.json" lazy></pc-asset>
     <pc-entity name="fx"></pc-entity>
 `;
-
-type LoaderCallback = (err: string | null, resource?: unknown) => void;
-
-/**
- * Replaces the app's resource loader with one that parks every load until the test settles it,
- * making settlement order a test input rather than a network accident. Settling a parked load
- * runs the registry's own completion path, so the asset's real `load`/`error` events fire.
- *
- * @param app - The booted application.
- * @returns Parked loads, keyed by the asset's file URL.
- */
-const parkLoads = (app: AppBase) => {
-    const parked = new Map<string, LoaderCallback>();
-    vi.spyOn(app.loader, 'load').mockImplementation(((url: string, _type: string, callback: LoaderCallback) => {
-        parked.set(url, callback);
-    }) as typeof app.loader.load);
-    return parked;
-};
 
 /**
  * The number of handlers subscribed to one of an asset's events, for asserting that a binding

--- a/test/integration/material.test.ts
+++ b/test/integration/material.test.ts
@@ -201,5 +201,55 @@ describe('<pc-material> integration', () => {
             asset.resource = texture;
             expect(() => asset.fire('load', asset), 'a late load must not touch the torn-down element').not.toThrow();
         });
+
+        it('applies only the newest asset when a superseded map load settles later', async () => {
+            const handle = await bootApp(`
+                <pc-asset id="tex-a" src="tex-a.png" lazy></pc-asset>
+                <pc-asset id="tex-b" src="tex-b.png" lazy></pc-asset>
+                <pc-material id="m" diffuse-map="tex-a"></pc-material>
+            `);
+            const element = handle.get<MaterialElement>('pc-material');
+            const assetA = handle.get<AssetElement>('pc-asset[id="tex-a"]').asset!;
+            const assetB = handle.get<AssetElement>('pc-asset[id="tex-b"]').asset!;
+
+            element.setAttribute('diffuse-map', 'tex-b');
+
+            // B settles first, then A - the superseded texture must not overwrite its replacement
+            const texB = new Texture(handle.app.graphicsDevice, { width: 1, height: 1 });
+            assetB.resource = texB;
+            assetB.fire('load', assetB);
+            const texA = new Texture(handle.app.graphicsDevice, { width: 1, height: 1 });
+            assetA.resource = texA;
+            assetA.fire('load', assetA);
+
+            expect(element.material!.diffuseMap, 'the superseded texture did not apply').toBe(texB);
+        });
+
+        it('keeps the current texture across a map whose load already failed, until a reload delivers', async () => {
+            const handle = await bootApp(`
+                <pc-asset id="tex-a" src="tex-a.png" lazy></pc-asset>
+                <pc-asset id="tex-b" src="tex-b.png" lazy></pc-asset>
+                <pc-material id="m" diffuse-map="tex-a"></pc-material>
+            `);
+            const element = handle.get<MaterialElement>('pc-material');
+            const assetA = handle.get<AssetElement>('pc-asset[id="tex-a"]').asset!;
+            const assetB = handle.get<AssetElement>('pc-asset[id="tex-b"]').asset!;
+
+            const texA = new Texture(handle.app.graphicsDevice, { width: 1, height: 1 });
+            assetA.resource = texA;
+            assetA.fire('load', assetA);
+            expect(element.material!.diffuseMap).toBe(texA);
+
+            // The failed shape: the engine marks a failed load `loaded` with no resource. The
+            // slot holds its current texture, as it does while a working replacement loads.
+            assetB.loaded = true;
+            element.setAttribute('diffuse-map', 'tex-b');
+            expect(element.material!.diffuseMap, 'a failed map keeps the current texture').toBe(texA);
+
+            const texB = new Texture(handle.app.graphicsDevice, { width: 1, height: 1 });
+            assetB.resource = texB;
+            assetB.fire('load', assetB);
+            expect(element.material!.diffuseMap, 'the reload delivered').toBe(texB);
+        });
     });
 });

--- a/test/integration/model.test.ts
+++ b/test/integration/model.test.ts
@@ -1,4 +1,3 @@
-import type { AppBase } from 'playcanvas';
 import { Entity, Vec3 } from 'playcanvas';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -6,6 +5,7 @@ import type { AppElement } from '../../src/app';
 import { bootApp, settle } from '../helpers/app';
 import { mount } from '../helpers/dom';
 import { useGuard } from '../helpers/guard';
+import { parkLoads } from '../helpers/loader';
 import { expectNeverReady, readyWithin } from '../helpers/ready';
 
 
@@ -29,26 +29,6 @@ const GLTF_SRC = containerSrc('model-root');
 const ASSET_TAG = `<pc-asset id="m" type="container" src="${GLTF_SRC}"></pc-asset>`;
 
 const ASSET_TAG_B = `<pc-asset id="m2" type="container" src="${containerSrc('model-root-b')}"></pc-asset>`;
-
-/**
- * Replaces the app's resource loader with one that parks every load until the test settles it,
- * making settlement order (and failure) a test input. Settling a parked load runs the registry's
- * own completion path, so the asset's real `load`/`error` events fire.
- *
- * @param app - The booted application.
- * @returns Parked loads, keyed by the asset's file URL.
- */
-const parkLoads = (app: AppBase) => {
-    const parked = new Map<string, (err: string | null, resource?: unknown) => void>();
-    vi.spyOn(app.loader, 'load').mockImplementation(((
-        url: string,
-        _type: string,
-        callback: (err: string | null, resource?: unknown) => void
-    ) => {
-        parked.set(url, callback);
-    }) as typeof app.loader.load);
-    return parked;
-};
 
 describe('<pc-model>', () => {
     const { errors, uncaught, warnings } = useGuard();

--- a/test/integration/sky.test.ts
+++ b/test/integration/sky.test.ts
@@ -1,0 +1,79 @@
+import type { AppBase, Asset } from 'playcanvas';
+import { Texture } from 'playcanvas';
+import { describe, expect, it } from 'vitest';
+
+import type { AssetElement } from '../../src/asset';
+import type { SkyElement } from '../../src/sky';
+import { bootApp } from '../helpers/app';
+import { useGuard } from '../helpers/guard';
+
+/**
+ * Two lazy textures for the sky to race between. jsdom never completes image loads, so a lazy
+ * texture stays pending until a test completes it by hand.
+ */
+const SKY_ASSETS = `
+    <pc-asset id="sky-a" src="sky-a.png" lazy></pc-asset>
+    <pc-asset id="sky-b" src="sky-b.png" lazy></pc-asset>
+`;
+
+/**
+ * Completes a texture asset's load by hand, firing its real `load` event.
+ *
+ * @param asset - The pending texture asset.
+ * @param app - The booted application, for its graphics device.
+ * @returns The texture the asset now holds.
+ */
+const finishTextureLoad = (asset: Asset, app: AppBase) => {
+    const texture = new Texture(app.graphicsDevice, { width: 4, height: 4 });
+    asset.resource = texture;
+    asset.loaded = true;
+    asset.fire('load', asset);
+    return texture;
+};
+
+describe('<pc-sky>', () => {
+    const { uncaught } = useGuard();
+
+    const settleTask = () => new Promise((resolve) => {
+        setTimeout(resolve, 0);
+    });
+
+    it('generates the skybox only from the newest asset when a superseded load settles later', async () => {
+        const { app, get } = await bootApp(`${SKY_ASSETS}<pc-scene><pc-sky asset="sky-a"></pc-sky></pc-scene>`);
+        const sky = get<SkyElement>('pc-sky');
+        const assetA = get<AssetElement>('pc-asset[id="sky-a"]').asset!;
+        const assetB = get<AssetElement>('pc-asset[id="sky-b"]').asset!;
+
+        // The load parks on app readiness before it subscribes; a macrotask lets it land
+        await settleTask();
+        sky.setAttribute('asset', 'sky-b');
+        await settleTask();
+
+        // B settles first, then A - the superseded texture must not regenerate the skybox
+        finishTextureLoad(assetB, app);
+        const skybox = app.scene.skybox;
+        expect(skybox, 'the newest asset generated the skybox').toBeTruthy();
+
+        finishTextureLoad(assetA, app);
+        expect(app.scene.skybox, 'the superseded asset did not regenerate it').toBe(skybox);
+        expect(uncaught.seen).toEqual([]);
+    });
+
+    it('survives an asset whose load already failed, and uses a later reload', async () => {
+        const { app, get } = await bootApp(`${SKY_ASSETS}<pc-scene><pc-sky></pc-sky></pc-scene>`);
+        const sky = get<SkyElement>('pc-sky');
+        const assetA = get<AssetElement>('pc-asset[id="sky-a"]').asset!;
+
+        // The failed shape: the engine marks a failed load `loaded` with no resource
+        assetA.loaded = true;
+
+        sky.setAttribute('asset', 'sky-a');
+        await settleTask();
+        expect(app.scene.skybox ?? null, 'no skybox from an empty resource').toBeNull();
+
+        // Without an error callback the binding waits, so a successful reload still delivers
+        finishTextureLoad(assetA, app);
+        expect(app.scene.skybox, 'the reload generated the skybox').toBeTruthy();
+        expect(uncaught.seen).toEqual([]);
+    });
+});


### PR DESCRIPTION
Follow-up to #438 (issue #436): migrates the remaining hand-rolled asset load subscriptions to `AssetBinding`. After this, every element that subscribes to an asset's settlement goes through the helper — the review of the other `useAsset` consumers found only id/Asset resolution handed to engine systems (gsplat, button, element, sound-slot, script), which have no subscription to centralize.

## Migrations

- **`AnimClipElement`** — its `_loadHandle`/`_errorHandle` fields, `_detachLoadHandlers()` and per-callback generation re-checks collapse into a binding; `_loadGeneration` remains only for the model-branch await. The asset branch maps 1:1, warnings unchanged.
- **`SkyElement`** — same shape, load-only. One ordering constraint is documented in place: the scene is adopted after the reference resolves but before the bind, because a loaded asset delivers synchronously and `_generateSkybox` needs the scene by then — while an unresolved id must leave the scene untouched (or teardown would destroy a skybox the element never created).
- **`MaterialElement`** — the per-slot `Map<TextureSlot, EventHandle>` becomes one binding per slot, created on first use and kept for the element's lifetime. Supersede-on-reassign and cancel-on-disconnect behavior is unchanged, and the slots gain the generation backstop they previously lacked.

## Two latent crashes fixed

The binding's settled-failure handling (from the #438 review) now covers these elements too. An asset that already failed reports `loaded` with no resource:

- `SkyElement` fed that empty resource straight to `EnvLighting.generateSkyboxCubemap` — a TypeError. It now waits for a reload, matching its behavior for a failure that happens while subscribed.
- `AnimClipElement` dereferenced `asset.resource.animations` for container sources — a TypeError. It now reports through its existing `...failed to load - clip not assigned` warning.

One deliberate behavior change, documented and tested: a material map pointed at an already-failed asset previously wrote the empty resource into the slot; it now keeps the current texture until a reload delivers, consistent with how a slot holds its texture while a working replacement loads.

## Tests

Each element gets an out-of-order race test (asset swapped while pending, loads settling newest-first) and an already-failed-source test. The three failure-shape tests crash or misapply against the previous implementations (verified by stashing the migrations); the race tests lock behavior that was already safe, as the model race test did in #438. The parked-loader helper the model and particle suites each carried moves to `test/helpers/loader.ts` now that a third suite needs it.

Full suite: 1061 tests pass. `custom-elements.json`, both editor integrations, `index.d.ts` and `index.d.cts` are byte-identical to the pre-change build, and standalone `tsc` passes over both declaration trees are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
