### PR TITLE
Categorize the API reference so nothing lands under Other

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -116,6 +116,8 @@ const ensureBaseStyles = () => {
  * backends and `error` holds the underlying failure. The element never becomes ready
  * and `app` stays `null` — listen for this event to show a fallback UI. Removing the element and
  * re-inserting it retries the boot with its current attributes. Does not bubble.
+ *
+ * @category Application
  */
 class AppElement extends AsyncElement {
     /**

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -26,7 +26,11 @@ const renderModes = new Map<'simple' | 'sliced' | 'tiled', number>([
     ['tiled', SPRITE_RENDERMODE_TILED]
 ]);
 
-/** The addressing modes for a texture asset. */
+/**
+ * The addressing modes for a texture asset.
+ *
+ * @category Types
+ */
 export type AddressMode = 'repeat' | 'clamp' | 'mirror';
 
 const addressModes = new Map<AddressMode, number>([
@@ -35,7 +39,11 @@ const addressModes = new Map<AddressMode, number>([
     ['mirror', ADDRESS_MIRRORED_REPEAT]
 ]);
 
-/** The minification filter modes for a texture asset. */
+/**
+ * The minification filter modes for a texture asset.
+ *
+ * @category Types
+ */
 export type MinFilterMode =
     'nearest' | 'linear' | 'nearest-mip-nearest' | 'linear-mip-nearest' | 'nearest-mip-linear' | 'linear-mip-linear';
 
@@ -51,6 +59,8 @@ const minFilterModes = new Map<MinFilterMode, number>([
 /**
  * The magnification filter modes for a texture asset. Magnification has no mip variants - the
  * engine (and the GPU) only accepts these two.
+ *
+ * @category Types
  */
 export type MagFilterMode = 'nearest' | 'linear';
 
@@ -195,6 +205,8 @@ const processBufferView = (
  * @fires {ErrorEvent} error - Fired when the asset fails to load, with the engine's error in
  * `message`. Does not bubble. The element still becomes ready — readiness means the load settled,
  * not that it succeeded.
+ *
+ * @category Resources
  */
 class AssetElement extends AsyncElement {
     private _addressU: AddressMode | null = null;

--- a/src/async-element.ts
+++ b/src/async-element.ts
@@ -7,6 +7,8 @@ import type { EntityBaseElement } from './entity-base';
  * @fires {CustomEvent} ready - Fired when the element is fully initialized — once per readiness
  * cycle, so an element that is torn down and re-initialized (for example by removing and
  * re-inserting it) fires it again. Bubbles and is composed.
+ *
+ * @category Base Classes
  */
 class AsyncElement extends HTMLElement {
     private _readyPromise: Promise<void>;
@@ -88,6 +90,8 @@ class AsyncElement extends HTMLElement {
 /**
  * A union of the tag names of all elements that initialize asynchronously (i.e. elements whose
  * classes extend {@link AsyncElement}).
+ *
+ * @category Types
  */
 type AsyncElementTagName = {
     [K in keyof HTMLElementTagNameMap]: HTMLElementTagNameMap[K] extends AsyncElement ? K : never;
@@ -104,6 +108,8 @@ type AsyncElementTagName = {
  * @returns A promise that resolves with the element once it's ready.
  * @example
  * const { app } = await whenReady('pc-app');
+ *
+ * @category Functions
  */
 function whenReady<K extends AsyncElementTagName>(target: K): Promise<HTMLElementTagNameMap[K]>;
 /**

--- a/src/components/anim-clip.ts
+++ b/src/components/anim-clip.ts
@@ -26,6 +26,8 @@ import { AnimComponentElement } from './anim-component';
  * @elementSummary The `<pc-anim-clip>` element declares one named animation clip on its parent
  * `<pc-anim>`, taken from the `asset` it names or, without one, from the enclosing `<pc-model>`'s
  * own animations. Must be a direct child of `<pc-anim>`.
+ *
+ * @category Components
  */
 class AnimClipElement extends AsyncElement {
     /**

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -8,7 +8,7 @@ import { parseBool } from '../parse';
 /**
  * Represents a component in the PlayCanvas engine.
  *
- * @category Components
+ * @category Base Classes
  */
 class ComponentElement<T extends Component = Component> extends AsyncElement {
     private _componentName: string;

--- a/src/components/joint-component.ts
+++ b/src/components/joint-component.ts
@@ -6,12 +6,18 @@ import { parseBool, parseEnum, parseNumber, parseVec2, parseVec3 } from '../pars
 
 import { ComponentElement } from './component';
 
-/** The constraint types supported by the `<pc-joint>` element. */
+/**
+ * The constraint types supported by the `<pc-joint>` element.
+ *
+ * @category Types
+ */
 export type JointType = 'fixed' | 'ball' | 'hinge' | 'slider' | '6dof';
 
 /**
  * The motion modes for a single joint axis: fully constrained (`locked`), constrained within
  * limits (`limited`) or unconstrained (`free`).
+ *
+ * @category Types
  */
 export type MotionMode = 'locked' | 'limited' | 'free';
 

--- a/src/components/script-instance.ts
+++ b/src/components/script-instance.ts
@@ -42,6 +42,8 @@ import { parseBool } from '../parse';
  * `detail` carries the new `enabled` state. Bubbles.
  * @fires {CustomEvent} scriptnamechange - Fired when the script is renamed on a live element. The
  * `detail` carries `oldName` and `newName`. Bubbles.
+ *
+ * @category Components
  */
 class ScriptInstanceElement extends AsyncElement {
     private _attributes: Record<string, any> = {};

--- a/src/components/sound-slot.ts
+++ b/src/components/sound-slot.ts
@@ -13,6 +13,8 @@ import { SoundComponentElement } from './sound-component';
  *
  * @elementSummary The `<pc-sound-slot>` element declares one named sound on its parent `<pc-sound>`
  * — its asset, volume, pitch, looping and autoplay. Must be a direct child of `<pc-sound>`.
+ *
+ * @category Components
  */
 class SoundSlotElement extends AsyncElement {
     private _asset = '';

--- a/src/entity-base.ts
+++ b/src/entity-base.ts
@@ -34,6 +34,8 @@ export const EVENT_ATTRIBUTES = SYNTHESIZED_EVENTS.map((type) => `on${type}`);
  * with the owning application (which joins picked scene nodes back to elements by identity,
  * never by name), and the pointer listener bookkeeping that lets the application lazily attach
  * its canvas handlers.
+ *
+ * @category Base Classes
  */
 class EntityBaseElement extends AsyncElement {
     protected _entity: Entity | null = null;

--- a/src/entity-owner.ts
+++ b/src/entity-owner.ts
@@ -36,6 +36,8 @@ export const buildDescendantEntities = (root: Element, app: AppBase) => {
  * property state, entity creation and parenting, and the reset that follows the entity's
  * destruction. `<pc-node>` sits outside this class: it borrows an entity a model instantiated,
  * and its properties are nullable overrides rather than owned values.
+ *
+ * @category Base Classes
  */
 class EntityOwnerElement extends EntityBaseElement {
     /**

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -44,6 +44,8 @@ import { parseBool, parseTags, parseVec3 } from './parse';
  * over the entity. A press and release that picked different entities fires on their nearest
  * common ancestor instead, as in the DOM. `detail` carries the click count, so a double click
  * arrives as a click whose `detail` is 2.
+ *
+ * @category Entities
  */
 class EntityElement extends EntityOwnerElement {
     connectedCallback() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,42 @@
 /**
- * The Engine Web Components module provides a set of Web Components for the PlayCanvas Engine.
- * While these components are normally instantiated in a declarative fashion using HTML, this
- * reference covers the TypeScript/JavaScript API that allows these components to be created
- * programmatically.
+ * The `@playcanvas/web-components` package provides a set of custom HTML elements for building 3D
+ * web apps with the PlayCanvas Engine. The elements are normally authored declaratively in HTML,
+ * which the {@link https://developer.playcanvas.com/user-manual/web-components/ | User Manual}
+ * covers. This reference covers their JavaScript API: the element classes, whose properties mirror
+ * their attributes and expose the engine objects behind them, and the {@link whenReady} function
+ * that waits for an element to finish initializing.
  *
- * @module EngineWebComponents
+ * @categoryDescription Application
+ * The elements at the top of every document: `<pc-app>`, which creates the application and the
+ * canvas it renders into, the `<pc-scene>` it renders, and the `<pc-sky>` behind that scene.
+ *
+ * @categoryDescription Resources
+ * The elements declared directly under `<pc-app>` for the scene to draw on: `<pc-asset>` and
+ * `<pc-material>`, which other elements reference by `id`, and `<pc-wasm>`, which loads a
+ * WebAssembly module the engine needs before the application starts.
+ *
+ * @categoryDescription Entities
+ * The elements that front an engine entity and host component elements. `<pc-entity>` and
+ * `<pc-model>` create their entity; `<pc-node>` binds to one inside the hierarchy a model
+ * instantiated.
+ *
+ * @categoryDescription Components
+ * The elements that add an engine component to the entity above them, and the repeatable children
+ * three of them take: `<pc-anim-clip>` under `<pc-anim>`, `<pc-script-instance>` under
+ * `<pc-script>` and `<pc-sound-slot>` under `<pc-sound>`.
+ *
+ * @categoryDescription Base Classes
+ * The classes the elements extend. None registers a tag of its own; each holds the members the
+ * elements of its kind inherit, such as `ready()`, `closestApp`, `entity` and `component`.
+ *
+ * @categoryDescription Functions
+ * Helpers for driving the elements from JavaScript. `whenReady` waits for an element to finish
+ * initializing and resolves with it.
+ *
+ * @categoryDescription Types
+ * The string unions and plain-data shapes used by the element properties and by `whenReady`.
+ *
+ * @module @playcanvas/web-components
  */
 
 /* eslint-disable import-x/order */

--- a/src/material.ts
+++ b/src/material.ts
@@ -29,7 +29,11 @@ import type { AppElement } from './app';
 import { AssetBinding } from './asset-binding';
 import { parseBool, parseColor, parseEnum, parseNumber, parseVec2 } from './parse';
 
-/** The blend modes for a material. */
+/**
+ * The blend modes for a material.
+ *
+ * @category Types
+ */
 export type BlendType =
     | 'none'
     | 'normal'
@@ -57,7 +61,11 @@ const blendTypes = new Map<BlendType, number>([
     ['subtractive', BLEND_SUBTRACTIVE]
 ]);
 
-/** The face culling modes for a material. */
+/**
+ * The face culling modes for a material.
+ *
+ * @category Types
+ */
 export type CullMode = 'none' | 'back' | 'front' | 'front-and-back';
 
 const cullModes = new Map<CullMode, number>([
@@ -67,7 +75,11 @@ const cullModes = new Map<CullMode, number>([
     ['front-and-back', CULLFACE_FRONTANDBACK]
 ]);
 
-/** The Fresnel models for a material. */
+/**
+ * The Fresnel models for a material.
+ *
+ * @category Types
+ */
 export type FresnelModel = 'none' | 'schlick';
 
 const fresnelModels = new Map<FresnelModel, number>([
@@ -75,7 +87,11 @@ const fresnelModels = new Map<FresnelModel, number>([
     ['schlick', FRESNEL_SCHLICK]
 ]);
 
-/** The specular occlusion modes for a material. */
+/**
+ * The specular occlusion modes for a material.
+ *
+ * @category Types
+ */
 export type OccludeSpecular = 'none' | 'ao' | 'gloss-dependent';
 
 const occludeSpeculars = new Map<OccludeSpecular, number>([
@@ -84,19 +100,31 @@ const occludeSpeculars = new Map<OccludeSpecular, number>([
     ['gloss-dependent', SPECOCC_GLOSSDEPENDENT]
 ]);
 
-/** The opacity dithering modes for a material. */
+/**
+ * The opacity dithering modes for a material.
+ *
+ * @category Types
+ */
 export type OpacityDither = 'none' | 'bayer8' | 'bluenoise' | 'ignnoise';
 
 // The DITHER_* constants are strings whose values are exactly these names, so a parsed value is
 // assigned to the material unchanged rather than mapped through a table.
 const opacityDithers: OpacityDither[] = ['none', 'bayer8', 'bluenoise', 'ignnoise'];
 
-/** The texture channels a color map can sample. */
+/**
+ * The texture channels a color map can sample.
+ *
+ * @category Types
+ */
 export type ColorChannel = 'r' | 'g' | 'b' | 'a' | 'rgb';
 
 const colorChannels: ColorChannel[] = ['r', 'g', 'b', 'a', 'rgb'];
 
-/** The texture channels a scalar map can sample. */
+/**
+ * The texture channels a scalar map can sample.
+ *
+ * @category Types
+ */
 export type ScalarChannel = 'r' | 'g' | 'b' | 'a';
 
 const scalarChannels: ScalarChannel[] = ['r', 'g', 'b', 'a'];
@@ -152,6 +180,8 @@ type TextureSlot =
  * @attribute {string} roughness-map - The id of the `pc-asset` to use as the roughness map. An
  * alias for `gloss-map` that also inverts the gloss channel, so do not combine it with the `gloss`
  * attributes.
+ *
+ * @category Resources
  */
 class MaterialElement extends HTMLElement {
     private _alphaTest = 0;

--- a/src/model.ts
+++ b/src/model.ts
@@ -9,6 +9,8 @@ import { parseBool, parseTags, parseVec3 } from './parse';
 /**
  * One material assignment of a {@link HierarchyNode} with a render component: a mesh instance's
  * position within the component and the runtime name of its current material.
+ *
+ * @category Types
  */
 type HierarchyMaterial = {
     /** The mesh instance's position in the render component's `meshInstances` array. */
@@ -26,6 +28,8 @@ type HierarchyMaterial = {
  * One node of the tree returned by {@link ModelElement.hierarchy}. A plain-data snapshot —
  * `JSON.stringify` serializes it — whose `toString()` renders the node's subtree as a printable
  * tree.
+ *
+ * @category Types
  */
 type HierarchyNode = {
     /**
@@ -160,6 +164,8 @@ const formatHierarchy = (root: HierarchyNode, counts: ReadonlyMap<string, number
  * @fires {ErrorEvent} error - Fired when the container asset fails to load, with the engine's
  * error in `message`. Does not bubble. The element still becomes ready — readiness means the load
  * settled, not that it succeeded.
+ *
+ * @category Entities
  */
 class ModelElement extends EntityOwnerElement {
     private _asset = '';

--- a/src/node.ts
+++ b/src/node.ts
@@ -14,6 +14,8 @@ import { parseBool, parseTags, parseVec3 } from './parse';
  * instantiated (or no `name` is assigned), `bound` once a node has been resolved and decorated,
  * `missing`/`ambiguous`/`duplicate` when resolution failed — each accompanied by a warning
  * naming the cause.
+ *
+ * @category Types
  */
 export type NodeBindingState = 'pending' | 'bound' | 'missing' | 'ambiguous' | 'duplicate';
 
@@ -34,6 +36,8 @@ type AuthoredState = {
  * attribute and `materialOverrides` property. A `name:X` key selects every mesh instance of the
  * bound node's render component whose baseline material is named `X`; an `index:N` key selects
  * mesh instance `N` and wins over a name rule for the same instance.
+ *
+ * @category Types
  */
 type MaterialOverrides = Readonly<Record<string, string>>;
 
@@ -204,6 +208,8 @@ const levenshtein = (a: string, b: string): number => {
  * over the node. A press and release that picked different entities fires on their nearest
  * common ancestor instead, as in the DOM. `detail` carries the click count, so a double click
  * arrives as a click whose `detail` is 2.
+ *
+ * @category Entities
  */
 class NodeElement extends EntityBaseElement {
     private _name = '';

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -13,6 +13,8 @@ import { parseColor, parseEnum, parseNumber, parseVec3 } from './parse';
  * @elementSummary The `<pc-scene>` element holds the entity hierarchy the application renders,
  * along with the scene-wide fog, exposure and gravity settings. Must be a direct child of
  * `<pc-app>`.
+ *
+ * @category Application
  */
 class SceneElement extends AsyncElement {
     /**

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -15,6 +15,8 @@ import { parseBool, parseEnum, parseNumber, parseVec3 } from './parse';
  * @elementSummary The `<pc-sky>` element renders a skybox from a texture asset, projected as an
  * infinite background, a box or a dome, and optionally lights the scene from it. Must be a direct
  * child of `<pc-scene>`.
+ *
+ * @category Application
  */
 class SkyElement extends AsyncElement {
     private _asset = '';

--- a/src/wasm.ts
+++ b/src/wasm.ts
@@ -27,6 +27,8 @@ import { AsyncElement } from './async-element';
  * @attribute {string} wasm - The URL of the module's WebAssembly binary.
  * @attribute {string} fallback - The URL of the module's asm.js fallback script, used when
  * WebAssembly is unavailable.
+ *
+ * @category Resources
  */
 class WasmElement extends AsyncElement {
     private _loadPromise: Promise<void> | null = null;

--- a/typedoc.json
+++ b/typedoc.json
@@ -47,6 +47,16 @@
         "@typedef",
         "@yields"
     ],
+    "categoryOrder": [
+        "Application",
+        "Resources",
+        "Entities",
+        "Components",
+        "Base Classes",
+        "Functions",
+        "Types",
+        "*"
+    ],
     "entryPoints": [
         "./src/index.ts"
     ],


### PR DESCRIPTION
## What

The [API reference](https://api.playcanvas.com/web-components/) landing page had two sections: **Components**, holding the 19 component element classes, and **Other**, holding everything else - 15 classes, 17 type aliases and `whenReady`.

Every class, type alias and function now carries a `@category`, so the page reads the way a document is structured:

| Category | Members |
| --- | --- |
| Application | `AppElement`, `SceneElement`, `SkyElement` |
| Resources | `AssetElement`, `MaterialElement`, `WasmElement` |
| Entities | `EntityElement`, `ModelElement`, `NodeElement` |
| Components | the 19 component elements, plus the repeatable children `AnimClipElement`, `ScriptInstanceElement` and `SoundSlotElement` |
| Base Classes | `AsyncElement`, `ComponentElement`, `EntityBaseElement`, `EntityOwnerElement` |
| Functions | `whenReady` |
| Types | the 17 exported type aliases |

Each category has a `@categoryDescription` in the module comment in `src/index.ts`, which TypeDoc renders under its heading, and `typedoc.json` pins the order with `categoryOrder`.

The module comment no longer describes "The Engine Web Components module". It names the package, points at the User Manual for declarative use, and states what this reference covers. The `@module` name changes from `EngineWebComponents` to `@playcanvas/web-components`.

## Why

Half the library was filed under "Other", which is the first thing a reader - or an LLM crawling the reference - sees on the landing page. This came out of a sweep of the public surface for readability.

## Notes for review

- Comments and TypeDoc config only; no runtime change.
- `custom-elements.json`, `vscode.html-custom-data.json` and `web-types.json` are byte-identical before and after - the analyzer ignores `@category`.
- TypeDoc still builds with zero warnings; `npm run lint`, `npm run type-check:src` and `npm test` (1219 tests) pass.
- Sidebar grouping (`navigation.includeCategories`) was tried and deliberately left off, so the sidebar stays a flat alphabetical list.
- Judgement calls worth a look: `SkyElement` sits under Application rather than in a separate Scene category, and the three repeatable children sit under Components beside their parents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
