### PR TITLE
Extract pointer handling from AppElement into an internal controller

### DIFF
--- a/custom-elements-manifest.config.mjs
+++ b/custom-elements-manifest.config.mjs
@@ -25,7 +25,7 @@ export default {
     // None of these files declares an element, so excluding them keeps the manifest to the public
     // element surface. The base classes in async-element.ts and components/component.ts are
     // deliberately included - the elements that extend them inherit their attributes and events.
-    exclude: ['src/asset-binding.ts', 'src/colors.ts', 'src/loading-bar.ts', 'src/parse.ts'],
+    exclude: ['src/asset-binding.ts', 'src/colors.ts', 'src/loading-bar.ts', 'src/parse.ts', 'src/pointer-controller.ts'],
 
     // dist is wiped by `prebuild` and shipped via the `files` and `exports` fields, so the
     // generated files can never go stale and never need committing

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import type { CameraComponent, GraphicsDevice, GraphNode, GSplatComponent, Entity } from 'playcanvas';
+import type { GraphicsDevice, GraphNode, Entity } from 'playcanvas';
 import {
     AppBase,
     AppOptions,
@@ -7,7 +7,6 @@ import {
     FILLMODE_NONE,
     Keyboard,
     Mouse,
-    Picker,
     RESOLUTION_AUTO,
     AnimComponentSystem,
     AnimationComponentSystem,
@@ -60,8 +59,7 @@ import {
     BatchManager,
     SoundManager,
     Lightmapper,
-    XrManager,
-    MeshInstance
+    XrManager
 } from 'playcanvas';
 
 import type { AssetElement } from './asset';
@@ -72,56 +70,8 @@ import type { EntityOwnerElement } from './entity-owner';
 import { LoadingBar } from './loading-bar';
 import type { MaterialElement } from './material';
 import { parseBool, parseEnum, parseNumber } from './parse';
+import { PointerController } from './pointer-controller';
 import type { WasmElement } from './wasm';
-
-/**
- * The event types whose listeners make an element a hover target. Hover resolution walks past
- * elements listening for none of them, so a silent element never swallows an ancestor's
- * enter/leave pair.
- */
-const hoverEventTypes = ['pointerenter', 'pointerleave', 'pointermove'] as const;
-
-/**
- * The canvas listeners each synthesized event type is driven by. Enter and leave are derived
- * from move picks. A click is concluded from the down/up pair, with pointercancel discarding a
- * press the browser takes back (for example a touch that becomes a scroll).
- */
-const canvasEventsFor: Record<(typeof SYNTHESIZED_EVENTS)[number], readonly string[]> = {
-    pointermove: ['pointermove'],
-    pointerenter: ['pointermove'],
-    pointerleave: ['pointermove'],
-    pointerdown: ['pointerdown'],
-    pointerup: ['pointerup'],
-    click: ['pointerdown', 'pointerup', 'pointercancel']
-};
-
-/**
- * How long after a click a further click on the same target still raises the click count that
- * `detail` carries, approximating the platform's double-click time.
- */
-const CLICK_CHAIN_MS = 500;
-
-/**
- * Finds the nearest common inclusive ancestor of two picked nodes - the node a click belongs to
- * when the press and the release picked different geometry, exactly as the DOM assigns a click
- * whose down and up have different targets.
- *
- * @param a - The node the press picked, or `null`.
- * @param b - The node the release picked, or `null`.
- * @returns The nearest common inclusive ancestor, or `null` when there is none.
- */
-const commonAncestor = (a: GraphNode | null, b: GraphNode | null): GraphNode | null => {
-    const ancestors = new Set<GraphNode>();
-    for (let node = a; node !== null; node = node.parent) {
-        ancestors.add(node);
-    }
-    for (let node = b; node !== null; node = node.parent) {
-        if (ancestors.has(node)) {
-            return node;
-        }
-    }
-    return null;
-};
 
 /**
  * Gives `pc-app` the sizing contract of a replaced element (`<video>`, `<img>`): a block-level
@@ -220,44 +170,16 @@ class AppElement extends AsyncElement {
      */
     private _entityElements = new Map<GraphNode, EntityBaseElement>();
 
-    private _picker: Picker | null = null;
-
-    private _hoveredEntity: EntityBaseElement | null = null;
-
-    // Identifies the newest in-flight hover pick, so out-of-order results can be discarded
-    private _pickToken = 0;
-
-    private _pointerHandlers: Record<string, EventListener | null> = {
-        pointermove: null,
-        pointerdown: null,
-        pointerup: null,
-        pointercancel: null
-    };
-
     /**
-     * The pick of each pointer's primary-button press, keyed by pointerId and kept while a click
-     * may still conclude it. The promise is stored rather than its result, so a release can
-     * await a press pick that has not resolved yet. Entries are removed by the matching
-     * pointerup or pointercancel, and only ever stored while some element listens for click -
-     * which is also what keeps those two canvas listeners attached.
+     * The pointer-input subsystem: the picker, the canvas handlers, and the synthesized-event
+     * dispatch. The element drives its lifecycle (connect on boot, resize with the drawing
+     * buffer, listener syncs, disconnect on teardown) and hands it the two lookups it needs -
+     * everything else about pointer input lives in the controller.
      */
-    private _downPicks = new Map<number, Promise<GraphNode | null>>();
-
-    /** Whether any element in the tree listens for click. Maintained by _syncCanvasListeners. */
-    private _clickListened = false;
-
-    /**
-     * The previous click's target, time and count, for chaining successive clicks into the
-     * click count that `detail` carries. `null` until a click has fired.
-     */
-    private _lastClick: { element: EntityBaseElement; time: number; count: number } | null = null;
-
-    /**
-     * Serializes dispatch of the discrete synthesized events (pointerdown, pointerup, click),
-     * whose picks resolve in GPU order, not canvas-event order. Replaced on teardown, so a pick
-     * that never resolves cannot stall the dispatches of a later boot.
-     */
-    private _dispatchChain: Promise<void> = Promise.resolve();
+    private _pointer = new PointerController({
+        elementFromNode: (node) => this._entityElements.get(node) ?? null,
+        pointerTargets: () => Array.from(this.querySelectorAll<EntityBaseElement>('pc-entity, pc-model, pc-node'))
+    });
 
     private _app: AppBase | null = null;
 
@@ -303,8 +225,8 @@ class AppElement extends AsyncElement {
         // entities. Registered once here rather than on every boot - the sync no-ops while there
         // is no canvas, and a re-booted element must not stack a second set.
         SYNTHESIZED_EVENTS.forEach((type) => {
-            this.addEventListener(`${type}:connect`, () => this._syncCanvasListeners());
-            this.addEventListener(`${type}:disconnect`, () => this._syncCanvasListeners());
+            this.addEventListener(`${type}:connect`, () => this._pointer.syncListeners());
+            this.addEventListener(`${type}:disconnect`, () => this._pointer.syncListeners());
         });
     }
 
@@ -497,7 +419,7 @@ class AppElement extends AsyncElement {
         app.setCanvasFillMode(FILLMODE_NONE);
         app.setCanvasResolution(RESOLUTION_AUTO);
 
-        this._pickerCreate();
+        this._pointer.connect(app, this._canvas!);
 
         // Track the element's box rather than the window: containers resize without any window
         // event (splitter drags, flex reflow, animations). Guarded because jsdom has no
@@ -607,7 +529,7 @@ class AppElement extends AsyncElement {
         this._bootGeneration++;
 
         this._optionsLocked = false;
-        this._pickerDestroy();
+        this._pointer.disconnect();
 
         // Clean up the application. Destroying it destroys every entity, whose destroy hooks
         // unregister them - clear() covers any entity the engine no longer reached.
@@ -648,57 +570,7 @@ class AppElement extends AsyncElement {
         }
         this.app.updateCanvasSize();
         const { width, height } = this.app.graphicsDevice;
-        this._picker?.resize(width, height);
-    }
-
-    private _pickerCreate() {
-        const { width, height } = this.app!.graphicsDevice;
-        this._picker = new Picker(this.app!, width, height);
-
-        // Create bound handlers but don't attach them yet. The move handler is async, so it is
-        // wrapped to discard the promise - a listener must not return one.
-        const listener = (handler: (event: PointerEvent) => void | Promise<void>): EventListener => {
-            return (event: Event) => {
-                handler.call(this, event as PointerEvent);
-            };
-        };
-
-        this._pointerHandlers.pointermove = listener(this._onPointerMove);
-        this._pointerHandlers.pointerdown = listener(this._onPointerDown);
-        this._pointerHandlers.pointerup = listener(this._onPointerUp);
-        this._pointerHandlers.pointercancel = (event: Event) => {
-            this._downPicks.delete((event as PointerEvent).pointerId);
-        };
-
-        // Attach canvas listeners for element listeners registered before this boot (e.g.
-        // handlers created from inline attributes when their elements were first upgraded, or
-        // listeners carried over from before a re-boot)
-        this._syncCanvasListeners();
-    }
-
-    private _pickerDestroy() {
-        if (this._canvas) {
-            Object.entries(this._pointerHandlers).forEach(([type, handler]) => {
-                if (handler) {
-                    this._canvas!.removeEventListener(type, handler);
-                }
-            });
-        }
-
-        this._picker = null;
-        this._hoveredEntity = null;
-        this._pointerHandlers = {
-            pointermove: null,
-            pointerdown: null,
-            pointerup: null,
-            pointercancel: null
-        };
-        this._downPicks.clear();
-        this._clickListened = false;
-        this._lastClick = null;
-
-        // Replace the chain: a pick that never resolves must not stall a later boot's dispatches
-        this._dispatchChain = Promise.resolve();
+        this._pointer.resize(width, height);
     }
 
     /**
@@ -734,313 +606,6 @@ class AppElement extends AsyncElement {
      */
     elementFromEntity(entity: Entity): EntityBaseElement | null {
         return this._entityElements.get(entity) ?? null;
-    }
-
-    /**
-     * Resolves the element that owns hover for a picked node: the nearest node up the parent
-     * chain - starting with the node itself - whose element listens for any of the hover event
-     * types. Skipping silent elements matches {@link _elementWithListener}, so a registered
-     * element with no hover listeners (a `<pc-model>` host, a plain child entity) is transparent
-     * to hover rather than swallowing a listening ancestor's enter/leave pair.
-     *
-     * @param node - The picked node, or `null`.
-     * @returns The hover-owning element, or `null`.
-     */
-    private _hoverTarget(node: GraphNode | null): EntityBaseElement | null {
-        while (node !== null) {
-            const element = this._entityElements.get(node);
-            if (element && hoverEventTypes.some((type) => element._hasListeners(type))) {
-                return element;
-            }
-            node = node.parent;
-        }
-        return null;
-    }
-
-    /**
-     * Like {@link _elementFromNode}, but skips elements without a listener for `type`, so a hit
-     * on an unlistened child still reaches a listening ancestor.
-     *
-     * @param node - The picked node, or `null`.
-     * @param type - The pointer event type a listener is required for.
-     * @returns The nearest listening element, or `null`.
-     */
-    private _elementWithListener(node: GraphNode | null, type: string): EntityBaseElement | null {
-        while (node !== null) {
-            const element = this._entityElements.get(node);
-            if (element?._hasListeners(type)) {
-                return element;
-            }
-            node = node.parent;
-        }
-        return null;
-    }
-
-    /**
-     * Converts a pointer event's client coordinates into drawing-buffer coordinates - the space
-     * the pick buffer and the camera viewports are laid out in. When the canvas has no CSS box
-     * to map through (jsdom; a hidden canvas receives no pointer events in a browser), the
-     * client coordinates are passed through unmapped and `mapped` is false, so callers know the
-     * coordinates correspond to no real geometry.
-     *
-     * @param event - The pointer event to convert.
-     * @param canvas - The canvas the event was dispatched on.
-     * @returns The buffer-space coordinates, and whether they were actually mapped.
-     */
-    private _getPickerCoordinates(
-        event: PointerEvent,
-        canvas: HTMLCanvasElement
-    ): { x: number; y: number; mapped: boolean } {
-        const canvasRect = canvas.getBoundingClientRect();
-        if (canvasRect.width === 0 || canvasRect.height === 0) {
-            return { x: event.clientX, y: event.clientY, mapped: false };
-        }
-        const scaleX = canvas.width / canvasRect.width;
-        const scaleY = canvas.height / canvasRect.height;
-        return {
-            x: (event.clientX - canvasRect.left) * scaleX,
-            y: (event.clientY - canvasRect.top) * scaleY,
-            mapped: true
-        };
-    }
-
-    /**
-     * Whether a camera's viewport contains the point. A camera renders into its normalized
-     * `rect`, whose origin is the bottom-left of the canvas while buffer coordinates run from
-     * the top-left - so the vertical test flips, as the engine's ElementInput flips it for UI
-     * input. The right and bottom edges are exclusive: a viewport rasterizes the half-open
-     * pixel range [left, right) x [top, bottom), so a coordinate on a shared edge belongs to
-     * the viewport whose first pixel it is - never to the one it just left, whose pick buffer
-     * holds nothing there.
-     *
-     * @param camera - The camera to test.
-     * @param x - The x coordinate, in buffer space.
-     * @param y - The y coordinate, in buffer space.
-     * @param canvas - The canvas the coordinates are relative to.
-     * @returns Whether the camera's viewport contains the point.
-     */
-    private _cameraContains(camera: CameraComponent, x: number, y: number, canvas: HTMLCanvasElement): boolean {
-        const rect = camera.rect;
-        const left = rect.x * canvas.width;
-        const bottom = (1 - rect.y) * canvas.height;
-        const top = bottom - rect.w * canvas.height;
-        return x >= left && x < left + rect.z * canvas.width && y >= top && y < bottom;
-    }
-
-    /**
-     * Picks the scene under the pointer and returns the graph node that was hit, or `null`.
-     *
-     * The camera is resolved the way the engine's ElementInput resolves it for UI input:
-     * enabled cameras are tried topmost-first (they render in ascending `priority` order),
-     * skipping cameras that render to a texture and cameras whose viewport `rect` does not
-     * contain the pointer. A camera that picks nothing ends the search if it clears the color
-     * buffer - its background visually owns the pixel - and otherwise cedes to the cameras
-     * beneath it, so an overlay camera only intercepts picks where it actually drew something.
-     * The pick buffer is prepared per camera, so each camera picks from its own layers.
-     *
-     * The read back is asynchronous because the synchronous {@link Picker.getSelection} is not
-     * supported on WebGPU, where it returns an empty selection rather than failing - which
-     * silently disabled every `onpointer*` handler once WebGPU became the resolved backend. The
-     * async variant works on both backends and does not block the main thread on a GPU read.
-     *
-     * @param event - The pointer event to pick under.
-     * @returns The graph node under the pointer, or `null` if nothing was hit.
-     */
-    private async _pickNode(event: PointerEvent): Promise<GraphNode | null> {
-        const app = this.app;
-        const picker = this._picker;
-        const canvas = this._canvas;
-        if (!app || !picker || !canvas) return null;
-
-        const { x, y, mapped } = this._getPickerCoordinates(event, canvas);
-
-        // Walked from the end: the array is sorted by ascending priority, so the last camera
-        // renders last and sits on top. Read through .at() because a pick handler may remove
-        // cameras while an earlier iteration's read back is in flight.
-        const cameras = app.systems.camera?.cameras ?? [];
-        for (let i = cameras.length - 1; i >= 0; i--) {
-            const camera = cameras.at(i);
-
-            // A camera rendering to a texture is not on the canvas.
-            if (!camera || camera.renderTarget) continue;
-
-            // Coordinates that could not be mapped cannot be tested for containment.
-            if (mapped && !this._cameraContains(camera, x, y, canvas)) continue;
-
-            picker.prepare(camera, app.scene);
-            const selection = await picker.getSelectionAsync(x, y);
-
-            // The element may have disconnected while the read back was in flight.
-            if (!this._picker || !this.app) return null;
-
-            if (selection.length > 0) {
-                const item = selection[0];
-                return item instanceof MeshInstance ? item.node : (item as GSplatComponent).entity;
-            }
-
-            // Nothing hit. A camera that clears the color buffer paints its background over
-            // everything beneath it, so the miss is final; one that does not is an overlay
-            // that the cameras beneath show through, so they get their turn.
-            if (camera.clearColorBuffer) return null;
-        }
-
-        return null;
-    }
-
-    private async _onPointerMove(event: PointerEvent) {
-        if (!this._picker || !this.app) return;
-
-        // Moves arrive faster than a pick resolves, so results can land out of order. Only the
-        // newest pick may update the hover state - an older one describes a pointer position the
-        // user has already left.
-        const token = ++this._pickToken;
-        const node = await this._pickNode(event);
-        if (token !== this._pickToken || !this._picker) return;
-
-        // The hovered element is the nearest one up the node's parent chain with a hover
-        // listener - the nearest-listener rule down/up use. Dispatch is still gated per event
-        // type below: having any hover listener selects the target, each event needs its own.
-        const newHoverEntity = this._hoverTarget(node);
-
-        // Handle enter/leave events
-        if (this._hoveredEntity !== newHoverEntity) {
-            if (this._hoveredEntity && this._hoveredEntity._hasListeners('pointerleave')) {
-                this._hoveredEntity.dispatchEvent(new PointerEvent('pointerleave', event));
-            }
-            if (newHoverEntity && newHoverEntity._hasListeners('pointerenter')) {
-                newHoverEntity.dispatchEvent(new PointerEvent('pointerenter', event));
-            }
-        }
-
-        // Update hover state
-        this._hoveredEntity = newHoverEntity;
-
-        // Handle pointermove event
-        if (newHoverEntity && newHoverEntity._hasListeners('pointermove')) {
-            newHoverEntity.dispatchEvent(new PointerEvent('pointermove', event));
-        }
-    }
-
-    /**
-     * Appends a dispatch step to {@link _dispatchChain}. Must be called synchronously from the
-     * canvas event handler - the order of appends is what carries canvas-event order. A step
-     * that rejects is reported and released, so the steps queued behind it still dispatch.
-     *
-     * @param step - The dispatch work to run once every earlier step has finished.
-     */
-    private _chainDispatch(step: () => Promise<void>) {
-        this._dispatchChain = this._dispatchChain.then(step).catch((error) => {
-            console.error(error);
-        });
-    }
-
-    private _onPointerDown(event: PointerEvent) {
-        if (!this._picker || !this.app) return;
-
-        // Picks stay concurrent - only the dispatch of the results is serialized
-        const pick = this._pickNode(event);
-
-        // A click concludes on the matching pointerup, which needs to know what the press
-        // picked. Primary button only - the only button a click can conclude from - and only
-        // while click is listened for, since it is the click mapping that keeps the pointerup
-        // and pointercancel listeners attached to clean the entry up again.
-        if (this._clickListened && event.button === 0) {
-            this._downPicks.set(event.pointerId, pick);
-        }
-
-        this._chainDispatch(async () => {
-            const node = await pick;
-            if (!this._picker) return; // the element disconnected while the pick was in flight
-
-            const entityElement = this._elementWithListener(node, 'pointerdown');
-            if (entityElement) {
-                entityElement.dispatchEvent(new PointerEvent('pointerdown', event));
-            }
-        });
-    }
-
-    private _onPointerUp(event: PointerEvent) {
-        if (!this._picker || !this.app) return;
-
-        // The press pick this release may conclude as a click. Claimed synchronously, so the
-        // entry is gone before any other event for this pointer can be handled.
-        const downPick = this._downPicks.get(event.pointerId);
-        this._downPicks.delete(event.pointerId);
-
-        const pick = this._pickNode(event);
-
-        this._chainDispatch(async () => {
-            const node = await pick;
-            if (!this._picker) return; // the element disconnected while the pick was in flight
-
-            const entityElement = this._elementWithListener(node, 'pointerup');
-            if (entityElement) {
-                entityElement.dispatchEvent(new PointerEvent('pointerup', event));
-            }
-        });
-
-        // A click fires where the DOM fires it: at the nearest common inclusive ancestor of
-        // what the press and the release picked, for the primary button only. Appended after
-        // the release's own step, so it dispatches after the pointerup that concludes it.
-        if (!downPick || event.button !== 0) return;
-
-        this._chainDispatch(async () => {
-            // A rejected pick was already reported by the press or release step that awaited it;
-            // here it just means no click can conclude.
-            const picked = await Promise.all([downPick, pick]).catch(() => null);
-            if (!picked || !this._picker) return;
-
-            const [downNode, upNode] = picked;
-            const clickElement = this._elementWithListener(commonAncestor(downNode, upNode), 'click');
-            if (clickElement) {
-                const click = new PointerEvent('click', event);
-
-                // The init above copied pointerup's `detail`, which the Pointer Events spec fixes
-                // at 0 - but click is exempt: its detail is the click count, chained here as the
-                // platform chains it (same target, within the double-click window). Overridden
-                // with defineProperty because an event instance used as an init dict cannot have
-                // single fields replaced.
-                const time = performance.now();
-                const last = this._lastClick;
-                const count =
-                    last && last.element === clickElement && time - last.time <= CLICK_CHAIN_MS ? last.count + 1 : 1;
-                this._lastClick = { element: clickElement, time, count };
-                Object.defineProperty(click, 'detail', { value: count });
-
-                clickElement.dispatchEvent(click);
-            }
-        });
-    }
-
-    /**
-     * Attaches exactly the canvas listeners the tree's current element listeners need, and
-     * detaches the rest. Recomputed whenever a listener connects or disconnects anywhere under
-     * this element: several synthesized types can need the same canvas listener (enter, leave
-     * and move all ride the move pick; click rides the down/up pair), so one type's removal
-     * must not detach a listener another type still uses. Re-attaching an attached listener is
-     * a no-op by EventTarget semantics, so no attach state is kept.
-     */
-    private _syncCanvasListeners() {
-        const canvas = this._canvas;
-        if (!canvas) return; // not booted yet: _pickerCreate syncs once the handlers exist
-
-        const elements = Array.from(this.querySelectorAll<EntityBaseElement>('pc-entity, pc-model, pc-node'));
-        const needed = new Set<string>();
-        for (const type of SYNTHESIZED_EVENTS) {
-            if (elements.some((element) => element._hasListeners(type))) {
-                canvasEventsFor[type].forEach((canvasType) => needed.add(canvasType));
-            }
-        }
-        this._clickListened = elements.some((element) => element._hasListeners('click'));
-
-        Object.entries(this._pointerHandlers).forEach(([canvasType, handler]) => {
-            if (!handler) return;
-            if (needed.has(canvasType)) {
-                canvas.addEventListener(canvasType, handler);
-            } else {
-                canvas.removeEventListener(canvasType, handler);
-            }
-        });
     }
 
     /**

--- a/src/pointer-controller.ts
+++ b/src/pointer-controller.ts
@@ -1,0 +1,530 @@
+import type { AppBase, CameraComponent, GraphNode, GSplatComponent } from 'playcanvas';
+import { MeshInstance, Picker } from 'playcanvas';
+
+import type { EntityBaseElement } from './entity-base';
+import { SYNTHESIZED_EVENTS } from './entity-base';
+
+// Keep `export` on these declarations. TypeScript removes the declaration and its inline export
+// when `stripInternal` is enabled. A separate `export { ... }` statement would remain in the
+// generated .d.ts file and refer to a declaration that had been removed.
+
+/**
+ * The event types whose listeners make an element a hover target. Hover resolution walks past
+ * elements listening for none of them, so a silent element never swallows an ancestor's
+ * enter/leave pair.
+ */
+const hoverEventTypes = ['pointerenter', 'pointerleave', 'pointermove'] as const;
+
+/**
+ * The canvas listeners each synthesized event type is driven by. Enter and leave are derived
+ * from move picks. A click is concluded from the down/up pair, with pointercancel discarding a
+ * press the browser takes back (for example a touch that becomes a scroll).
+ */
+const canvasEventsFor: Record<(typeof SYNTHESIZED_EVENTS)[number], readonly string[]> = {
+    pointermove: ['pointermove'],
+    pointerenter: ['pointermove'],
+    pointerleave: ['pointermove'],
+    pointerdown: ['pointerdown'],
+    pointerup: ['pointerup'],
+    click: ['pointerdown', 'pointerup', 'pointercancel']
+};
+
+/**
+ * How long after a click a further click on the same target still raises the click count that
+ * `detail` carries, approximating the platform's double-click time.
+ */
+const CLICK_CHAIN_MS = 500;
+
+/**
+ * Finds the nearest common inclusive ancestor of two picked nodes - the node a click belongs to
+ * when the press and the release picked different geometry, exactly as the DOM assigns a click
+ * whose down and up have different targets.
+ *
+ * @param a - The node the press picked, or `null`.
+ * @param b - The node the release picked, or `null`.
+ * @returns The nearest common inclusive ancestor, or `null` when there is none.
+ */
+const commonAncestor = (a: GraphNode | null, b: GraphNode | null): GraphNode | null => {
+    const ancestors = new Set<GraphNode>();
+    for (let node = a; node !== null; node = node.parent) {
+        ancestors.add(node);
+    }
+    for (let node = b; node !== null; node = node.parent) {
+        if (ancestors.has(node)) {
+            return node;
+        }
+    }
+    return null;
+};
+
+/**
+ * The services the pointer controller needs from its host `<pc-app>` element. Both are read
+ * fresh on every use, so the controller follows the host's registrations and tree without
+ * holding any of them.
+ *
+ * @internal
+ */
+export type PointerHost = {
+    /**
+     * Resolves a graph node to the element fronting it, or `null` for a node no element fronts
+     * (for example, a node inside a model's instantiated hierarchy).
+     */
+    elementFromNode(node: GraphNode): EntityBaseElement | null;
+
+    /**
+     * The entity-fronting elements currently under the host, whose listeners decide which canvas
+     * handlers are needed.
+     */
+    pointerTargets(): EntityBaseElement[];
+};
+
+/**
+ * The pointer-input subsystem of a `<pc-app>` element: it owns the engine {@link Picker}, the
+ * canvas pointer handlers, and everything between them - mapping browser coordinates into the
+ * drawing buffer, selecting the camera, resolving picked nodes to listening elements, tracking
+ * hover, and dispatching the synthesized pointer and click events in canvas-event order.
+ *
+ * The host drives a small lifecycle: {@link connect} once the application and canvas exist,
+ * {@link resize} when the drawing buffer changes size, {@link syncListeners} when a descendant's
+ * pointer listeners change, and {@link disconnect} on teardown. Everything else is internal.
+ *
+ * @internal
+ */
+export class PointerController {
+    private _host: PointerHost;
+
+    private _app: AppBase | null = null;
+
+    private _canvas: HTMLCanvasElement | null = null;
+
+    private _picker: Picker | null = null;
+
+    private _hoveredEntity: EntityBaseElement | null = null;
+
+    // Identifies the newest in-flight hover pick, so out-of-order results can be discarded
+    private _pickToken = 0;
+
+    private _pointerHandlers: Record<string, EventListener | null> = {
+        pointermove: null,
+        pointerdown: null,
+        pointerup: null,
+        pointercancel: null
+    };
+
+    /**
+     * The pick of each pointer's primary-button press, keyed by pointerId and kept while a click
+     * may still conclude it. The promise is stored rather than its result, so a release can
+     * await a press pick that has not resolved yet. Entries are removed by the matching
+     * pointerup or pointercancel, and only ever stored while some element listens for click -
+     * which is also what keeps those two canvas listeners attached.
+     */
+    private _downPicks = new Map<number, Promise<GraphNode | null>>();
+
+    /** Whether any element in the tree listens for click. Maintained by syncListeners. */
+    private _clickListened = false;
+
+    /**
+     * The previous click's target, time and count, for chaining successive clicks into the
+     * click count that `detail` carries. `null` until a click has fired.
+     */
+    private _lastClick: { element: EntityBaseElement; time: number; count: number } | null = null;
+
+    /**
+     * Serializes dispatch of the discrete synthesized events (pointerdown, pointerup, click),
+     * whose picks resolve in GPU order, not canvas-event order. Replaced on disconnect, so a
+     * pick that never resolves cannot stall the dispatches of a later boot.
+     */
+    private _dispatchChain: Promise<void> = Promise.resolve();
+
+    /**
+     * @param host - The services the controller reads from its host element.
+     */
+    constructor(host: PointerHost) {
+        this._host = host;
+    }
+
+    /**
+     * Creates the picker and the canvas handlers for a booted application, and attaches whatever
+     * canvas listeners the tree's current element listeners already need (handlers created from
+     * inline attributes when their elements were first upgraded, or listeners carried over from
+     * before a re-boot).
+     *
+     * @param app - The application to pick against.
+     * @param canvas - The canvas the application renders into.
+     */
+    connect(app: AppBase, canvas: HTMLCanvasElement) {
+        this._app = app;
+        this._canvas = canvas;
+
+        const { width, height } = app.graphicsDevice;
+        this._picker = new Picker(app, width, height);
+
+        // Create bound handlers but don't attach them yet. The move handler is async, so it is
+        // wrapped to discard the promise - a listener must not return one.
+        const listener = (handler: (event: PointerEvent) => void | Promise<void>): EventListener => {
+            return (event: Event) => {
+                handler.call(this, event as PointerEvent);
+            };
+        };
+
+        this._pointerHandlers.pointermove = listener(this._onPointerMove);
+        this._pointerHandlers.pointerdown = listener(this._onPointerDown);
+        this._pointerHandlers.pointerup = listener(this._onPointerUp);
+        this._pointerHandlers.pointercancel = (event: Event) => {
+            this._downPicks.delete((event as PointerEvent).pointerId);
+        };
+
+        this.syncListeners();
+    }
+
+    /**
+     * Detaches the canvas listeners and drops every piece of pointer state, so nothing picked or
+     * queued before the teardown can affect a later boot. Safe to call on a controller that was
+     * never connected.
+     */
+    disconnect() {
+        if (this._canvas) {
+            Object.entries(this._pointerHandlers).forEach(([type, handler]) => {
+                if (handler) {
+                    this._canvas!.removeEventListener(type, handler);
+                }
+            });
+        }
+
+        this._app = null;
+        this._canvas = null;
+        this._picker = null;
+        this._hoveredEntity = null;
+        this._pointerHandlers = {
+            pointermove: null,
+            pointerdown: null,
+            pointerup: null,
+            pointercancel: null
+        };
+        this._downPicks.clear();
+        this._clickListened = false;
+        this._lastClick = null;
+
+        // Replace the chain: a pick that never resolves must not stall a later boot's dispatches
+        this._dispatchChain = Promise.resolve();
+    }
+
+    /**
+     * Resizes the picker to the drawing buffer. The picker must track the buffer, or picks would
+     * land at stale coordinates after a resize.
+     *
+     * @param width - The drawing buffer width.
+     * @param height - The drawing buffer height.
+     */
+    resize(width: number, height: number) {
+        this._picker?.resize(width, height);
+    }
+
+    /**
+     * Attaches exactly the canvas listeners the tree's current element listeners need, and
+     * detaches the rest. Called whenever a listener connects or disconnects anywhere under the
+     * host element: several synthesized types can need the same canvas listener (enter, leave
+     * and move all ride the move pick; click rides the down/up pair), so one type's removal
+     * must not detach a listener another type still uses. Re-attaching an attached listener is
+     * a no-op by EventTarget semantics, so no attach state is kept. Does nothing before
+     * {@link connect} - connecting syncs once the handlers exist.
+     */
+    syncListeners() {
+        const canvas = this._canvas;
+        if (!canvas) return;
+
+        const elements = this._host.pointerTargets();
+        const needed = new Set<string>();
+        for (const type of SYNTHESIZED_EVENTS) {
+            if (elements.some((element) => element._hasListeners(type))) {
+                canvasEventsFor[type].forEach((canvasType) => needed.add(canvasType));
+            }
+        }
+        this._clickListened = elements.some((element) => element._hasListeners('click'));
+
+        Object.entries(this._pointerHandlers).forEach(([canvasType, handler]) => {
+            if (!handler) return;
+            if (needed.has(canvasType)) {
+                canvas.addEventListener(canvasType, handler);
+            } else {
+                canvas.removeEventListener(canvasType, handler);
+            }
+        });
+    }
+
+    /**
+     * Resolves the element that owns hover for a picked node: the nearest node up the parent
+     * chain - starting with the node itself - whose element listens for any of the hover event
+     * types. Skipping silent elements matches {@link _elementWithListener}, so a registered
+     * element with no hover listeners (a `<pc-model>` host, a plain child entity) is transparent
+     * to hover rather than swallowing a listening ancestor's enter/leave pair.
+     *
+     * @param node - The picked node, or `null`.
+     * @returns The hover-owning element, or `null`.
+     */
+    private _hoverTarget(node: GraphNode | null): EntityBaseElement | null {
+        while (node !== null) {
+            const element = this._host.elementFromNode(node);
+            if (element && hoverEventTypes.some((type) => element._hasListeners(type))) {
+                return element;
+            }
+            node = node.parent;
+        }
+        return null;
+    }
+
+    /**
+     * Like {@link _hoverTarget}, but for one event type: skips elements without a listener for
+     * `type`, so a hit on an unlistened child still reaches a listening ancestor.
+     *
+     * @param node - The picked node, or `null`.
+     * @param type - The pointer event type a listener is required for.
+     * @returns The nearest listening element, or `null`.
+     */
+    private _elementWithListener(node: GraphNode | null, type: string): EntityBaseElement | null {
+        while (node !== null) {
+            const element = this._host.elementFromNode(node);
+            if (element?._hasListeners(type)) {
+                return element;
+            }
+            node = node.parent;
+        }
+        return null;
+    }
+
+    /**
+     * Converts a pointer event's client coordinates into drawing-buffer coordinates - the space
+     * the pick buffer and the camera viewports are laid out in. When the canvas has no CSS box
+     * to map through (jsdom; a hidden canvas receives no pointer events in a browser), the
+     * client coordinates are passed through unmapped and `mapped` is false, so callers know the
+     * coordinates correspond to no real geometry.
+     *
+     * @param event - The pointer event to convert.
+     * @param canvas - The canvas the event was dispatched on.
+     * @returns The buffer-space coordinates, and whether they were actually mapped.
+     */
+    private _getPickerCoordinates(
+        event: PointerEvent,
+        canvas: HTMLCanvasElement
+    ): { x: number; y: number; mapped: boolean } {
+        const canvasRect = canvas.getBoundingClientRect();
+        if (canvasRect.width === 0 || canvasRect.height === 0) {
+            return { x: event.clientX, y: event.clientY, mapped: false };
+        }
+        const scaleX = canvas.width / canvasRect.width;
+        const scaleY = canvas.height / canvasRect.height;
+        return {
+            x: (event.clientX - canvasRect.left) * scaleX,
+            y: (event.clientY - canvasRect.top) * scaleY,
+            mapped: true
+        };
+    }
+
+    /**
+     * Whether a camera's viewport contains the point. A camera renders into its normalized
+     * `rect`, whose origin is the bottom-left of the canvas while buffer coordinates run from
+     * the top-left - so the vertical test flips, as the engine's ElementInput flips it for UI
+     * input. The right and bottom edges are exclusive: a viewport rasterizes the half-open
+     * pixel range [left, right) x [top, bottom), so a coordinate on a shared edge belongs to
+     * the viewport whose first pixel it is - never to the one it just left, whose pick buffer
+     * holds nothing there.
+     *
+     * @param camera - The camera to test.
+     * @param x - The x coordinate, in buffer space.
+     * @param y - The y coordinate, in buffer space.
+     * @param canvas - The canvas the coordinates are relative to.
+     * @returns Whether the camera's viewport contains the point.
+     */
+    private _cameraContains(camera: CameraComponent, x: number, y: number, canvas: HTMLCanvasElement): boolean {
+        const rect = camera.rect;
+        const left = rect.x * canvas.width;
+        const bottom = (1 - rect.y) * canvas.height;
+        const top = bottom - rect.w * canvas.height;
+        return x >= left && x < left + rect.z * canvas.width && y >= top && y < bottom;
+    }
+
+    /**
+     * Picks the scene under the pointer and returns the graph node that was hit, or `null`.
+     *
+     * The camera is resolved the way the engine's ElementInput resolves it for UI input:
+     * enabled cameras are tried topmost-first (they render in ascending `priority` order),
+     * skipping cameras that render to a texture and cameras whose viewport `rect` does not
+     * contain the pointer. A camera that picks nothing ends the search if it clears the color
+     * buffer - its background visually owns the pixel - and otherwise cedes to the cameras
+     * beneath it, so an overlay camera only intercepts picks where it actually drew something.
+     * The pick buffer is prepared per camera, so each camera picks from its own layers.
+     *
+     * The read back is asynchronous because the synchronous {@link Picker.getSelection} is not
+     * supported on WebGPU, where it returns an empty selection rather than failing - which
+     * silently disabled every `onpointer*` handler once WebGPU became the resolved backend. The
+     * async variant works on both backends and does not block the main thread on a GPU read.
+     *
+     * @param event - The pointer event to pick under.
+     * @returns The graph node under the pointer, or `null` if nothing was hit.
+     */
+    private async _pickNode(event: PointerEvent): Promise<GraphNode | null> {
+        const app = this._app;
+        const picker = this._picker;
+        const canvas = this._canvas;
+        if (!app || !picker || !canvas) return null;
+
+        const { x, y, mapped } = this._getPickerCoordinates(event, canvas);
+
+        // Walked from the end: the array is sorted by ascending priority, so the last camera
+        // renders last and sits on top. Read through .at() because a pick handler may remove
+        // cameras while an earlier iteration's read back is in flight.
+        const cameras = app.systems.camera?.cameras ?? [];
+        for (let i = cameras.length - 1; i >= 0; i--) {
+            const camera = cameras.at(i);
+
+            // A camera rendering to a texture is not on the canvas.
+            if (!camera || camera.renderTarget) continue;
+
+            // Coordinates that could not be mapped cannot be tested for containment.
+            if (mapped && !this._cameraContains(camera, x, y, canvas)) continue;
+
+            picker.prepare(camera, app.scene);
+            const selection = await picker.getSelectionAsync(x, y);
+
+            // The host may have disconnected while the read back was in flight.
+            if (!this._picker || !this._app) return null;
+
+            if (selection.length > 0) {
+                const item = selection[0];
+                return item instanceof MeshInstance ? item.node : (item as GSplatComponent).entity;
+            }
+
+            // Nothing hit. A camera that clears the color buffer paints its background over
+            // everything beneath it, so the miss is final; one that does not is an overlay
+            // that the cameras beneath show through, so they get their turn.
+            if (camera.clearColorBuffer) return null;
+        }
+
+        return null;
+    }
+
+    private async _onPointerMove(event: PointerEvent) {
+        if (!this._picker || !this._app) return;
+
+        // Moves arrive faster than a pick resolves, so results can land out of order. Only the
+        // newest pick may update the hover state - an older one describes a pointer position the
+        // user has already left.
+        const token = ++this._pickToken;
+        const node = await this._pickNode(event);
+        if (token !== this._pickToken || !this._picker) return;
+
+        // The hovered element is the nearest one up the node's parent chain with a hover
+        // listener - the nearest-listener rule down/up use. Dispatch is still gated per event
+        // type below: having any hover listener selects the target, each event needs its own.
+        const newHoverEntity = this._hoverTarget(node);
+
+        // Handle enter/leave events
+        if (this._hoveredEntity !== newHoverEntity) {
+            if (this._hoveredEntity && this._hoveredEntity._hasListeners('pointerleave')) {
+                this._hoveredEntity.dispatchEvent(new PointerEvent('pointerleave', event));
+            }
+            if (newHoverEntity && newHoverEntity._hasListeners('pointerenter')) {
+                newHoverEntity.dispatchEvent(new PointerEvent('pointerenter', event));
+            }
+        }
+
+        // Update hover state
+        this._hoveredEntity = newHoverEntity;
+
+        // Handle pointermove event
+        if (newHoverEntity && newHoverEntity._hasListeners('pointermove')) {
+            newHoverEntity.dispatchEvent(new PointerEvent('pointermove', event));
+        }
+    }
+
+    /**
+     * Appends a dispatch step to {@link _dispatchChain}. Must be called synchronously from the
+     * canvas event handler - the order of appends is what carries canvas-event order. A step
+     * that rejects is reported and released, so the steps queued behind it still dispatch.
+     *
+     * @param step - The dispatch work to run once every earlier step has finished.
+     */
+    private _chainDispatch(step: () => Promise<void>) {
+        this._dispatchChain = this._dispatchChain.then(step).catch((error) => {
+            console.error(error);
+        });
+    }
+
+    private _onPointerDown(event: PointerEvent) {
+        if (!this._picker || !this._app) return;
+
+        // Picks stay concurrent - only the dispatch of the results is serialized
+        const pick = this._pickNode(event);
+
+        // A click concludes on the matching pointerup, which needs to know what the press
+        // picked. Primary button only - the only button a click can conclude from - and only
+        // while click is listened for, since it is the click mapping that keeps the pointerup
+        // and pointercancel listeners attached to clean the entry up again.
+        if (this._clickListened && event.button === 0) {
+            this._downPicks.set(event.pointerId, pick);
+        }
+
+        this._chainDispatch(async () => {
+            const node = await pick;
+            if (!this._picker) return; // the host disconnected while the pick was in flight
+
+            const entityElement = this._elementWithListener(node, 'pointerdown');
+            if (entityElement) {
+                entityElement.dispatchEvent(new PointerEvent('pointerdown', event));
+            }
+        });
+    }
+
+    private _onPointerUp(event: PointerEvent) {
+        if (!this._picker || !this._app) return;
+
+        // The press pick this release may conclude as a click. Claimed synchronously, so the
+        // entry is gone before any other event for this pointer can be handled.
+        const downPick = this._downPicks.get(event.pointerId);
+        this._downPicks.delete(event.pointerId);
+
+        const pick = this._pickNode(event);
+
+        this._chainDispatch(async () => {
+            const node = await pick;
+            if (!this._picker) return; // the host disconnected while the pick was in flight
+
+            const entityElement = this._elementWithListener(node, 'pointerup');
+            if (entityElement) {
+                entityElement.dispatchEvent(new PointerEvent('pointerup', event));
+            }
+        });
+
+        // A click fires where the DOM fires it: at the nearest common inclusive ancestor of
+        // what the press and the release picked, for the primary button only. Appended after
+        // the release's own step, so it dispatches after the pointerup that concludes it.
+        if (!downPick || event.button !== 0) return;
+
+        this._chainDispatch(async () => {
+            // A rejected pick was already reported by the press or release step that awaited it;
+            // here it just means no click can conclude.
+            const picked = await Promise.all([downPick, pick]).catch(() => null);
+            if (!picked || !this._picker) return;
+
+            const [downNode, upNode] = picked;
+            const clickElement = this._elementWithListener(commonAncestor(downNode, upNode), 'click');
+            if (clickElement) {
+                const click = new PointerEvent('click', event);
+
+                // The init above copied pointerup's `detail`, which the Pointer Events spec fixes
+                // at 0 - but click is exempt: its detail is the click count, chained here as the
+                // platform chains it (same target, within the double-click window). Overridden
+                // with defineProperty because an event instance used as an init dict cannot have
+                // single fields replaced.
+                const time = performance.now();
+                const last = this._lastClick;
+                const count =
+                    last && last.element === clickElement && time - last.time <= CLICK_CHAIN_MS ? last.count + 1 : 1;
+                this._lastClick = { element: clickElement, time, count };
+                Object.defineProperty(click, 'detail', { value: count });
+
+                clickElement.dispatchEvent(click);
+            }
+        });
+    }
+}

--- a/src/pointer-controller.ts
+++ b/src/pointer-controller.ts
@@ -93,6 +93,15 @@ export type PointerHost = {
 export class PointerController {
     private _host: PointerHost;
 
+    /**
+     * Incremented by every connect and disconnect. Async work captures the value when it starts
+     * and stops if it has moved on - so a pick or dispatch belonging to an earlier connection
+     * can neither keep reading through its destroyed picker nor deliver into a later
+     * connection. The field null checks alone cannot tell the two apart once a reconnect has
+     * repopulated them.
+     */
+    private _generation = 0;
+
     private _app: AppBase | null = null;
 
     private _canvas: HTMLCanvasElement | null = null;
@@ -153,6 +162,7 @@ export class PointerController {
      * @param canvas - The canvas the application renders into.
      */
     connect(app: AppBase, canvas: HTMLCanvasElement) {
+        this._generation++;
         this._app = app;
         this._canvas = canvas;
 
@@ -183,6 +193,8 @@ export class PointerController {
      * never connected.
      */
     disconnect() {
+        this._generation++;
+
         if (this._canvas) {
             Object.entries(this._pointerHandlers).forEach(([type, handler]) => {
                 if (handler) {
@@ -363,6 +375,7 @@ export class PointerController {
      * @returns The graph node under the pointer, or `null` if nothing was hit.
      */
     private async _pickNode(event: PointerEvent): Promise<GraphNode | null> {
+        const generation = this._generation;
         const app = this._app;
         const picker = this._picker;
         const canvas = this._canvas;
@@ -386,8 +399,9 @@ export class PointerController {
             picker.prepare(camera, app.scene);
             const selection = await picker.getSelectionAsync(x, y);
 
-            // The host may have disconnected while the read back was in flight.
-            if (!this._picker || !this._app) return null;
+            // The host may have disconnected - or disconnected and reconnected - while the read
+            // back was in flight. Either way this pick's connection is gone.
+            if (generation !== this._generation) return null;
 
             if (selection.length > 0) {
                 const item = selection[0];
@@ -408,10 +422,12 @@ export class PointerController {
 
         // Moves arrive faster than a pick resolves, so results can land out of order. Only the
         // newest pick may update the hover state - an older one describes a pointer position the
-        // user has already left.
+        // user has already left, and one from an earlier connection describes a scene that no
+        // longer exists.
+        const generation = this._generation;
         const token = ++this._pickToken;
         const node = await this._pickNode(event);
-        if (token !== this._pickToken || !this._picker) return;
+        if (token !== this._pickToken || generation !== this._generation) return;
 
         // The hovered element is the nearest one up the node's parent chain with a hover
         // listener - the nearest-listener rule down/up use. Dispatch is still gated per event
@@ -453,6 +469,8 @@ export class PointerController {
     private _onPointerDown(event: PointerEvent) {
         if (!this._picker || !this._app) return;
 
+        const generation = this._generation;
+
         // Picks stay concurrent - only the dispatch of the results is serialized
         const pick = this._pickNode(event);
 
@@ -466,7 +484,7 @@ export class PointerController {
 
         this._chainDispatch(async () => {
             const node = await pick;
-            if (!this._picker) return; // the host disconnected while the pick was in flight
+            if (generation !== this._generation) return; // this press's connection is gone
 
             const entityElement = this._elementWithListener(node, 'pointerdown');
             if (entityElement) {
@@ -478,6 +496,8 @@ export class PointerController {
     private _onPointerUp(event: PointerEvent) {
         if (!this._picker || !this._app) return;
 
+        const generation = this._generation;
+
         // The press pick this release may conclude as a click. Claimed synchronously, so the
         // entry is gone before any other event for this pointer can be handled.
         const downPick = this._downPicks.get(event.pointerId);
@@ -487,7 +507,7 @@ export class PointerController {
 
         this._chainDispatch(async () => {
             const node = await pick;
-            if (!this._picker) return; // the host disconnected while the pick was in flight
+            if (generation !== this._generation) return; // this release's connection is gone
 
             const entityElement = this._elementWithListener(node, 'pointerup');
             if (entityElement) {
@@ -504,7 +524,7 @@ export class PointerController {
             // A rejected pick was already reported by the press or release step that awaited it;
             // here it just means no click can conclude.
             const picked = await Promise.all([downPick, pick]).catch(() => null);
-            if (!picked || !this._picker) return;
+            if (!picked || generation !== this._generation) return;
 
             const [downNode, upNode] = picked;
             const clickElement = this._elementWithListener(commonAncestor(downNode, upNode), 'click');

--- a/test/integration/app-sizing.test.ts
+++ b/test/integration/app-sizing.test.ts
@@ -49,7 +49,8 @@ describe('<pc-app> sizing', () => {
         vi.stubGlobal('devicePixelRatio', 2);
 
         const { appElement } = await bootApp('', { appAttributes: 'max-pixel-ratio="1"' });
-        const picker = (appElement as unknown as { _picker: { width: number; height: number } })._picker;
+        const picker = (appElement as unknown as { _pointer: { _picker: { width: number; height: number } } })
+            ._pointer._picker;
         expect(picker.width).toBe(800);
         expect(picker.height).toBe(600);
 

--- a/test/integration/pointer-controller.test.ts
+++ b/test/integration/pointer-controller.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { EntityBaseElement } from '../../src/entity-base';
+import type { PointerHost } from '../../src/pointer-controller';
+import { PointerController } from '../../src/pointer-controller';
+import { bootApp } from '../helpers/app';
+import { useGuard } from '../helpers/guard';
+
+/**
+ * A stand-in for an entity-fronting element: a plain element carrying the one internal method
+ * the controller reads for listener demand. The set decides which synthesized events it claims
+ * to listen for, and can be changed between syncs.
+ *
+ * @param types - The event types the element initially listens for.
+ * @returns The element and its mutable listener set.
+ */
+const listeningTarget = (...types: string[]) => {
+    const listening = new Set(types);
+    const element = document.createElement('div') as unknown as EntityBaseElement;
+    (element as unknown as { _hasListeners: (type: string) => boolean })._hasListeners = (type) => listening.has(type);
+    return { element, listening };
+};
+
+/**
+ * A host over a fixed target list, with no node-to-element resolution.
+ *
+ * @param targets - The elements the host reports as pointer targets.
+ * @returns The host services.
+ */
+const hostFor = (targets: EntityBaseElement[]): PointerHost => ({
+    elementFromNode: () => null,
+    pointerTargets: () => targets
+});
+
+/**
+ * The controller exercised directly against its host seams, without any entity elements - what
+ * the extraction makes testable. The full pick-and-dispatch behavior stays covered end to end by
+ * pointer.test.ts.
+ */
+describe('PointerController', () => {
+    useGuard();
+
+    it('tolerates its whole lifecycle before connect', () => {
+        const controller = new PointerController(hostFor([]));
+
+        expect(() => {
+            controller.syncListeners();
+            controller.resize(800, 600);
+            controller.disconnect();
+        }).not.toThrow();
+    });
+
+    it('connect attaches the canvas listeners already listened for before it', async () => {
+        const { app } = await bootApp();
+        const { element } = listeningTarget('pointermove');
+        const controller = new PointerController(hostFor([element]));
+
+        // No canvas yet: nothing to attach, nothing to throw
+        controller.syncListeners();
+
+        const canvas = document.createElement('canvas');
+        const add = vi.spyOn(canvas, 'addEventListener');
+        controller.connect(app, canvas);
+
+        expect(add.mock.calls.map((call) => call[0])).toContain('pointermove');
+        controller.disconnect();
+    });
+
+    it('attaches exactly the canvas listeners each synthesized event type needs', async () => {
+        // The demand table: enter, leave and move ride the move pick; click rides the down/up
+        // pair plus the cancel that discards a press the browser takes back. Each sync must also
+        // detach whatever the current listeners no longer need.
+        const allCanvasTypes = ['pointercancel', 'pointerdown', 'pointermove', 'pointerup'];
+        const table: [string, string[]][] = [
+            ['pointermove', ['pointermove']],
+            ['pointerenter', ['pointermove']],
+            ['pointerleave', ['pointermove']],
+            ['pointerdown', ['pointerdown']],
+            ['pointerup', ['pointerup']],
+            ['click', ['pointercancel', 'pointerdown', 'pointerup']]
+        ];
+
+        const { app } = await bootApp();
+        const { element, listening } = listeningTarget();
+        const controller = new PointerController(hostFor([element]));
+        const canvas = document.createElement('canvas');
+        controller.connect(app, canvas);
+
+        const add = vi.spyOn(canvas, 'addEventListener');
+        const remove = vi.spyOn(canvas, 'removeEventListener');
+
+        for (const [type, needed] of table) {
+            listening.clear();
+            listening.add(type);
+            add.mockClear();
+            remove.mockClear();
+
+            controller.syncListeners();
+
+            expect(add.mock.calls.map((call) => call[0]).sort(), `attached for '${type}'`).toEqual(needed);
+            expect(remove.mock.calls.map((call) => call[0]).sort(), `detached for '${type}'`).toEqual(
+                allCanvasTypes.filter((canvasType) => !needed.includes(canvasType))
+            );
+        }
+
+        // No listeners at all: every canvas listener detaches
+        listening.clear();
+        remove.mockClear();
+        controller.syncListeners();
+        expect(remove.mock.calls.map((call) => call[0]).sort()).toEqual(allCanvasTypes);
+        controller.disconnect();
+    });
+
+    it('reads the target list fresh on every sync', async () => {
+        // The host owns the tree; the controller must follow it rather than hold a copy.
+        const { app } = await bootApp();
+        const targets: EntityBaseElement[] = [];
+        const controller = new PointerController(hostFor(targets));
+        const canvas = document.createElement('canvas');
+        controller.connect(app, canvas);
+
+        const add = vi.spyOn(canvas, 'addEventListener');
+        controller.syncListeners();
+        expect(add, 'no targets, nothing to attach').not.toHaveBeenCalled();
+
+        targets.push(listeningTarget('pointerdown').element);
+        controller.syncListeners();
+        expect(add.mock.calls.map((call) => call[0])).toContain('pointerdown');
+        controller.disconnect();
+    });
+
+    it('disconnect detaches every canvas handler', async () => {
+        const { app } = await bootApp();
+        const { element } = listeningTarget('pointermove', 'click');
+        const controller = new PointerController(hostFor([element]));
+        const canvas = document.createElement('canvas');
+        controller.connect(app, canvas);
+
+        const remove = vi.spyOn(canvas, 'removeEventListener');
+        controller.disconnect();
+
+        expect(remove.mock.calls.map((call) => call[0]).sort()).toEqual([
+            'pointercancel',
+            'pointerdown',
+            'pointermove',
+            'pointerup'
+        ]);
+
+        // Disconnected again, nothing is left to touch
+        remove.mockClear();
+        controller.disconnect();
+        expect(remove).not.toHaveBeenCalled();
+    });
+});

--- a/test/integration/pointer.test.ts
+++ b/test/integration/pointer.test.ts
@@ -283,6 +283,29 @@ describe('pc-app pointer picking', () => {
         expect(spies.pointerenter).not.toHaveBeenCalled();
     });
 
+    it('ignores a hover pick from a previous connection that resolves after a re-boot', async () => {
+        // A remove and re-insert repopulates the picker and application, so presence checks
+        // alone cannot tell an old operation from the new connection - only a pick's own
+        // connection may deliver it.
+        const { appElement, container, canvas, element, spies } = await bootTarget();
+        const pending = deferred<ReturnType<typeof hit>[]>();
+        stubPicker(appElement, [pending.promise]);
+
+        canvas.dispatchEvent(move(400, 300));
+
+        appElement.remove();
+        container.appendChild(appElement);
+        await readyWithin(appElement);
+        await settle(container);
+        appElement.app!.autoRender = false;
+
+        // The old connection's pick resolves now, against the re-booted entity
+        pending.resolve([hit(element.entity!)]);
+        await flush();
+
+        expect(spies.pointerenter, "the old connection's hover pick must not apply").not.toHaveBeenCalled();
+    });
+
     it('dispatches pointerdown and pointerup on the picked entity', async () => {
         const { appElement, canvas, entity, spies } = await bootTarget();
         stubPicker(appElement, [[hit(entity)], [hit(entity)]]);
@@ -673,6 +696,29 @@ describe('pc-app pointer picking', () => {
             expect(spies.pointerdown, 'the re-booted chain dispatches immediately').toHaveBeenCalledTimes(1);
             expect(spies.pointerup).toHaveBeenCalledTimes(1);
             expect(spies.click).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not dispatch a press picked before a re-boot into the new connection', async () => {
+            // The re-boot repopulates the picker and application, so the old press's dispatch
+            // step cannot rely on their presence - its own connection is gone.
+            const { appElement, container, canvas, element, spies } = await bootClickTarget();
+            const pending = deferred<ReturnType<typeof hit>[]>();
+            stubPicker(appElement, [pending.promise]);
+
+            canvas.dispatchEvent(down());
+
+            appElement.remove();
+            container.appendChild(appElement);
+            await readyWithin(appElement);
+            await settle(container);
+            appElement.app!.autoRender = false;
+
+            // The old connection's pick resolves now, against the re-booted entity
+            pending.resolve([hit(element.entity!)]);
+            await flush();
+
+            expect(spies.pointerdown, "the old connection's press must not dispatch").not.toHaveBeenCalled();
+            expect(spies.click).not.toHaveBeenCalled();
         });
 
         it('tracks presses per pointer', async () => {

--- a/test/integration/pointer.test.ts
+++ b/test/integration/pointer.test.ts
@@ -57,7 +57,7 @@ const stubPicker = (
 ) => {
     const calls = { sync: 0, async: 0, cameras: [] as unknown[] };
 
-    (appElement as unknown as { _picker: unknown })._picker = {
+    (appElement as unknown as { _pointer: { _picker: unknown } })._pointer._picker = {
         prepare: (camera: unknown) => {
             calls.cameras.push(camera);
         },


### PR DESCRIPTION
Fixes #440

`AppElement` carried a self-contained pointer-input subsystem — picker lifecycle, canvas handlers, listener synchronization, coordinate mapping, camera selection, hover tracking, ordered dispatch and click synthesis — alongside application boot, graphics setup, sizing, preload and teardown. This moves that subsystem into an internal `PointerController` and leaves `AppElement` with thin delegation.

## Shape

`src/pointer-controller.ts` owns everything pointer-specific, moved verbatim (constants, state, and logic — including every load-bearing comment):

- the engine `Picker` and its lifecycle;
- the canvas handlers and demand-driven listener synchronization;
- browser-to-buffer coordinate mapping and camera/viewport selection;
- picked-node → nearest-listening-element resolution and hover transitions with stale-move suppression;
- the serialized dispatch chain that preserves down/up/click order across GPU-ordered pick resolution, per-pointer press tracking, `pointercancel`, and click `detail` chaining.

Its lifecycle is four explicit calls, all driven by `AppElement`: `connect(app, canvas)` on boot, `resize(width, height)` when the drawing buffer changes, `syncListeners()` on descendant listener changes, and `disconnect()` on teardown (which also replaces the dispatch chain, so a pick that never resolves cannot stall a later boot — unchanged semantics).

Instead of reaching into `AppElement`, the controller reads two host services, both evaluated fresh on every use:

- `elementFromNode(node)` — the entity→element identity map lookup;
- `pointerTargets()` — the entity-fronting elements whose listeners decide which canvas handlers are needed.

`AppElement` keeps boot/destruction, canvas sizing, and the element-registration/`elementFromEntity` contract; callers of `_registerEntityElement`/`_unregisterEntityElement`/`elementFromEntity` are untouched.

## Behavior

Unchanged by construction — the code moved verbatim with only the seam substitutions (`this.app` → the connected app, map lookup → host service). The 37-test pointer integration suite passes as-is, apart from repointing its two private-internals seams (`stubPicker` and the picker-resize assertion in `app-sizing.test.ts`) from `appElement._picker` to the controller.

Five focused controller tests are added (`test/integration/pointer-controller.test.ts`), covering what the extraction makes testable directly — through stub hosts, with no entity elements: the lifecycle is safe in any order around `connect`, listener state carried from before boot attaches at `connect`, the full synthesized-event → canvas-listener demand table (attach *and* detach per sync), the target list being read fresh each sync, and `disconnect` detaching every handler.

## Public surface

The controller is internal: `@internal` with inline exports (stripped to `export {};` in the emitted declarations) and excluded from the CEM analyzer like the other non-element modules. `custom-elements.json`, both editor integrations, `index.d.ts` and `index.d.cts` are byte-identical to the pre-change build; standalone `tsc` passes over both declaration trees and publint are clean. Full suite: 1066 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
