### PR TITLE
Use US spelling in comments and prose across examples, src and test

### DIFF
--- a/examples/assets/scripts/choose-color.mjs
+++ b/examples/assets/scripts/choose-color.mjs
@@ -123,7 +123,7 @@ export class ChooseColor extends Script {
     static TRANSITION_SPEED = 2;
 
     /**
-     * Metallic paint is a pigmented base coat with aluminium flake, so it wants some metalness -
+     * Metallic paint is a pigmented base coat with aluminum flake, so it wants some metalness -
      * but not a mirror. Solid and Special colors get their shine from the clear coat alone.
      */
     static METALNESS = {

--- a/examples/assets/scripts/ui-layout.mjs
+++ b/examples/assets/scripts/ui-layout.mjs
@@ -117,7 +117,7 @@ export class UiLayout extends Script {
 
     /**
      * Binds each control to its action. The buttons are declared in the page so their labels and
-     * layout stay in the markup; only the behaviour lives here.
+     * layout stay in the markup; only the behavior lives here.
      */
     _wireControls() {
         const actions = {

--- a/examples/assets/scripts/vehicle.mjs
+++ b/examples/assets/scripts/vehicle.mjs
@@ -199,7 +199,7 @@ export class Vehicle extends Script {
     steerRate = 5;
 
     /**
-     * The fraction of full lock still available once the car is travelling at
+     * The fraction of full lock still available once the car is traveling at
      * {@link highSpeedLockAt}. Full lock at speed is a spin, so cars wind the steering off as they
      * gather pace.
      *
@@ -370,7 +370,7 @@ export class Vehicle extends Script {
     }
 
     /**
-     * The speed the chassis is travelling at, in km/h, negative when reversing.
+     * The speed the chassis is traveling at, in km/h, negative when reversing.
      *
      * @type {number}
      */

--- a/examples/head-tracked-window.html
+++ b/examples/head-tracked-window.html
@@ -69,7 +69,7 @@
             }
 
             /* Calibration panel. The physical size of the display and the position of its
-               webcam cannot be read from the browser, so they have to be dialled in */
+               webcam cannot be read from the browser, so they have to be dialed in */
             #calibrate {
                 position: fixed;
                 bottom: max(16px, env(safe-area-inset-bottom));
@@ -169,7 +169,7 @@
                          capture is Y-down, so the inner entity flips it upright and the outer
                          one yaws the barrel toward the viewer - a few degrees off dead-on,
                          which keeps its length legible rather than end-on to the eye. The
-                         position was dialled in by eye: her head and the muzzle sit at very
+                         position was dialed in by eye: her head and the muzzle sit at very
                          different depths, so a lateral shift moves them across the screen by
                          different amounts and no single value centers both -->
                     <pc-entity name="figure" position="-0.3 -1.37 -0.719" rotation="0 122.3 0" scale="0.077 0.077 0.077">

--- a/examples/js/example-list.mjs
+++ b/examples/js/example-list.mjs
@@ -1,5 +1,5 @@
 /**
- * The catalogue behind the example browser's sidebar. Categories appear in the order they first
+ * The catalog behind the example browser's sidebar. Categories appear in the order they first
  * occur here, and examples in the order they are listed within a category - both hand-authored,
  * running simplest first so a newcomer can read down a category.
  *

--- a/examples/js/product-viewer.mjs
+++ b/examples/js/product-viewer.mjs
@@ -17,13 +17,13 @@
 import { whenReady } from '@playcanvas/web-components';
 
 /**
- * Selects mesh instance 0 - every part in this asset has exactly one. Only hover recolours a
+ * Selects mesh instance 0 - every part in this asset has exactly one. Only hover recolors a
  * part; a picked part keeps its own material, since the explode and the panel already say which
  * one it is, and tinting it would hide the material the panel is reporting.
  */
 const HOVER = '{"index:0": "hl-hover"}';
 
-/** Per-frame approach fraction, and the offset in metres at which a part counts as arrived. */
+/** Per-frame approach fraction, and the offset in meters at which a part counts as arrived. */
 const REDUCED_MOTION = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 const EASE = REDUCED_MOTION ? 1 : 0.16;
 const SETTLED = 0.0002;
@@ -56,7 +56,7 @@ const STYLES = `
     gap: 7px;
 }
 
-/* Picks up the drone's own accent trim colour */
+/* Picks up the drone's own accent trim color */
 .pv-head::before {
     content: "";
     flex: none;
@@ -90,7 +90,7 @@ const STYLES = `
     min-height: 86px;
 }
 
-/* The hint is shorter than the readout, so centre it in the reserved box rather than leaving
+/* The hint is shorter than the readout, so center it in the reserved box rather than leaving
    a gap that reads as an unfinished card */
 .pv-part.is-idle {
     display: flex;
@@ -173,7 +173,7 @@ const STYLES = `
     color: rgba(255, 255, 255, 0.8);
 }
 
-/* The part's real colour, read off the instantiated material */
+/* The part's real color, read off the instantiated material */
 .pv-swatch {
     width: 11px;
     height: 11px;
@@ -283,19 +283,19 @@ if (tree) {
     collect(tree);
 }
 
-// Wait for every pc-node to bind before reading colours off the live materials, and do it before
+// Wait for every pc-node to bind before reading colors off the live materials, and do it before
 // any override can be applied, so these are the asset's own values.
 await Promise.all(parts.map(part => part.ready()));
 
 const channel = v => Math.round(Math.min(1, Math.max(0, v)) * 255).toString(16).padStart(2, '0');
 
 /**
- * The average colour of a texture, by letting the canvas downscale it to a single pixel. Needed
+ * The average color of a texture, by letting the canvas downscale it to a single pixel. Needed
  * for a textured part, whose diffuse factor is plain white and so says nothing about how it
- * looks. Texture bytes are already sRGB, as the material colours below are.
+ * looks. Texture bytes are already sRGB, as the material colors below are.
  *
  * @param {object} texture - The engine texture to sample.
- * @returns {string | null} The colour as CSS, or `null` if the source cannot be read.
+ * @returns {string | null} The color as CSS, or `null` if the source cannot be read.
  */
 const sampleTexture = (texture) => {
     const source = texture.getSource?.();
@@ -315,7 +315,7 @@ const sampleTexture = (texture) => {
 };
 
 /**
- * A part's own colour as CSS. StandardMaterial colours are already gamma-space - the glTF loader
+ * A part's own color as CSS. StandardMaterial colors are already gamma-space - the glTF loader
  * converts baseColorFactor out of linear on the way in - so these go straight to CSS. Encoding
  * them again washes every swatch out.
  */
@@ -324,7 +324,7 @@ for (const part of parts) {
     const material = part.entity?.render?.meshInstances?.[0]?.material;
     if (!material) continue;
     const emissive = material.emissive;
-    // An emissive part (the nav lights) is its emissive colour, not its near-black base
+    // An emissive part (the nav lights) is its emissive color, not its near-black base
     const lit = emissive && emissive.r + emissive.g + emissive.b > 0.25;
     const c = lit ? emissive : material.diffuse;
     const factor = `#${channel(c.r)}${channel(c.g)}${channel(c.b)}`;

--- a/examples/product-viewer.html
+++ b/examples/product-viewer.html
@@ -26,7 +26,7 @@
                  removing the attribute puts the GLB's own material back, so no material state is
                  tracked anywhere. A picked part deliberately keeps its own material - being
                  pulled out of the assembly and named in the panel is signal enough, and
-                 recolouring it would hide the very material the panel is reporting. -->
+                 recoloring it would hide the very material the panel is reporting. -->
             <pc-material id="hl-hover" diffuse="0.07 0.20 0.28" metalness="0.3" gloss="0.85" use-metalness="true"
                          emissive="#1f8fbe" emissive-intensity="0.16"></pc-material>
             <!-- Scene -->
@@ -82,7 +82,7 @@
                      reads, and data-explode is where the part travels to when it is picked.
                      Each part is authored on the model origin, so that offset IS its position
                      override - and dropping the attribute returns it to the assembled pose.
-                     Offsets are in metres, +X left, +Y up, +Z forward. -->
+                     Offsets are in meters, +X left, +Y up, +Z forward. -->
                 <pc-model name="drone" asset="drone">
                     <!-- Fuselage -->
                     <pc-node name="canopy"  data-label="Top Shell"      data-spec="Satin ABS · 18 g"            data-explode="0 0.034 0"></pc-node>

--- a/examples/ragdoll.html
+++ b/examples/ragdoll.html
@@ -38,12 +38,12 @@
             <pc-scene>
                 <!-- The HDR is the scene's only image-based light. type="none" keeps the skybox out
                      of the frame while `lighting` still builds the environment atlas from it, so the
-                     metal and glass have something to reflect against the flat clear colour. -->
+                     metal and glass have something to reflect against the flat clear color. -->
                 <pc-sky asset="studio" type="none" lighting></pc-sky>
                 <!-- Camera. The ball launcher fires from here, through wherever you tap. -->
                 <pc-entity name="camera" position="1.05 1.85 4.35">
                     <!-- Very dark on purpose. With cameraFrame attached the scene renders into a
-                         linear HDR target and tone mapping happens at compose, so the clear colour
+                         linear HDR target and tone mapping happens at compose, so the clear color
                          is a linear value - this is roughly #1b1d21 once it reaches the screen. -->
                     <pc-camera clear-color="#030304"></pc-camera>
                     <pc-script>
@@ -132,7 +132,7 @@
                         part is its own rigid body, so physics writes a world transform straight onto
                         the node it drives. Every <pc-node> below binds one of those nodes by its name
                         in the asset and hangs a collision shape and a rigid body on it, and each
-                        part's origin was authored at its centre of mass so the shapes sit centred.
+                        part's origin was authored at its center of mass so the shapes sit centered.
 
                         Each joint lives on a <pc-entity> nested inside the part it drives, positioned
                         in that part's local space - so the joint frame follows the part rather than
@@ -178,7 +178,7 @@
 
                             <!-- The hook, with no limits so it swings freely. Its height is what
                                  keeps the ragdoll stable: hang the chest from a point off its
-                                 vertical axis and the torso has to fold to get its centre of
+                                 vertical axis and the torso has to fold to get its center of
                                  mass under the pin, which parks the waist, sternum and neck
                                  cones hard against their limits and leaves the solver fighting a
                                  standing violation every step - the whole rig buzzes. Lifting

--- a/examples/robot-arm.html
+++ b/examples/robot-arm.html
@@ -155,7 +155,7 @@
                 background-color: rgba(255, 255, 255, 0.14);
             }
 
-            /* The popup list is drawn by the OS, so it needs its own colours */
+            /* The popup list is drawn by the OS, so it needs its own colors */
             .anim-select option {
                 background: #1b1b1b;
                 color: #fff;

--- a/src/components/script-instance.ts
+++ b/src/components/script-instance.ts
@@ -194,7 +194,7 @@ class ScriptInstanceElement extends AsyncElement {
                 break;
             case 'name':
                 // The first set is handled by the parent's creation paths (the boot query and
-                // the added-node mutation), so only a genuine rename is signalled here. Note
+                // the added-node mutation), so only a genuine rename is signaled here. Note
                 // that setAttribute fires this callback even when the value is unchanged.
                 if (oldValue !== null && oldValue !== newValue) {
                     this.dispatchEvent(

--- a/src/loading-bar.ts
+++ b/src/loading-bar.ts
@@ -105,7 +105,7 @@ export class LoadingBar {
     }
 
     /**
-     * Removes the bar immediately, cancelling any pending fade. Idempotent.
+     * Removes the bar immediately, canceling any pending fade. Idempotent.
      */
     destroy() {
         if (this._sweep) {

--- a/src/material.ts
+++ b/src/material.ts
@@ -319,7 +319,7 @@ class MaterialElement extends HTMLElement {
 
     /**
      * One asset binding per texture slot, created on first use and kept for the element's
-     * lifetime. A slot's binding is superseded when the slot is reassigned and cancelled when the
+     * lifetime. A slot's binding is superseded when the slot is reassigned and canceled when the
      * element disconnects, so a late-arriving asset can never write a texture the element no
      * longer wants.
      */
@@ -533,7 +533,7 @@ class MaterialElement extends HTMLElement {
         }
 
         // Drop any load still pending for this slot - its texture is no longer the one we want.
-        // Cancelled here rather than left to the bind below, which the material-less and
+        // Canceled here rather than left to the bind below, which the material-less and
         // clear-slot returns never reach.
         binding.cancel();
 

--- a/test/README.md
+++ b/test/README.md
@@ -7,7 +7,7 @@ Five tiers, four of which run in Node and need neither a build nor a browser.
 | Unit        | `npm run test:unit`        | `node`      | The pure parsers in `src/parse.ts` and the `CSS_COLORS` table           |
 | Elements    | `npm run test:elements`    | `jsdom`     | Attribute and property surface, with no engine created                  |
 | Integration | `npm run test:integration` | `jsdom`     | A real `AppBase` on `NullGraphicsDevice`, via `<pc-app backend="null">` |
-| Examples    | `npm run test:examples`    | `node`\*    | `examples/` as a set: the catalogue, and the markup of every page       |
+| Examples    | `npm run test:examples`    | `node`\*    | `examples/` as a set: the catalog, and the markup of every page       |
 | Browser     | _(not yet implemented)_    | Chromium    | The built `dist/` bundle and the example pages                          |
 
 `npm test` runs the four Node tiers. `npm run test:watch` watches them, and
@@ -20,7 +20,7 @@ tier, still reads its sources as text and imports nothing.
 
 `example-list.test.ts` exists because `examples/js/example-list.mjs` is the only name a reader sees in
 the sidebar while each page carries its own `<title>`, and those two drifted apart across a third of
-the examples before it was added. It also fails on an example page that the catalogue never lists — a
+the examples before it was added. It also fails on an example page that the catalog never lists — a
 page nothing imports, which no other tier can see.
 
 `example-markup.test.ts` parses every page and checks it against the registered elements, because
@@ -116,9 +116,9 @@ attributed to the test that caused it.
 
 ## Known bugs
 
-When a test documents a defect, pin the **actual** behaviour in an `it(...)` whose title ends
+When a test documents a defect, pin the **actual** behavior in an `it(...)` whose title ends
 `(known bug #NNN)`, with a comment naming the file, line and root cause, and add an `it.todo(...)`
-stating the intended behaviour beside it.
+stating the intended behavior beside it.
 
 Do **not** use `it.fails()` — it passes for _any_ failure, so it silently absorbs an unrelated
 regression on the same path, and it cannot see errors that are reported rather than thrown. Do not
@@ -141,7 +141,7 @@ defect executably, and makes the fix a one-line flip.
 - `test.for` over `test.each`, so the case arrives typed.
 - `expect.soft` inside table-driven cases, so one broken attribute reports every finding in a single
   run. Fail fast everywhere else.
-- Alphabetise members, except in table-driven suites where the order comes from
+- Alphabetize members, except in table-driven suites where the order comes from
   `observedAttributes` — the source of truth. Re-sorting would make failures harder to correlate.
 
 ## Environment notes
@@ -157,7 +157,7 @@ can reach it first. `test/integration/environment.test.ts` asserts the exact res
 that file is red, treat every other integration result as unreliable.
 
 Not polyfilled, on purpose: `ResizeObserver` (unused by the engine and by `src/`), `navigator.xr`
-(absent is the correct headless answer; a stub sends `XrManager` down paths jsdom cannot honour), and
+(absent is the correct headless answer; a stub sends `XrManager` down paths jsdom cannot honor), and
 `AudioContext` (absent means `SoundManager.context` is `null`, and sound slots still work). The
 `canvas` npm package is **not** a dependency — it implements 2D drawing, not layout, and the null
 device never asks for a context.

--- a/test/elements/attribute-removal.test.ts
+++ b/test/elements/attribute-removal.test.ts
@@ -8,7 +8,7 @@ import { useGuard } from '../helpers/guard';
  *
  * Custom elements pass `null` to attributeChangedCallback on removal. These cases used to assign
  * that null through, so the element property reported `null` where its own backing field had been
- * initialised to `''` - and the value then reached the engine. `attributeChangedCallback` declared
+ * initialized to `''` - and the value then reached the engine. `attributeChangedCallback` declared
  * `newValue: string`, so TypeScript never flagged any of it; widening the signature is what
  * surfaced the whole set at once.
  *

--- a/test/elements/entity.test.ts
+++ b/test/elements/entity.test.ts
@@ -6,7 +6,7 @@ import { mount } from '../helpers/dom';
 import { useGuard } from '../helpers/guard';
 
 /**
- * Element-level behaviour, with no <pc-app> and therefore no engine. Every setter caches to a
+ * Element-level behavior, with no <pc-app> and therefore no engine. Every setter caches to a
  * private field and only writes through when `this.entity` exists, so attribute handling is fully
  * observable on a disconnected element.
  */

--- a/test/elements/material.test.ts
+++ b/test/elements/material.test.ts
@@ -8,7 +8,7 @@ const kebabToCamel = (name: string) => name.replace(/-([a-z])/g, (_, char) => ch
 
 /** Attributes whose element property is not simply the camel-cased attribute name. */
 const ALIASES: Record<string, string> = {
-    // The engine keeps the initialism capitalised, so the mechanical conversion does not apply
+    // The engine keeps the initialism capitalized, so the mechanical conversion does not apply
     'enable-ggx-specular': 'enableGGXSpecular',
     roughness: 'gloss',
     'roughness-map': 'glossMap'

--- a/test/elements/model.test.ts
+++ b/test/elements/model.test.ts
@@ -5,7 +5,7 @@ import type { ModelElement } from '../../src/model';
 import { useGuard } from '../helpers/guard';
 
 /**
- * Element-level behaviour, with no <pc-app> and therefore no engine. Every setter caches to a
+ * Element-level behavior, with no <pc-app> and therefore no engine. Every setter caches to a
  * private field and only writes through when the host entity exists, so attribute handling is
  * fully observable on a disconnected element. The host-entity attributes mirror <pc-entity>'s;
  * the cases here pin that the shared machinery really is wired into this element.

--- a/test/examples/example-list.test.ts
+++ b/test/examples/example-list.test.ts
@@ -55,7 +55,7 @@ describe('example-list.mjs', () => {
     /**
      * The browser groups by category into a Map keyed on the category string, so a category listed
      * in two separate blocks silently merges into one sidebar section - and the within-category
-     * "simplest first" order the catalogue documents stops describing what a reader sees.
+     * "simplest first" order the catalog documents stops describing what a reader sees.
      */
     it('keeps each category in one contiguous block', () => {
         const blocks = examples

--- a/test/examples/example-markup.test.ts
+++ b/test/examples/example-markup.test.ts
@@ -107,7 +107,7 @@ describe('examples/*.html', () => {
     });
 
     /**
-     * An attribute the element does not recognise is dropped in silence, so markup that reads
+     * An attribute the element does not recognize is dropped in silence, so markup that reads
      * correctly can do nothing at all. Three of these had accumulated before this ran: a
      * `tone-mapping` that should have been `tonemap`, and an `intensity` and a `cast-shadows` sitting
      * on <pc-entity> rather than on the component below it.

--- a/test/helpers/guard.ts
+++ b/test/helpers/guard.ts
@@ -126,7 +126,7 @@ export const currentGuard = () => active;
  *
  * This is load bearing rather than convenient. The library reports every misuse through
  * console.warn - it never throws and never rejects - so the warning IS the assertion for a whole
- * class of behaviour, and an unclaimed warning is how a test silently stops meaning anything.
+ * class of behavior, and an unclaimed warning is how a test silently stops meaning anything.
  * Three examples that are untestable without it:
  *
  * - A component element outside <pc-entity>: the only observable difference from correct placement

--- a/test/integration/asset-texture-options.test.ts
+++ b/test/integration/asset-texture-options.test.ts
@@ -49,7 +49,7 @@ describe('<pc-asset> texture options', () => {
     });
 
     it('drives the engine TextureHandler: patching applies every mapped value', async () => {
-        // A key the handler does not recognise would assign undefined here, so this pins the
+        // A key the handler does not recognize would assign undefined here, so this pins the
         // kebab-to-snake rename against the real engine rather than against this library's tables
         const { app, get } = await bootApp(ALL_OPTIONS);
 

--- a/test/integration/environment.test.ts
+++ b/test/integration/environment.test.ts
@@ -99,10 +99,10 @@ describe('headless environment', () => {
     });
 
     it('loads the release build of playcanvas, not the debug build', () => {
-        // Because playcanvas is valid ESM in node_modules, Vitest externalises it and Node resolves
+        // Because playcanvas is valid ESM in node_modules, Vitest externalizes it and Node resolves
         // it with the node/import conditions, landing on the release build. Inlining it would pick
         // the development condition and give the .dbg build with Debug.assert live - a real
-        // behavioural difference decided by externalisation heuristics rather than by our config,
+        // behavioral difference decided by externalization heuristics rather than by our config,
         // so a future Vitest upgrade could flip it silently. This pins it.
         const resolve = (import.meta as unknown as { resolve?: (specifier: string) => string }).resolve;
         if (!resolve) {

--- a/test/integration/material.test.ts
+++ b/test/integration/material.test.ts
@@ -75,7 +75,7 @@ describe('<pc-material> integration', () => {
         expect(material.metalness).toBe(0);
     });
 
-    it('honours use-metalness="false" for the older specular workflow', async () => {
+    it('honors use-metalness="false" for the older specular workflow', async () => {
         const { get } = await bootApp('<pc-material id="m" use-metalness="false"></pc-material>');
 
         expect(get<MaterialElement>('pc-material').material!.useMetalness).toBe(false);

--- a/test/setup/dom.ts
+++ b/test/setup/dom.ts
@@ -82,7 +82,7 @@ HTMLCanvasElement.prototype.getBoundingClientRect = function getBoundingClientRe
  * which Vitest then prints. backend="null" never reaches it, so this exists purely so that a test
  * which forgets backend="null" fails with one legible error instead of that plus jsdom noise.
  *
- * @returns Always `null`, matching jsdom's own unimplemented behaviour.
+ * @returns Always `null`, matching jsdom's own unimplemented behavior.
  */
 HTMLCanvasElement.prototype.getContext = function getContext() {
     return null;
@@ -108,7 +108,7 @@ Object.defineProperty(window, 'devicePixelRatio', {
 //   with no observer callbacks firing between assertions. Resize-driven syncing is exercised
 //   through the max-pixel-ratio setter, which shares the same code path.
 // - navigator.xr: absent means XrManager reports supported === false, which is the correct
-//   headless answer. A truthy stub would push it down paths jsdom cannot honour.
+//   headless answer. A truthy stub would push it down paths jsdom cannot honor.
 // - AudioContext: absent means SoundManager's lazy context getter returns null. Verified that
 //   <pc-sound>/<pc-sound-slot> still create slots via addSlot() with no context.
 

--- a/test/unit/colors.test.ts
+++ b/test/unit/colors.test.ts
@@ -6,7 +6,7 @@ import { CSS_COLORS } from '../../src/colors';
 describe('CSS_COLORS', () => {
     const entries = Object.entries(CSS_COLORS);
 
-    it('contains the full CSS named-colour set', () => {
+    it('contains the full CSS named-color set', () => {
         expect(entries).toHaveLength(148);
     });
 
@@ -38,7 +38,7 @@ describe('CSS_COLORS', () => {
         ['slategray', 'slategrey'],
         ['darkslategray', 'darkslategrey'],
         ['lightslategray', 'lightslategrey']
-    ])('%s and %s are the same colour', ([first, second]) => {
+    ])('%s and %s are the same color', ([first, second]) => {
         expect(CSS_COLORS[first]).toBe(CSS_COLORS[second]);
     });
 

--- a/test/unit/parse.test.ts
+++ b/test/unit/parse.test.ts
@@ -219,7 +219,7 @@ describe('parse', () => {
 
     describe('parseColor', () => {
         it.for([
-            // CSS colour names, matched case insensitively via toLowerCase()
+            // CSS color names, matched case insensitively via toLowerCase()
             ['red', [1, 0, 0, 1]],
             ['REBECCAPURPLE', [0.4, 0.2, 0.6, 1]],
             // Hex, including the 3- and 4-digit short forms


### PR DESCRIPTION
The repo convention is US spelling everywhere — code, comments, JSDoc, commit messages, release notes and identifiers — matching the engine's own API surface (`Color`, `parseColor`, `normalize`, `initialize`). Three example pages had drifted to British forms in their HTML comments, and a sweep of the rest of `examples/`, `src/` and `test/` turned up more of the same.

Comments, JSDoc and Markdown prose only. No behavior change.

## What changed

26 files, 51 lines.

| Form | → | Where |
|---|---|---|
| `colour*` | `color*` | `examples/ragdoll.html`, `examples/robot-arm.html`, `examples/product-viewer.html`, `examples/js/product-viewer.mjs` ×10, `test/unit/colors.test.ts`, `test/unit/parse.test.ts` |
| `centre` / `centred` | `center` / `centered` | `examples/ragdoll.html`, `examples/js/product-viewer.mjs` |
| `behaviour(al)` | `behavior(al)` | `examples/assets/scripts/ui-layout.mjs`, `test/elements/entity.test.ts`, `test/elements/model.test.ts`, `test/helpers/guard.ts`, `test/setup/dom.ts`, `test/integration/environment.test.ts`, `test/README.md` ×2 |
| `-ise` / `-isation` | `-ize` / `-ization` | `externalises`, `externalisation`, `recognise` ×2, `capitalised`, `initialised`, `Alphabetise` |
| `honour(s)` | `honor(s)` | `test/setup/dom.ts`, `test/README.md`, `test/integration/material.test.ts` |
| `catalogue` | `catalog` | `examples/js/example-list.mjs`, `test/examples/example-list.test.ts`, `test/README.md` ×2 |
| doubled-l | single-l | `cancelling` / `cancelled` (`src/loading-bar.ts`, `src/material.ts` ×2), `signalled` (`src/components/script-instance.ts`), `travelling` ×2 (`examples/assets/scripts/vehicle.mjs`), `dialled` ×2 (`examples/head-tracked-window.html`) |
| `metres`, `aluminium` | `meters`, `aluminum` | `examples/js/product-viewer.mjs`, `examples/product-viewer.html`, `examples/assets/scripts/choose-color.mjs` |

## Notes for review

Three of those 51 lines are **test titles** rather than comments — `honours use-metalness="false" for the older specular workflow`, `contains the full CSS named-colour set` and `%s and %s are the same colour`. They are descriptive prose, not API values, so they were converted along with the comments.

Left alone deliberately, as API values or third-party names rather than prose:

- the `grey` / `gray` CSS keyword aliases in `src/colors.ts` and the `['gray', 'grey']` pair that tests them
- the `grey-cross` / `grey-panel` asset ids in `examples/scroll-view.html`
- `'Agate Grey'` in `examples/assets/scripts/choose-color.mjs` — a real paint name
- `towards`, which is standard in US English too and appears at many sites

**One open question.** Two user-facing `data-spec` strings in `examples/product-viewer.html` still read `"Anodised 6061 aluminium"` and `"Machined aluminium · 3-axis"`. They render in the product viewer's spec panel, and they are invented prose rather than a third-party name — so by the convention they arguably belong as `Anodized`/`aluminum`. This PR scopes itself to comments, so they are untouched; happy to flip them if reviewers want the display text swept too.

## Testing

- `npm run lint` — clean
- `npm run test:examples` — 322/322 pass
- `npm test` — 1219/1219 pass across 53 files (run because `src/` comments and test titles were touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
