### PR TITLE
Stop the example chrome swallowing the first press after its buttons fade

### DIFF
--- a/examples/assets/scripts/falling-blocks.mjs
+++ b/examples/assets/scripts/falling-blocks.mjs
@@ -625,9 +625,8 @@ export class TouchControls extends Script {
         this._onUp = this._onUp.bind(this);
         this._onCancel = this._onCancel.bind(this);
 
-        // Capture phase, because the example chrome swallows the first bubbling
-        // pointerdown after its buttons have idle-faded - a same-node capture listener
-        // still sees every press
+        // Capture phase on window, so a press is seen whatever the page's own UI above the
+        // canvas does with it on the way back up
         window.addEventListener('pointerdown', this._onDown, { capture: true });
         window.addEventListener('pointermove', this._onMove, { capture: true });
         window.addEventListener('pointerup', this._onUp, { capture: true });

--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -40,9 +40,10 @@ pc-app {
     transition: opacity 0.5s ease;
 }
 
+/* Faded out but still hit-testable, so a press aimed at the buttons lands on them instead of
+   falling through to the scene behind - the page helper spends that press on revealing them */
 .example-button-container.faded {
     opacity: 0;
-    pointer-events: none;
 }
 
 .example-button-container.bottom-right {

--- a/examples/js/example.mjs
+++ b/examples/js/example.mjs
@@ -120,20 +120,43 @@ function onActivity() {
     idleTimeout = setTimeout(fadeWhenIdle, IDLE_FADE_MS);
 }
 
-// While faded the buttons are not hit-testable, so a press aimed at them would fall
-// through to the page beneath - and on touch there is no pointermove to reveal them
-// first. Capture the press, spend it on revealing the buttons, and stop it from
-// reaching the page (mouse users are unaffected: pointermove reveals before any click).
-function onPress(event) {
-    if (container.classList.contains('faded')) {
-        event.stopPropagation();
-    }
+// Faded, the buttons stay hit-testable, so a press aimed at one lands on it rather than falling
+// through to the page beneath - and on touch, where no pointermove precedes the tap, that press
+// is also what reveals them. It is spent on the reveal: a button the user could not see must not
+// act, so the click it produces is stopped before reaching the button. Every press re-decides
+// this, so a press that finds the buttons already revealed leaves nothing to stop.
+let pressSpent = false;
+
+function onPress() {
+    pressSpent = container.classList.contains('faded');
     onActivity();
 }
 
-window.addEventListener('pointerdown', onPress, { capture: true, passive: true });
-window.addEventListener('touchstart', onPress, { capture: true, passive: true });
-for (const event of ['pointermove', 'keydown']) {
-    window.addEventListener(event, onActivity, { passive: true });
+// Keyboard activity reveals the buttons too, and a keyboard activation produces a click with no
+// press behind it, so nothing is left to spend.
+function onKeyDown() {
+    pressSpent = false;
+    onActivity();
 }
+
+container.addEventListener(
+    'click',
+    (event) => {
+        if (pressSpent) {
+            pressSpent = false;
+            event.stopPropagation();
+        }
+    },
+    { capture: true }
+);
+
+// Pointer events cover touch, so touchstart is the press signal only where they are absent: a
+// browser firing both would run onPress twice for one press, the second time after the reveal
+// had already cleared the faded class.
+window.addEventListener(window.PointerEvent ? 'pointerdown' : 'touchstart', onPress, {
+    capture: true,
+    passive: true
+});
+window.addEventListener('pointermove', onActivity, { passive: true });
+window.addEventListener('keydown', onKeyDown, { passive: true });
 onActivity();


### PR DESCRIPTION
## The problem

`examples/js/example.mjs` fades its button container after 3.5s of idle and sets `pointer-events: none` on it, so a press aimed at the buttons would fall through to the scene. To prevent that, it installed a capture-phase `pointerdown`/`touchstart` listener on `window`:

```js
function onPress(event) {
    if (container.classList.contains('faded')) {
        event.stopPropagation();
    }
    onActivity();
}
```

That suppressed **every** press page-wide, not just those aimed at the buttons. The old comment claimed "mouse users are unaffected: pointermove reveals before any click" — true for mouse, but a tap has no preceding `pointermove`. So on touch, the first tap after every idle period never reached the `<canvas>`: `PointerController` recorded no down-pick and synthesized no `click`.

Every tap-driven example lost its first tap — `model-inspector` (tap a drone part to isolate it), `tweening`, `annotations`, `splat-annotations`, `falling-blocks`.

## The fix

Keep the buttons hit-testable while faded (drop `pointer-events: none`) and stop nothing page-wide. A press aimed at the buttons then lands on a *button* rather than the canvas, so no interception is needed to keep it away from the scene, and presses anywhere else are untouched. The reported failure mode becomes structurally impossible rather than narrowed.

Three supporting details:

- **The reveal press must not activate the button it hit** — that button was invisible when pressed. A **container-scoped** capture-phase `click` listener stops that one click. This is necessary, not speculative: the instant `faded` is removed mid-press, `elementFromPoint` at the same coordinates flips from `canvas` to `button[title="Edit on StackBlitz"]`, so a browser that hit-tests at tap-recognition time lands the derived click on the button.
- **`pressSpent` is re-decided by every press**, so a press that finds the buttons already revealed leaves nothing to stop.
- **The press signal is now `pointerdown` *or* `touchstart`, not both.** A browser firing both ran the handler twice per press — the second time after the reveal had already cleared `faded`, clobbering the decision. `touchstart` is only needed where Pointer Events are absent.

`examples/assets/scripts/falling-blocks.mjs` gets a comment-only correction. It said its `TouchControls` listeners use the capture phase "because the example chrome swallows the first bubbling pointerdown after its buttons have idle-faded" — a workaround for exactly this defect. Left as capture (still a reasonable choice for a game input controller), but the stale reason is gone so it doesn't get copied into new scripts. No behavior change.

## Verification

**A/B with trusted input**, against the actual shipped code (reverted the files, measured, restored — restored copies confirmed byte-identical to what was tested). Cursor parked on the target so no `pointermove` preceded the press — the touch-equivalent condition:

| | old code | this change |
|---|---|---|
| trusted `pointerdown`, target `canvas`, 0 preceding `pointermove` | `canvasDown: 0` — canvas never saw it | `canvasDown: 1` |

A `MutationObserver` on the container's class gives positive proof of the state at press time (its callback is a microtask, so it lands after the press):

```
ts 50977  class -> faded: true
ts 50980  trusted pointerdown, pointerType "mouse", target canvas
ts 50981  class -> faded: false     (the press itself revealed them)
```

Plus, from trusted input:

- Trusted click on a drone part picks end-to-end: `entityClicks: ["trim"]`.
- **Press landing on a faded button**: `faded:true` -> trusted press with `target: button` -> `faded:false`; `buttonActivations: []`, `canvasDown: 0`, stays revealed. Reveals without activating, and nothing leaks to the scene.
- **Press on a visible button** (regression check): `buttonActivations: ["Edit on StackBlitz"]`.

**Synthesized `pointerType: 'touch'`** taps on a 375x812 touch-emulated viewport, hit-testing afresh for the click target as the tap gesture does:

| | model-inspector | tweening | falling-blocks |
|---|---|---|---|
| First tap on a scene object after 3.5s idle | canvas press, part picked | canvas press, `click` on star | canvas press, game touch controller saw it |
| Tap aimed at faded buttons | revealed, **not activated**, canvas untouched | revealed, **not activated** | revealed, not activated |
| Tap on now-visible button | activates | activates | page's own Start button fires `game:start` |

model-inspector ran 4/4 consecutive clean-load iterations.

`npm run lint` clean; `npm test` 1072/1072 across 52 files.

### Caveats

The trusted presses were **mouse**, not touch — under mobile emulation every `computer` click timed out on this surface, so trusted touch was unobtainable. The trusted mouse press was instead put into the touch-equivalent condition (zero preceding `pointermove` while faded), which is precisely what makes the touch case fail. The `pointerType: 'touch'` evidence is the synthesized runs above.

## Reviewer note

One deliberate behavior change: while faded, the container's ~136x40 box now swallows hover/pick for the scene behind it. That area is button-owned whenever the buttons are visible, and a `pointermove` there reveals them within a frame, so it is effectively always button-owned. If you would rather keep that region pointer-transparent, the alternative is a rect hit-test of the press against `container.getBoundingClientRect()` — but that keeps a page-wide `stopPropagation()` in the code, which is what caused this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
