### PR TITLE
Package an example's own source into its StackBlitz project

### DIFF
--- a/examples/js/stackblitz.mjs
+++ b/examples/js/stackblitz.mjs
@@ -4,28 +4,201 @@ const EXAMPLES_BASE = 'https://playcanvas.github.io/web-components/examples/';
 const PACKAGE_REGEX = /\/node_modules\/((?:@[\w.-]+\/)?[\w.-]+)/g;
 
 /**
- * Rewrites an example's HTML so it runs as a standalone npm-based project: the local library
- * build and repo-relative node_modules paths become project-root node_modules paths (installed
- * from npm), while example-relative resources (assets, scripts, styles) load from the deployed
- * examples site.
- * @param {string} html - The example's HTML source.
- * @returns {string} The transformed HTML.
+ * Matches a path into one of the five directories holding an example's own resources, wherever it
+ * appears: an HTML attribute, a CSS url(), or a JS string - including a template literal like
+ * assets/sounds/optic-${name}.mp3, whose interpolation survives the rewrite below because only the
+ * leading directory segments are ever resolved.
+ *
+ * Requiring one of those directory names is also what keeps relative import specifiers out of this
+ * pattern: nothing is imported through one of those directories, so a specifier such as
+ * ./stackblitz.mjs never matches here. Specifiers resolve against a different base - see baseOf().
+ *
+ * Being a text scan, this reads comments as readily as code. A quoted path in a comment is
+ * therefore rewritten like any other, and one naming a module or stylesheet packages that file -
+ * harmless either way, which is why no attempt is made to tell the two apart. Paths in the
+ * comments below are deliberately left unquoted so they stay out of it.
  */
