### PR TITLE
Restore the ragdoll example's shadow bias, lost with the pc-light defaults

### DIFF
--- a/examples/ragdoll.html
+++ b/examples/ragdoll.html
@@ -66,20 +66,17 @@
                         }'></pc-script-instance>
                     </pc-script>
                 </pc-entity>
-                <!-- Light. PCSS gives a contact-hard, distance-soft shadow, which is what sells the
-                     robot hanging clear of the floor. penumbra-size is the softness control and it
-                     bites hard at this scale - 0.05 smears the shadow into a barely visible smudge,
-                     where 0.012 keeps the feet and legs readable. shadow-distance is deliberately
-                     larger than the scene needs, so the shadow survives zooming out to the far end
-                     of the camera's zoom-range.
-
-                     normal-offset-bias is what keeps the floor and the robot's own plates clear of
-                     shadow acne, and it is the only bias that reaches a PCSS shadow: shadow-bias
-                     feeds the hardware polygon offset, which the engine switches off for PCSS, so
-                     reaching for that one instead does nothing at all. 0.02 is a shade over one
-                     shadow texel at this shadow-distance and resolution, and about the least that
-                     clears the acne. Much higher starts eating the robot's own self-shadowing - by
-                     0.05 the shadow the chest lip casts down onto the reactor has visibly receded. -->
+                <!-- Light. PCSS is here for the contact hardening: the shadow tightens as the robot
+                     swings nearer the floor. Three of these read differently to how they behave.
+                     shadow-distance sizes the map off the camera frustum, not the casters, and 16
+                     is what keeps a shadow at the far end of the zoom-range - which leaves it coarse
+                     close up, so penumbra-falloff runs high and that wide penumbra doubles as
+                     anti-aliasing. Lower it for a crisper contact and the silhouette staircases.
+                     penumbra-size is a fraction of the shadow camera's depth range rather than a
+                     world size, which couples it to shadow-distance and is why 0.012 bites so hard
+                     here. normal-offset-bias is the only bias PCSS reads - shadow-bias feeds the
+                     hardware polygon offset, which the engine switches off for PCSS - and 0.02 is
+                     about one shadow texel, the least that clears the acne. -->
                 <pc-entity name="light" rotation="52 32 0">
                     <pc-light cast-shadows
                               shadow-type="pcss-32f"

--- a/examples/ragdoll.html
+++ b/examples/ragdoll.html
@@ -71,13 +71,22 @@
                      bites hard at this scale - 0.05 smears the shadow into a barely visible smudge,
                      where 0.012 keeps the feet and legs readable. shadow-distance is deliberately
                      larger than the scene needs, so the shadow survives zooming out to the far end
-                     of the camera's zoom-range. -->
+                     of the camera's zoom-range.
+
+                     normal-offset-bias is what keeps the floor and the robot's own plates clear of
+                     shadow acne, and it is the only bias that reaches a PCSS shadow: shadow-bias
+                     feeds the hardware polygon offset, which the engine switches off for PCSS, so
+                     reaching for that one instead does nothing at all. 0.02 is a shade over one
+                     shadow texel at this shadow-distance and resolution, and about the least that
+                     clears the acne. Much higher starts eating the robot's own self-shadowing - by
+                     0.05 the shadow the chest lip casts down onto the reactor has visibly receded. -->
                 <pc-entity name="light" rotation="52 32 0">
                     <pc-light cast-shadows
                               shadow-type="pcss-32f"
                               intensity="1"
                               shadow-distance="16"
                               shadow-resolution="2048"
+                              normal-offset-bias="0.02"
                               penumbra-size="0.012"
                               penumbra-falloff="5"
                               shadow-samples="16"


### PR DESCRIPTION
Aligning `pc-light` with the engine's shadow defaults (#412) dropped `normalOffsetBias` from 0.05 to 0. The ragdoll's light had been relying on that 0.05 without ever naming it, so the floor and the robot's own plates came back covered in shadow acne.

## The obvious knob does not work here

This light is `shadow-type="pcss-32f"`, and `shadow-bias` only feeds the hardware polygon offset — which `Light._updateShadowBias()` forces to zero whenever `_isPcss`, because PCSS stores depth in a color buffer, making the offset a WebGL no-op that WebGPU applies inconsistently.

Confirmed live rather than assumed: putting `shadowBias` back to the old 0.2 leaves `depthBias` at 0 and the acne completely unchanged. The PCSS shader path (`PCSSDirectional` in `shadowSoft.js`) never reads `shadowParams` either, and a directional shadow coord gets a fixed `saturate(z) - 0.0001` regardless.

`normal-offset-bias` is the only bias that reaches a PCSS shadow. Worth knowing before anyone reaches for `shadow-bias` in a PCSS scene again, which is why the comment says so.

## Why 0.02 and not the old 0.05

Measured, not restored. A shadow texel here is `2 * orthoHeight / resolution` = 0.0153 units, so 0.02 is about 1.3 texels — the textbook one-to-two. Sweeping it:

| value | result |
|---|---|
| 0 | acne on the floor and on the robot's plates |
| 0.01 | floor clean at range, residual mottling inside penumbras up close |
| **0.02** | **clean, self-shadowing intact** |
| 0.05 (old default) | clean, but the shadow the chest lip casts onto the reactor visibly recedes |
| 0.12 | self-shadowing largely gone |

The old 0.05 would have worked. It just costs contact detail on the robot itself long before it peter-pans anything on the floor — and this example's whole point is the contact-hard PCSS shadow. `product-viewer` already carries `normal-offset-bias="0.02"` against a `pcss-32f` light, so the value is consistent with the one example that had already solved this.

## Verification

Rendered from the edited file, not from live property pokes: default framing, close grazing views of the floor, the robot's plates at close range, the dropped ragdoll's contact shadow, and a resting ball. `npm run test:examples` passes (322 tests).

## Left for their own change

Two sibling examples have the same regression. Each wants a value picked by looking at it, so they are deliberately not bundled here:

- **`robot-arm.html`** — `pcss-32f`, no bias. Faint horizontal banding on the dark floor; 0.02 clears it.
- **`physics-joints.html`** — default `pcf3-32f`. Fine stipple across the white floor. This one is PCF, so `shadow-bias` *is* live and both knobs need tuning.

The `vsm-16f` examples look unaffected — VSM is blur-based and does not stipple. `falling-blocks` showed nothing visible behind its start overlay.


## Second commit: saying what the PCSS attributes actually do

Comment only, no attribute values change, so the rendered image is unchanged. Three attributes were described by their names rather than their behavior:

- **`penumbra-size` is not a world size.** While `shadow-blocker-samples > 0` it's a fraction of the shadow camera's depth range, which couples it to `shadow-distance` — and it flips to a world radius when blocker samples is 0, so its units depend on another attribute. The old "bites hard at this scale" was that coupling showing through.
- **`penumbra-falloff="5"` was undocumented and load-bearing.** `shadow-distance` sizes the map off the camera frustum, not the casters, so 16 leaves ~0.015 m/texel against a zoom that closes to 1.5 m; the wide penumbra doubles as anti-aliasing. Lowering it to chase a crisper contact — which the old "contact-hard, distance-soft" framing invited — exposes the texel staircase.
- **`shadow-distance`** is justified by what breaks: 8 halves the texel but then loses the shadow entirely when zoomed out.

`shadow-resolution="4096"` and `num-cascades="3"` were both tried as ways out. Each only halves the step size, and cascades add a floor seam to tune away for three shadow renders in a 3 m scene — so neither is worth it, and both are left out of the comment as more detail than an example wants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
