### PR TITLE
Reduce the ragdoll's light comment to the bare Light marker

### DIFF
--- a/examples/ragdoll.html
+++ b/examples/ragdoll.html
@@ -66,17 +66,7 @@
                         }'></pc-script-instance>
                     </pc-script>
                 </pc-entity>
-                <!-- Light. PCSS is here for the contact hardening: the shadow tightens as the robot
-                     swings nearer the floor. Three of these read differently to how they behave.
-                     shadow-distance sizes the map off the camera frustum, not the casters, and 16
-                     is what keeps a shadow at the far end of the zoom-range - which leaves it coarse
-                     close up, so penumbra-falloff runs high and that wide penumbra doubles as
-                     anti-aliasing. Lower it for a crisper contact and the silhouette staircases.
-                     penumbra-size is a fraction of the shadow camera's depth range rather than a
-                     world size, which couples it to shadow-distance and is why 0.012 bites so hard
-                     here. normal-offset-bias is the only bias PCSS reads - shadow-bias feeds the
-                     hardware polygon offset, which the engine switches off for PCSS - and 0.02 is
-                     about one shadow texel, the least that clears the acne. -->
+                <!-- Light -->
                 <pc-entity name="light" rotation="52 32 0">
                     <pc-light cast-shadows
                               shadow-type="pcss-32f"


### PR DESCRIPTION
The ragdoll's light comment had grown to eleven lines, describing in turn what PCSS, `shadow-distance`, `penumbra-size`, `penumbra-falloff` and `normal-offset-bias` each do. Six of those lines predate #449; #449 added the rest.

Every other example labels its light with a bare `<!-- Light -->` and lets the attributes speak for themselves. This one now does too.

For context on how far out of line it was — comment block lengths across `examples/`:

| Block length | Count |
| --- | --- |
| 1 line | 279 |
| 2–3 lines | 44 |
| 4–6 lines | 14 |
| ≥7 lines | 14 |

## Notes for review

- **No attribute values change**, so the rendered image is unchanged. `normal-offset-bias="0.02"` from #449 stays exactly as it is.
- The other long comments in the file are untouched — the 19-line node-binding block is from #388 and the 11-line note on the hook's height is from #398. Neither is mine and neither was in scope here.
- playcanvas/web-components#451 does the same to `robot-arm` and `physics-joints`, which is where I introduced the same problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