-export function transformHtml(html) {
-    return html
-        .replace(/(\.\.\/)+dist\//g, '/node_modules/@playcanvas/web-components/dist/')
-        .replace(/(\.\.\/)+node_modules\//g, '/node_modules/')
-        .replace(/(["'(])((?:assets|css|img|js|modules)\/)/g, `$1${EXAMPLES_BASE}$2`);
+const RESOURCE_REGEX = /(["'`(])((?:\.\.\/)*(?:assets|css|img|js|modules)\/[^"'`)\s]*)/g;
+
+/**
+ * Matches the specifier of a relative import, re-export or dynamic import (and, incidentally, of a
+ * CSS @import, which resolves the same way). Bare specifiers are left to the page's import map.
+ */
+const IMPORT_REGEX = /\b(?:from|import)\s*\(?\s*(["'])(\.{1,2}\/[^"']*)\1/g;
+
+/** Matches the tag that loads the examples site's shared chrome - see stripSiteChrome(). */
+const CHROME_SCRIPT_REGEX = /^[ \t]*<script type="module" src="js\/example\.mjs"><\/script>\r?\n?/gm;
+
+/**
+ * The extensions of the files packaged into the project rather than loaded from the deployed site:
+ * the source a reader would want to read and edit. Binary resources - models, textures, sounds, and
+ * the wasm modules under modules/ - stay on the site.
+ */
+const SOURCE_EXTENSIONS = ['.css', '.mjs'];
+
+/** The directory part of an example-relative path: assets/scripts/rotate.mjs -> assets/scripts. */
+function dirOf(path) {
+    const index = path.lastIndexOf('/');
+    return index === -1 ? '' : path.slice(0, index);
 }
 
 /**
- * Collects the names of all npm packages referenced via /node_modules/ URLs in the given HTML.
- * @param {string} html - The transformed example HTML.
+ * The directory a file's own resource paths resolve against. For the page, and for the strings a
+ * module hands to fetch() or an asset loader, that is the document - so the examples root. For a
+ * CSS url() or @import it is the stylesheet itself.
+ *
+ * Import specifiers are the third case, resolving against the importing module, which is why they
+ * are matched separately (IMPORT_REGEX) and never rewritten: their targets are packaged at their
+ * original paths, so the specifier that reaches them already resolves.
+ * @param {string} path - The file's example-relative path.
+ * @returns {string} The directory to resolve the file's resource paths against.
+ */
+function baseOf(path) {
+    return path.endsWith('.css') ? dirOf(path) : '';
+}
+
+/**
+ * Resolves a relative path against a directory, both example-relative.
+ *
+ * Textual rather than `new URL()`: some of these paths are template literals, and URL would
+ * percent-encode the braces of an interpolation and corrupt it.
+ * @param {string} ref - The path as written.
+ * @param {string} dir - The directory to resolve it against, '' for the examples root.
+ * @returns {string | null} The example-relative path, or null if it climbs above the examples root.
+ */
+function resolvePath(ref, dir) {
+    const segments = dir === '' ? [] : dir.split('/');
+    for (const segment of ref.split('/')) {
+        if (segment === '..') {
+            if (segments.length === 0) {
+                return null;
+            }
+            segments.pop();
+        } else if (segment !== '.' && segment !== '') {
+            segments.push(segment);
+        }
+    }
+    return segments.join('/');
+}
+
+/**
+ * Drops the tag that loads js/example.mjs, the chrome the examples site wraps around every page:
+ * fullscreen, AR/VR entry, the button that produced this project, and a link to the page's source
+ * on GitHub. None of it is part of the example, and in a project none of it is much use either -
+ * the StackBlitz and view-source buttons act on the site, and the XR ones only appear when
+ * app.xr.isAvailable() says so, which a preview iframe never does.
+ *
+ * Applied before the source walk, so the chrome module and everything it imports - this file
+ * included - stay out of the project rather than being packaged and then left unused.
+ * @param {string} html - The example's HTML source.
+ * @returns {string} The HTML without the chrome tag.
+ */
+export function stripSiteChrome(html) {
+    return html.replace(CHROME_SCRIPT_REGEX, '');
+}
+
+/**
+ * Rewrites one of an example's source files so it runs as part of a standalone npm-based project:
+ * the local library build and repo-relative node_modules paths become project-root node_modules
+ * paths (installed from npm), while resources the project does not carry load from the deployed
+ * examples site.
+ * @param {string} source - The file's source text.
+ * @param {string} path - The file's example-relative path, e.g. index.html or css/example.css.
+ * @param {Set<string>} [packaged] - Example-relative paths of the files packaged alongside this one.
+ * References to those are left as written, so they resolve inside the project.
+ * @returns {string} The transformed source.
+ */
+export function transformSource(source, path, packaged = new Set()) {
+    const base = baseOf(path);
+    return source
+        .replace(/(\.\.\/)+dist\//g, '/node_modules/@playcanvas/web-components/dist/')
+        .replace(/(\.\.\/)+node_modules\//g, '/node_modules/')
+        .replace(RESOURCE_REGEX, (match, quote, ref) => {
+            const resolved = resolvePath(ref, base);
+            // A path that leaves examples/ is left alone: the project has a root of its own, and
+            // the one such path - stackblitz.mjs reading ../package.json - is better served by it
+            if (resolved === null || packaged.has(resolved)) {
+                return match;
+            }
+            return `${quote}${EXAMPLES_BASE}${resolved}`;
+        });
+}
+
+/**
+ * The example-relative paths of the local source files one file references. Every relative import
+ * specifier counts, whatever its extension - a module the project does not carry cannot be resolved
+ * any other way - while a resource path only counts if it is source rather than a binary asset.
+ * @param {string} source - The file's source text.
+ * @param {string} path - The file's own example-relative path.
+ * @returns {string[]} The referenced paths, which may contain duplicates.
+ */
+function referencesIn(source, path) {
+    const paths = [];
+
+    for (const [, , ref] of source.matchAll(IMPORT_REGEX)) {
+        const resolved = resolvePath(ref, dirOf(path));
+        if (resolved !== null) {
+            paths.push(resolved);
+        }
+    }
+
+    for (const [, , ref] of source.matchAll(RESOURCE_REGEX)) {
+        const resolved = resolvePath(ref, baseOf(path));
+        if (resolved !== null && SOURCE_EXTENSIONS.some((ext) => resolved.endsWith(ext))) {
+            paths.push(resolved);
+        }
+    }
+
+    return paths;
+}
+
+/**
+ * Walks an example's local source graph from its HTML and reads every file in it - the modules and
+ * stylesheets the page loads, then whatever those reference in turn. The graph really is recursive:
+ * the AR examples declare a script that imports assets/scripts/face-tracking.mjs, which the page
+ * itself never names.
+ * @param {string} html - The example's HTML source, chrome stripped and otherwise untransformed.
+ * @param {(path: string) => Promise<string | null>} read - Reads one example-relative path,
+ * resolving to null if it cannot be read.
+ * @returns {Promise<Record<string, string>>} The sources, keyed by example-relative path.
+ */
+export async function collectSources(html, read) {
+    /** @type {Record<string, string>} */
+    const sources = {};
+    const seen = new Set();
+    let pending = referencesIn(html, 'index.html');
+
+    while (pending.length > 0) {
+        // Deduplicated within the batch as well as against earlier ones: three of the AR scripts
+        // reach face-tracking.mjs, and two of them are loaded by the same page
+        const batch = [...new Set(pending)].filter((path) => !seen.has(path));
+        batch.forEach((path) => seen.add(path));
+
+        const results = await Promise.all(batch.map(async (path) => [path, await read(path)]));
+
+        pending = [];
+        for (const [path, source] of results) {
+            // A file that cannot be read is simply not packaged, and transformSource then leaves
+            // every reference to it pointing at the deployed site
+            if (source === null) {
+                continue;
+            }
+            sources[path] = source;
+            pending.push(...referencesIn(source, path));
+        }
+    }
+
+    return sources;
+}
+
+/**
+ * Collects the names of all npm packages referenced via /node_modules/ URLs in the given source.
+ * @param {string} source - A transformed file from the generated project.
  * @returns {Set<string>} The referenced package names.
  */
-export function collectPackages(html) {
+export function collectPackages(source) {
     const packages = new Set();
-    for (const [, name] of html.matchAll(PACKAGE_REGEX)) {
+    for (const [, name] of source.matchAll(PACKAGE_REGEX)) {
         packages.add(name);
     }
     return packages;
@@ -111,9 +284,10 @@ function postToStackBlitz({ title, description, files }, target) {
 }
 
 /**
- * Opens the current example as an editable StackBlitz project. The project installs `playcanvas`
- * and `@playcanvas/web-components` (plus any other packages the example imports) from npm and
- * serves the example HTML, while assets continue to load from the deployed examples site.
+ * Opens the current example as an editable StackBlitz project. The project carries the example's
+ * own source - its HTML, stylesheet and modules, but not the site's shared chrome - and installs
+ * `playcanvas` and `@playcanvas/web-components` (plus any other packages the example imports) from
+ * npm, while binary assets continue to load from the deployed examples site.
  */
 export async function openInStackBlitz() {
     // Open the tab synchronously so the browser attributes it to the user's click; the form
@@ -127,13 +301,31 @@ export async function openInStackBlitz() {
             fetch('../package.json').then((r) => (r.ok ? r.json() : {}))
         ]);
 
-        const transformed = transformHtml(html);
+        const page = stripSiteChrome(html);
+
+        // Example pages sit at the root of examples/, so an example-relative path is also relative
+        // to this page
+        const sources = await collectSources(page, (path) =>
+            fetch(path)
+                .then((r) => (r.ok ? r.text() : null))
+                .catch(() => null)
+        );
+
+        const packaged = new Set(Object.keys(sources));
+        const files = { 'index.html': transformSource(page, 'index.html', packaged) };
+        for (const [path, source] of Object.entries(sources)) {
+            files[path] = transformSource(source, path, packaged);
+        }
+
         const slug = window.location.pathname
             .split('/')
             .pop()
             .replace(/\.html$/, '');
         const title = document.title;
-        const packageJson = buildPackageJson(rootPkg, collectPackages(transformed), `pwc-example-${slug}`);
+        // Read across every file, not just the page: a packaged module can be the only thing that
+        // names a package, as the mediapipe examples do when they load their wasm out of node_modules
+        const packages = new Set(Object.values(files).flatMap((contents) => [...collectPackages(contents)]));
+        const packageJson = buildPackageJson(rootPkg, packages, `pwc-example-${slug}`);
 
         const readme = [
             `# ${title}`,
@@ -141,7 +333,9 @@ export async function openInStackBlitz() {
             'A [PlayCanvas Web Components](https://www.npmjs.com/package/@playcanvas/web-components)',
             'example - a 3D scene declared entirely in HTML.',
             '',
-            'Edit `index.html` and refresh the preview to see your changes.',
+            'Everything the example implements is here to edit: `index.html`, its stylesheet, and the',
+            'modules it loads. Refresh the preview to see your changes. Models, textures, sounds and',
+            'the other binary assets load from the PlayCanvas examples site.',
             '',
             '- [User Manual](https://developer.playcanvas.com/user-manual/web-components/)',
             '- [API Reference](https://api.playcanvas.com/web-components)',
@@ -154,7 +348,7 @@ export async function openInStackBlitz() {
                 title,
                 description: 'A PlayCanvas Web Components example - a 3D scene declared entirely in HTML',
                 files: {
-                    'index.html': transformed,
+                    ...files,
                     'package.json': JSON.stringify(packageJson, null, 4),
                     'README.md': readme
                 }

--- a/test/examples/stackblitz.test.ts
+++ b/test/examples/stackblitz.test.ts
@@ -1,0 +1,400 @@
+/// <reference types="vite/client" />
+
+import { describe, expect, it, test } from 'vitest';
+
+import { collectPackages, collectSources, stripSiteChrome, transformSource } from '../../examples/js/stackblitz.mjs';
+
+const DEPLOYED = 'https://playcanvas.github.io/web-components/examples/';
+
+describe('stripSiteChrome', () => {
+    it('removes the chrome tag and its line, leaving the rest of the page untouched', () => {
+        const html = [
+            '        <pc-app></pc-app>',
+            '        <script type="module" src="js/example.mjs"></script>',
+            '    </body>'
+        ].join('\n');
+
+        expect(stripSiteChrome(html)).toBe('        <pc-app></pc-app>\n    </body>');
+    });
+
+    /** The deployed site serves LF; the working tree is CRLF. */
+    it('removes the line whichever way it is terminated', () => {
+        const crlf = '<body>\r\n        <script type="module" src="js/example.mjs"></script>\r\n</body>';
+
+        expect(stripSiteChrome(crlf)).toBe('<body>\r\n</body>');
+    });
+
+    /**
+     * js/model-inspector.mjs sits in the same directory and is loaded the same way, but it is the
+     * example's own page glue - the panel the example is about - not chrome.
+     */
+    it('leaves an example page module of its own alone', () => {
+        const html = '        <script type="module" src="js/model-inspector.mjs"></script>';
+
+        expect(stripSiteChrome(html)).toBe(html);
+    });
+
+    it('is a no-op on the two pages that never loaded the chrome', () => {
+        const html = '<pc-app><pc-asset src="assets/scripts/solar-system.mjs"></pc-asset></pc-app>';
+
+        expect(stripSiteChrome(html)).toBe(html);
+    });
+});
+
+describe('transformSource', () => {
+    it('points the library build at the installed package', () => {
+        const html = '<script type="module" src="../dist/pwc.mjs"></script>';
+
+        expect(transformSource(html, 'index.html')).toBe(
+            '<script type="module" src="/node_modules/@playcanvas/web-components/dist/pwc.mjs"></script>'
+        );
+    });
+
+    it('points repo-relative node_modules at the project root', () => {
+        const html = '"playcanvas": "../node_modules/playcanvas/build/playcanvas.mjs"';
+
+        expect(transformSource(html, 'index.html')).toBe(
+            '"playcanvas": "/node_modules/playcanvas/build/playcanvas.mjs"'
+        );
+    });
+
+    it('sends resources the project does not carry to the deployed site', () => {
+        const html = [
+            '<pc-asset src="assets/models/star.glb"></pc-asset>',
+            '<pc-wasm glue="modules/ammo/ammo.wasm.js"></pc-wasm>',
+            '<img src="img/playcanvas.png">'
+        ].join('\n');
+
+        expect(transformSource(html, 'index.html')).toBe(
+            [
+                `<pc-asset src="${DEPLOYED}assets/models/star.glb"></pc-asset>`,
+                `<pc-wasm glue="${DEPLOYED}modules/ammo/ammo.wasm.js"></pc-wasm>`,
+                `<img src="${DEPLOYED}img/playcanvas.png">`
+            ].join('\n')
+        );
+    });
+
+    /**
+     * The point of the whole exercise: a packaged file keeps its original path, so the reference to
+     * it is the one thing that must NOT be rewritten - otherwise the project carries a copy nothing
+     * loads, and still runs the deployed site's code.
+     */
+    it('leaves references to packaged files as written', () => {
+        const html = [
+            '<link rel="stylesheet" href="css/example.css">',
+            '<pc-asset src="assets/scripts/rotate.mjs"></pc-asset>',
+            '<script type="module" src="js/example.mjs"></script>'
+        ].join('\n');
+        const packaged = new Set(['css/example.css', 'assets/scripts/rotate.mjs', 'js/example.mjs']);
+
+        expect(transformSource(html, 'index.html', packaged)).toBe(html);
+    });
+
+    /**
+     * A stylesheet resolves url() against itself, not the page, so packaging css/example.css moves
+     * what '../img/' means. Only the leading segments are resolved; the rest is copied through.
+     */
+    it('resolves a stylesheet url() against the stylesheet', () => {
+        const css = '.icon-ar { mask-image: url("../img/ar.svg"); }';
+
+        expect(transformSource(css, 'css/example.css')).toBe(`.icon-ar { mask-image: url("${DEPLOYED}img/ar.svg"); }`);
+    });
+
+    /**
+     * Rewriting by prefix rather than by URL is what keeps this working: `new URL()` would
+     * percent-encode the braces and leave the example fetching a literal '$%7Bname%7D'.
+     */
+    it('keeps a template literal interpolation intact', () => {
+        const source = 'await fetch(`assets/sounds/optic-${name}.mp3`);';
+
+        expect(transformSource(source, 'assets/scripts/optic-blast-visuals.mjs')).toBe(
+            `await fetch(\`${DEPLOYED}assets/sounds/optic-\${name}.mp3\`);`
+        );
+    });
+
+    /**
+     * stackblitz.mjs reads the repo's package.json from above examples/, and the project has a
+     * package.json of its own at exactly that spot - so the honest thing is to leave it be.
+     */
+    it('leaves a path that climbs above examples/ alone', () => {
+        const source = "fetch('../package.json')";
+
+        expect(transformSource(source, 'js/stackblitz.mjs')).toBe(source);
+    });
+
+    /**
+     * An import specifier resolves against the importing module, and both ends of a relative one
+     * are packaged at their original paths - so it already resolves, and rewriting it against the
+     * page (the base every other path in a module uses) would break it.
+     */
+    it('leaves relative import specifiers alone', () => {
+        const source = "import { FaceTracking } from './face-tracking.mjs';";
+
+        expect(transformSource(source, 'assets/scripts/optic-blast-tracking.mjs')).toBe(source);
+    });
+});
+
+describe('collectSources', () => {
+    /**
+     * A miniature of the real graph: a page that loads a stylesheet, two scripts and the shared
+     * example chrome; chrome that imports a second module; two scripts that share a third; and one
+     * binary asset that must stay on the deployed site.
+     */
+    const TREE: Record<string, string> = {
+        'index.html': [
+            '<link rel="stylesheet" href="css/example.css">',
+            '<pc-asset src="assets/models/star.glb"></pc-asset>',
+            '<pc-asset src="assets/scripts/a.mjs"></pc-asset>',
+            '<pc-asset src="assets/scripts/b.mjs"></pc-asset>',
+            '<script type="module" src="js/example.mjs"></script>'
+        ].join('\n'),
+        'css/example.css': '.icon { mask-image: url("../img/ar.svg"); }',
+        'js/example.mjs': "import { openInStackBlitz } from './stackblitz.mjs';",
+        'js/stackblitz.mjs': 'export const openInStackBlitz = () => {};',
+        'assets/scripts/a.mjs': "import { shared } from './shared.mjs';",
+        'assets/scripts/b.mjs': "import { shared } from './shared.mjs';",
+        'assets/scripts/shared.mjs': 'export const shared = 1;'
+    };
+
+    /** Reads from TREE, recording every path asked for - including ones that are not in it. */
+    const reader = (tree: Record<string, string> = TREE) => {
+        const reads: string[] = [];
+        return {
+            reads,
+            read: (path: string) => {
+                reads.push(path);
+                return Promise.resolve(path in tree ? tree[path] : null);
+            }
+        };
+    };
+
+    it('reads the stylesheets and modules the page loads', async () => {
+        const { read } = reader();
+
+        const sources = await collectSources(TREE['index.html'], read);
+
+        expect(Object.keys(sources).sort()).toEqual([
+            'assets/scripts/a.mjs',
+            'assets/scripts/b.mjs',
+            'assets/scripts/shared.mjs',
+            'css/example.css',
+            'js/example.mjs',
+            'js/stackblitz.mjs'
+        ]);
+    });
+
+    /**
+     * The graph is recursive in practice, not just in principle: every page loads js/example.mjs,
+     * which imports js/stackblitz.mjs. A one-level walk would package the chrome and leave it
+     * importing a module that is not there.
+     */
+    it('follows imports of imports', async () => {
+        const { read } = reader();
+
+        const sources = await collectSources(TREE['index.html'], read);
+
+        expect(sources['js/stackblitz.mjs']).toBe(TREE['js/stackblitz.mjs']);
+    });
+
+    it('resolves an import specifier against the importing module', async () => {
+        const { read } = reader();
+
+        const sources = await collectSources(TREE['index.html'], read);
+
+        expect(sources['assets/scripts/shared.mjs']).toBe(TREE['assets/scripts/shared.mjs']);
+    });
+
+    it('reads each file once, however many modules reach it', async () => {
+        const { reads, read } = reader();
+
+        await collectSources(TREE['index.html'], read);
+
+        expect(reads).toEqual([...new Set(reads)]);
+    });
+
+    it('leaves binary resources to the deployed site', async () => {
+        const { reads, read } = reader();
+
+        await collectSources(TREE['index.html'], read);
+
+        expect(reads).not.toContain('assets/models/star.glb');
+        expect(reads).not.toContain('img/ar.svg');
+    });
+
+    /**
+     * A file that cannot be read is left out rather than packaged empty, which is what makes the
+     * fallback work: transformSource sends every reference outside the packaged set to the site.
+     */
+    it('skips a file it cannot read, leaving the reference to the deployed site', async () => {
+        const html = '<pc-asset src="assets/scripts/missing.mjs"></pc-asset>';
+        const { read } = reader({});
+
+        const sources = await collectSources(html, read);
+        const packaged = new Set(Object.keys(sources));
+
+        expect(packaged.size).toBe(0);
+        expect(transformSource(html, 'index.html', packaged)).toBe(
+            `<pc-asset src="${DEPLOYED}assets/scripts/missing.mjs"></pc-asset>`
+        );
+    });
+});
+
+describe('collectPackages', () => {
+    it('reads scoped and unscoped package names off /node_modules/ paths', () => {
+        const source = [
+            '"@mediapipe/tasks-vision": "/node_modules/@mediapipe/tasks-vision/vision_bundle.mjs"',
+            '"playcanvas": "/node_modules/playcanvas/build/playcanvas.mjs"',
+            '"opentype.js": "/node_modules/opentype.js/dist/opentype.module.js"'
+        ].join('\n');
+
+        expect([...collectPackages(source)].sort()).toEqual(['@mediapipe/tasks-vision', 'opentype.js', 'playcanvas']);
+    });
+
+    it('ignores bare specifiers, which the import map resolves', () => {
+        expect(collectPackages("import { Script } from 'playcanvas';").size).toBe(0);
+    });
+});
+
+/**
+ * The pipeline run against the real examples, with the sources read out of the repo instead of over
+ * the network. Everything above tests a rule; this tests that the rules cover the corpus.
+ */
+describe('examples/*.html', () => {
+    /**
+     * Every page, and every source file a page could reach, inlined by Vite as text - the same glob
+     * the other two Examples-tier suites use, and for the same reason: the repo carries no
+     * @types/node.
+     */
+    const files: Record<string, string> = import.meta.glob('../../examples/**/*.{html,mjs,css}', {
+        query: '?raw',
+        import: 'default',
+        eager: true
+    });
+
+    /** The files above, re-keyed on their example-relative paths. */
+    const tree = Object.fromEntries(
+        Object.entries(files).map(([key, source]) => [key.replace('../../examples/', ''), source])
+    );
+
+    const read = (path: string) => Promise.resolve(path in tree ? tree[path] : null);
+
+    /** The one page under examples/ that is not an example: it is the shell that renders the rest. */
+    const pages = Object.keys(tree)
+        .filter((path) => path.endsWith('.html') && path !== 'index.html')
+        .sort();
+
+    /**
+     * Builds the project for one page: the same steps openInStackBlitz() takes, minus the
+     * package.json, the README and the form post.
+     */
+    const build = async (page: string) => {
+        const html = stripSiteChrome(tree[page]);
+        const sources = await collectSources(html, read);
+        const packaged = new Set(Object.keys(sources));
+
+        const project: Record<string, string> = {
+            'index.html': transformSource(html, 'index.html', packaged)
+        };
+        for (const [path, source] of Object.entries(sources)) {
+            project[path] = transformSource(source, path, packaged);
+        }
+        return project;
+    };
+
+    /**
+     * References out of a transformed file: HTML and CSS paths, then import specifiers. Written
+     * against the syntax rather than against stackblitz.mjs's own patterns, so that a reference in
+     * a form those patterns do not match shows up here as a failure rather than as agreement.
+     */
+    const referencesIn = (source: string): string[] => [
+        ...[...source.matchAll(/(?:src|href)="([^"]+)"/g)].map(([, ref]) => ref),
+        ...[...source.matchAll(/url\(["']?([^"')]+)["']?\)/g)].map(([, ref]) => ref),
+        ...[...source.matchAll(/\b(?:from|import)\s*\(?\s*["']([^"']+)["']/g)].map(([, ref]) => ref)
+    ];
+
+    /**
+     * A reference the project has to satisfy itself. Absolute URLs and /node_modules/ paths are
+     * served by the site and by npm; anything without a '/' (playcanvas, opentype.js) or starting
+     * with '@' is a bare specifier the import map resolves.
+     */
+    const isLocal = (ref: string): boolean =>
+        !/^(?:[a-z]+:)?\/\//.test(ref) &&
+        !ref.startsWith('data:') &&
+        !ref.startsWith('/node_modules/') &&
+        !ref.startsWith('@') &&
+        ref.includes('/');
+
+    it('finds every example page', () => {
+        expect(pages.length).toBe(42);
+    });
+
+    /**
+     * The check the packaging exists for. A project whose files reference each other and nothing
+     * else local is one a reader can edit; a reference to a path the project does not carry is
+     * either a 404 or - worse, because it looks like it works - the deployed site's code running
+     * inside an editable project.
+     */
+    describe('carries every local file its project references', () => {
+        test.for(pages)('%s', async (page) => {
+            const project = await build(page);
+            // build() stops short of the two files openInStackBlitz() writes itself
+            const carried = new Set([...Object.keys(project), 'package.json', 'README.md']);
+
+            const missing = Object.entries(project).flatMap(([path, source]) =>
+                referencesIn(source)
+                    .filter(isLocal)
+                    .map((ref) => ({ path, ref, resolved: resolve(ref, path) }))
+                    .filter(({ resolved }) => !carried.has(resolved))
+            );
+
+            expect(missing).toEqual([]);
+        });
+    });
+
+    /**
+     * Closure alone would also be satisfied by sending every module to the deployed site, so assert
+     * the substantive half too: the source a page names is source the project carries.
+     */
+    describe('packages every module and stylesheet the page loads', () => {
+        test.for(pages)('%s', async (page) => {
+            const project = await build(page);
+            const named = referencesIn(stripSiteChrome(tree[page]))
+                .filter((ref) => /\.(?:mjs|css)$/.test(ref))
+                // ../dist and ../node_modules are the library and its dependencies, from npm
+                .filter((ref) => !ref.startsWith('../'));
+
+            expect(named.length).toBeGreaterThan(0);
+            expect(named.filter((ref) => !(ref in project))).toEqual([]);
+        });
+    });
+
+    /**
+     * The chrome is the one thing deliberately left out, and leaving it out has to hold for the
+     * whole corpus: neither the module nor js/stackblitz.mjs, which only it imports, may survive
+     * into a project - and no page may keep a tag loading either.
+     */
+    describe('carries none of the examples site chrome', () => {
+        test.for(pages)('%s', async (page) => {
+            const project = await build(page);
+
+            expect(Object.keys(project)).not.toContain('js/example.mjs');
+            expect(Object.keys(project)).not.toContain('js/stackblitz.mjs');
+            // The name survives in prose on two pages, whose panels explain why they sit clear of
+            // buttons that used to be there - so match the tag, not the string
+            expect(project['index.html']).not.toMatch(/<script[^>]*js\/example\.mjs/);
+        });
+    });
+});
+
+/**
+ * Resolves a reference the way the file holding it does: an import specifier and a CSS url() go
+ * through the file's own directory, and everything else through the page. Kept out of the describe
+ * above only because hoisting reads better than a nested const here.
+ * @param ref - The reference as written.
+ * @param path - The example-relative path of the file holding it.
+ * @returns The example-relative path the reference lands on.
+ */
+function resolve(ref: string, path: string): string {
+    const dir = ref.startsWith('.') || path.endsWith('.css') ? path.replace(/[^/]*$/, '') : '';
+    return new URL(ref, `https://project.invalid/${dir}`).pathname.slice(1);
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -10,10 +10,11 @@
     // `moduleResolution: "bundler"` and `strict` are inherited, so tests resolve extensionless
     // relative imports exactly as src/ does and are held to identical strictness.
     //
-    // `allowJs` is for the one JS file a test imports: examples/js/example-list.mjs, the example
-    // catalogue. It stays plain JS because the example browser loads it unbuilt in a <script
-    // type="module">, so inference off the object literals is the only way to type it. `checkJs`
-    // stays off, so examples/ is read for types and never reported on.
+    // `allowJs` is for the JS files a test imports: examples/js/example-list.mjs, the example
+    // catalogue, and examples/js/stackblitz.mjs, which builds the StackBlitz project. They stay
+    // plain JS because the examples load them unbuilt in a <script type="module">, so inference off
+    // the literals and the JSDoc is the only way to type them. `checkJs` stays off, so examples/ is
+    // read for types and never reported on.
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "noEmit": true,


### PR DESCRIPTION
## Problem

`examples/js/stackblitz.mjs` wrote three files into the generated project — `index.html`, `package.json` and `README.md` — and `transformHtml()` rewrote every example-relative path to the deployed GitHub Pages URL:

```js
.replace(/(["'(])((?:assets|css|img|js|modules)\/)/g, `$1${EXAMPLES_BASE}$2`);
```

So the JavaScript that implements each example was not in the project at all. It was neither visible nor editable, and it was fetched at runtime from a mutable hosted file, which means an exported project silently changes behavior whenever the site is redeployed. The README told the reader to edit `index.html` and refresh — the only thing they could in fact edit.

## What changed

`openInStackBlitz()` now walks the example's local source graph from its HTML and packages every module and stylesheet it reaches, at its original relative path, leaving those references un-rewritten so they resolve inside the project.

Unchanged: binary resources (models, textures, sounds, splats, wasm modules) keep loading from the deployed site, and npm packages still resolve from `/node_modules/`, pinned to this repo's own versions.

Across the corpus that packages **88 source files** over 42 examples — about two per example, each of them the example's own. The ones that carry real behavior are now in the project: `ui-layout.mjs` (276 lines), `choose-color.mjs` (283), `model-inspector.mjs` (~500), `scroll-view.mjs` (86).

### Three resolution bases

This is where the difficulty is, and where a reviewer's attention is best spent. The walk also has to be recursive: the AR examples declare a script that imports `face-tracking.mjs`, which no page names.

| Reference | Resolves against | Handling |
| --- | --- | --- |
| import specifier (`./face-tracking.mjs`) | the importing module | discovered, never rewritten — both ends are packaged at their original paths, so it already resolves |
| any other string in a module (``fetch(`assets/sounds/optic-${name}.mp3`)``) | the document | rewritten **by prefix**, not through `new URL()` — URL would percent-encode the braces and leave the example fetching a literal `$%7Bname%7D` |
| CSS `url("../img/ar.svg")` | the stylesheet | rewritten to an absolute deployed URL. This one *had* to change: packaging `css/example.css` moves what `../img/` means |

`fetch('../package.json')` climbs out of `examples/` and is left alone; in a project it lands on the project's own `package.json`.

### API changes within `examples/js/`

- `transformHtml(html)` → `transformSource(source, path, packaged)`, now applied to the page *and* to each packaged file. Nothing outside this file imported it.
- `collectPackages()` is read across every generated file rather than the page alone, since a packaged module can be the only thing naming a package.
- New exports: `collectSources(html, read)` and `stripSiteChrome(html)`.

### The site chrome is dropped, not packaged

`js/example.mjs` adds fullscreen, AR/VR entry, the StackBlitz button itself and a view-source link. None of that is part of the example, and none of it is useful in a project: the first two act on the site, and the XR ones are gated on `app.xr.isAvailable()`, which a preview iframe never satisfies. `stripSiteChrome()` removes the tag *before* the walk, which also keeps `js/stackblitz.mjs` — reachable only through that module — out of the project.

Worth knowing: 16 examples declare `xrSession`/`xrControllers`/`xrNavigation`, and `example.mjs` was the only thing firing `ar:start`/`vr:start`. Stripping it does remove the sole AR/VR entry point, but those buttons never rendered in a StackBlitz preview anyway.

An example's *own* page module is untouched — `model-inspector.html` still packages `js/model-inspector.mjs`, same directory and same kind of tag — so the strip matches the exact filename rather than anything under `js/`.

## Tests

There was **no existing coverage** for this module; this adds the first. 46 tests in the `examples` tier:

- Rule-level tests for each rewrite, for the chrome strip and for the graph walk.
- Three per-page sweeps over all 42 examples, asserting that every local reference in a generated project lands on a file the project carries, that every module and stylesheet a page loads is packaged, and that no chrome survives. They read real sources through `import.meta.glob`, so they need no network, and the reference scan is written against the syntax rather than against `stackblitz.mjs`'s own patterns — a reference in a form those patterns miss shows up as a failure rather than as agreement.

The sweeps earned their keep: they caught a duplicate fetch (paths repeated *within* one BFS batch were not deduped, so `face-tracking.mjs` was fetched twice on two AR pages) and a doc comment of mine that was packaging `rotate.mjs` into every project.

`tsconfig.test.json`'s comment about "the one JS file a test imports" is updated, since there are now two.

## Known limitation

The scan is textual, so a quoted path in a comment is treated like one in code. It rewrites harmlessly, and a quoted module path would package a file nothing loads, so no attempt is made to tell the two apart — a comment tokenizer would be more risk than the noise is worth. Comments in `stackblitz.mjs` use unquoted paths instead.

Consequently `robot-arm.html` and `shadow-cascades.html` keep a CSS comment mentioning `js/example.mjs`, explaining why their panel sits bottom-left. The buttons it refers to are no longer in the export. Cosmetic, and not worth rewriting example HTML over.

## Verification

`npm run lint`, `npm run type-check` and the full suite (1219 tests) pass.

Beyond the tests, generated the project for two examples, served it with `node_modules` linked in, and loaded it in a browser:

- **spinning-cube** — no chrome buttons, one script tag (the library), no console errors; packaged `rotate.mjs` registers as `Rotate` and advances Euler angles per frame; clear color exactly `[128, 153, 230]` (`#8099e6`); 3441 pixels change under rotation. `/js/example.mjs` 404s from the project.
- **model-inspector** — no chrome buttons; the packaged page glue builds its panel from `pc-model.hierarchy()` ("Camera Drone / 27 parts · 11 materials"); GLB and HDR load from the deployed site; `camera-controls.mjs` and `camera-frame.mjs` load from `/node_modules/playcanvas/scripts/esm/`; 434 distinct sampled colors rendered.
