### PR TITLE
Document the collision, rigid body and screen accessors

### DIFF
--- a/src/components/collision-component.ts
+++ b/src/components/collision-component.ts
@@ -99,6 +99,11 @@ class CollisionComponentElement extends ComponentElement<CollisionComponent> {
         return super.component;
     }
 
+    /**
+     * Sets the rotation of the collision shape relative to the entity, in local space. Defaults to
+     * no rotation.
+     * @param value - The angular offset.
+     */
     set angularOffset(value: Quat) {
         this._angularOffset = value;
         if (this.component) {
@@ -106,10 +111,19 @@ class CollisionComponentElement extends ComponentElement<CollisionComponent> {
         }
     }
 
+    /**
+     * Gets the rotation of the collision shape relative to the entity, in local space.
+     * @returns The angular offset.
+     */
     get angularOffset() {
         return this._angularOffset;
     }
 
+    /**
+     * Sets the local axis along which a `capsule`, `cylinder` or `cone` shape is aligned: 0 for X,
+     * 1 for Y and 2 for Z. Defaults to 1.
+     * @param value - The axis.
+     */
     set axis(value: number) {
         this._axis = value;
         if (this.component) {
@@ -117,10 +131,21 @@ class CollisionComponentElement extends ComponentElement<CollisionComponent> {
         }
     }
 
+    /**
+     * Gets the local axis along which a `capsule`, `cylinder` or `cone` shape is aligned: 0 for X,
+     * 1 for Y and 2 for Z.
+     * @returns The axis.
+     */
     get axis() {
         return this._axis;
     }
 
+    /**
+     * Sets whether a `mesh` shape is treated as a convex hull rather than a triangle mesh. A
+     * triangle mesh can only be used with a `static` rigid body; a convex hull can also move as a
+     * `dynamic` or `kinematic` one. Defaults to `false`.
+     * @param value - Whether the mesh is a convex hull.
+     */
     set convexHull(value: boolean) {
         this._convexHull = value;
         if (this.component) {
@@ -128,10 +153,19 @@ class CollisionComponentElement extends ComponentElement<CollisionComponent> {
         }
     }
 
+    /**
+     * Gets whether a `mesh` shape is treated as a convex hull rather than a triangle mesh.
+     * @returns Whether the mesh is a convex hull.
+     */
     get convexHull() {
         return this._convexHull;
     }
 
+    /**
+     * Sets the half-extents of a `box` shape along its local X, Y and Z axes. Defaults to 0.5 in
+     * each axis.
+     * @param value - The half-extents.
+     */
     set halfExtents(value: Vec3) {
         this._halfExtents = value;
         if (this.component) {
@@ -139,10 +173,19 @@ class CollisionComponentElement extends ComponentElement<CollisionComponent> {
         }
     }
 
+    /**
+     * Gets the half-extents of a `box` shape along its local X, Y and Z axes.
+     * @returns The half-extents.
+     */
     get halfExtents() {
         return this._halfExtents;
     }
 
+    /**
+     * Sets the total height of a `capsule`, `cylinder` or `cone` shape, measured tip to tip along
+     * its `axis`. Defaults to 2.
+     * @param value - The height.
+     */
     set height(value: number) {
         this._height = value;
         if (this.component) {
@@ -150,10 +193,20 @@ class CollisionComponentElement extends ComponentElement<CollisionComponent> {
         }
     }
 
+    /**
+     * Gets the total height of a `capsule`, `cylinder` or `cone` shape, measured tip to tip along
+     * its `axis`.
+     * @returns The height.
+     */
     get height() {
         return this._height;
     }
 
+    /**
+     * Sets the position of the collision shape relative to the entity, along its local axes.
+     * Defaults to no offset.
+     * @param value - The linear offset.
+     */
     set linearOffset(value: Vec3) {
         this._linearOffset = value;
         if (this.component) {
@@ -161,10 +214,18 @@ class CollisionComponentElement extends ComponentElement<CollisionComponent> {
         }
     }
 
+    /**
+     * Gets the position of the collision shape relative to the entity, along its local axes.
+     * @returns The linear offset.
+     */
     get linearOffset() {
         return this._linearOffset;
     }
 
+    /**
+     * Sets the radius of a `sphere`, `capsule`, `cylinder` or `cone` shape. Defaults to 0.5.
+     * @param value - The radius.
+     */
     set radius(value: number) {
         this._radius = value;
         if (this.component) {
@@ -172,10 +233,21 @@ class CollisionComponentElement extends ComponentElement<CollisionComponent> {
         }
     }
 
+    /**
+     * Gets the radius of a `sphere`, `capsule`, `cylinder` or `cone` shape.
+     * @returns The radius.
+     */
     get radius() {
         return this._radius;
     }
 
+    /**
+     * Sets the shape of the collision volume. Can be `box`, `sphere`, `capsule`, `cylinder`,
+     * `cone`, `mesh` or `compound`: a `mesh` shape takes its geometry from the host entity's
+     * render asset, and a `compound` shape combines the shapes of descendant entities' collision
+     * components into one rigid shape. Defaults to `box`.
+     * @param value - The type.
+     */
     set type(value: 'box' | 'capsule' | 'compound' | 'cone' | 'cylinder' | 'mesh' | 'sphere') {
         this._type = value;
         if (this.component) {
@@ -184,6 +256,10 @@ class CollisionComponentElement extends ComponentElement<CollisionComponent> {
         }
     }
 
+    /**
+     * Gets the shape of the collision volume.
+     * @returns The type.
+     */
     get type() {
         return this._type;
     }

--- a/src/components/rigid-body-component.ts
+++ b/src/components/rigid-body-component.ts
@@ -94,6 +94,11 @@ class RigidBodyComponentElement extends ComponentElement<RigidBodyComponent> {
         return super.component;
     }
 
+    /**
+     * Sets the rate at which the body loses angular velocity over time, from 0 (none) to 1.
+     * Defaults to 0.
+     * @param value - The angular damping.
+     */
     set angularDamping(value: number) {
         this._angularDamping = value;
         if (this.component) {
@@ -101,10 +106,19 @@ class RigidBodyComponentElement extends ComponentElement<RigidBodyComponent> {
         }
     }
 
+    /**
+     * Gets the rate at which the body loses angular velocity over time, from 0 (none) to 1.
+     * @returns The angular damping.
+     */
     get angularDamping() {
         return this._angularDamping;
     }
 
+    /**
+     * Sets the scaling applied to the body's rotation about each axis: 0 locks an axis and 1 leaves
+     * it free. Applies to `dynamic` bodies only. Defaults to 1 in each axis.
+     * @param value - The angular factor.
+     */
     set angularFactor(value: Vec3) {
         this._angularFactor = value;
         if (this.component) {
@@ -112,10 +126,20 @@ class RigidBodyComponentElement extends ComponentElement<RigidBodyComponent> {
         }
     }
 
+    /**
+     * Gets the scaling applied to the body's rotation about each axis: 0 locks an axis and 1 leaves
+     * it free.
+     * @returns The angular factor.
+     */
     get angularFactor() {
         return this._angularFactor;
     }
 
+    /**
+     * Sets the friction applied where the body contacts another, from 0 (slides freely) to 1
+     * (grips). Defaults to 0.5.
+     * @param value - The friction.
+     */
     set friction(value: number) {
         this._friction = value;
         if (this.component) {
@@ -123,10 +147,20 @@ class RigidBodyComponentElement extends ComponentElement<RigidBodyComponent> {
         }
     }
 
+    /**
+     * Gets the friction applied where the body contacts another, from 0 (slides freely) to 1
+     * (grips).
+     * @returns The friction.
+     */
     get friction() {
         return this._friction;
     }
 
+    /**
+     * Sets the rate at which the body loses linear velocity over time, from 0 (none) to 1. Defaults
+     * to 0.
+     * @param value - The linear damping.
+     */
     set linearDamping(value: number) {
         this._linearDamping = value;
         if (this.component) {
@@ -134,10 +168,19 @@ class RigidBodyComponentElement extends ComponentElement<RigidBodyComponent> {
         }
     }
 
+    /**
+     * Gets the rate at which the body loses linear velocity over time, from 0 (none) to 1.
+     * @returns The linear damping.
+     */
     get linearDamping() {
         return this._linearDamping;
     }
 
+    /**
+     * Sets the scaling applied to the body's movement along each axis: 0 locks an axis and 1 leaves
+     * it free. Applies to `dynamic` bodies only. Defaults to 1 in each axis.
+     * @param value - The linear factor.
+     */
     set linearFactor(value: Vec3) {
         this._linearFactor = value;
         if (this.component) {
@@ -145,10 +188,20 @@ class RigidBodyComponentElement extends ComponentElement<RigidBodyComponent> {
         }
     }
 
+    /**
+     * Gets the scaling applied to the body's movement along each axis: 0 locks an axis and 1 leaves
+     * it free.
+     * @returns The linear factor.
+     */
     get linearFactor() {
         return this._linearFactor;
     }
 
+    /**
+     * Sets the mass of the body. Applies to `dynamic` bodies only; `static` and `kinematic` bodies
+     * behave as if infinitely massive. Defaults to 1.
+     * @param value - The mass.
+     */
     set mass(value: number) {
         this._mass = value;
         if (this.component) {
@@ -156,10 +209,20 @@ class RigidBodyComponentElement extends ComponentElement<RigidBodyComponent> {
         }
     }
 
+    /**
+     * Gets the mass of the body, which applies to `dynamic` bodies only.
+     * @returns The mass.
+     */
     get mass() {
         return this._mass;
     }
 
+    /**
+     * Sets the bounciness of the body, from 0 (all energy lost in a collision) to 1 (none lost).
+     * The restitution of both colliding bodies is multiplied together, so two bodies at 1 bounce
+     * fully and one at 0 stops any bounce. Defaults to 0.
+     * @param value - The restitution.
+     */
     set restitution(value: number) {
         this._restitution = value;
         if (this.component) {
@@ -167,10 +230,19 @@ class RigidBodyComponentElement extends ComponentElement<RigidBodyComponent> {
         }
     }
 
+    /**
+     * Gets the bounciness of the body, from 0 (all energy lost in a collision) to 1 (none lost).
+     * @returns The restitution.
+     */
     get restitution() {
         return this._restitution;
     }
 
+    /**
+     * Sets the friction that resists the body rolling across a contact, where `friction` resists it
+     * sliding. Defaults to 0.
+     * @param value - The rolling friction.
+     */
     set rollingFriction(value: number) {
         this._rollingFriction = value;
         if (this.component) {
@@ -178,10 +250,22 @@ class RigidBodyComponentElement extends ComponentElement<RigidBodyComponent> {
         }
     }
 
+    /**
+     * Gets the friction that resists the body rolling across a contact, where `friction` resists it
+     * sliding.
+     * @returns The rolling friction.
+     */
     get rollingFriction() {
         return this._rollingFriction;
     }
 
+    /**
+     * Sets how the body takes part in the simulation. Can be `static` (never moves, and other
+     * bodies collide with it), `dynamic` (moved by forces, gravity and collisions) or `kinematic`
+     * (moved only by setting its transform, and pushes `dynamic` bodies aside). Defaults to
+     * `static`.
+     * @param value - The type.
+     */
     set type(value: 'static' | 'dynamic' | 'kinematic') {
         this._type = value;
         if (this.component) {
@@ -189,6 +273,10 @@ class RigidBodyComponentElement extends ComponentElement<RigidBodyComponent> {
         }
     }
 
+    /**
+     * Gets how the body takes part in the simulation: `static`, `dynamic` or `kinematic`.
+     * @returns The type.
+     */
     get type() {
         return this._type;
     }

--- a/src/components/screen-component.ts
+++ b/src/components/screen-component.ts
@@ -66,6 +66,11 @@ class ScreenComponentElement extends ComponentElement<ScreenComponent> {
         return super.component;
     }
 
+    /**
+     * Sets the order in which the screen is drawn relative to other screens in the same layer, from
+     * 0 to 255, with higher values drawn on top. Defaults to 0.
+     * @param value - The priority.
+     */
     set priority(value: number) {
         this._priority = value;
         if (this.component) {
@@ -73,10 +78,21 @@ class ScreenComponentElement extends ComponentElement<ScreenComponent> {
         }
     }
 
+    /**
+     * Gets the order in which the screen is drawn relative to other screens in the same layer, from
+     * 0 to 255, with higher values drawn on top.
+     * @returns The priority.
+     */
     get priority() {
         return this._priority;
     }
 
+    /**
+     * Sets the resolution the screen's layout was designed for, as a width and height in pixels.
+     * Used only when `screenSpace` is set and `scaleMode` is `blend`, when the contents scale from
+     * this resolution to the actual canvas size, weighted by `scaleBlend`. Defaults to 640 by 320.
+     * @param value - The reference resolution.
+     */
     set referenceResolution(value: Vec2) {
         this._referenceResolution = value;
         if (this.component) {
@@ -84,10 +100,20 @@ class ScreenComponentElement extends ComponentElement<ScreenComponent> {
         }
     }
 
+    /**
+     * Gets the resolution the screen's layout was designed for, as a width and height in pixels.
+     * @returns The reference resolution.
+     */
     get referenceResolution() {
         return this._referenceResolution;
     }
 
+    /**
+     * Sets the width and height of the screen in pixels. A screen-space screen ignores this and
+     * always matches the canvas; a world-space screen uses it to size its contents. Defaults to 640
+     * by 320.
+     * @param value - The resolution.
+     */
     set resolution(value: Vec2) {
         this._resolution = value;
         if (this.component) {
@@ -95,6 +121,11 @@ class ScreenComponentElement extends ComponentElement<ScreenComponent> {
         }
     }
 
+    /**
+     * Gets the width and height of the screen in pixels, which a screen-space screen overrides with
+     * the canvas size.
+     * @returns The resolution.
+     */
     get resolution() {
         return this._resolution;
     }
@@ -142,6 +173,11 @@ class ScreenComponentElement extends ComponentElement<ScreenComponent> {
         return this._scaleMode;
     }
 
+    /**
+     * Sets whether the screen renders its `<pc-element>` descendants in screen space, as a 2D
+     * overlay on the canvas, rather than in the world. Defaults to `false`.
+     * @param value - Whether the screen is in screen space.
+     */
     set screenSpace(value: boolean) {
         this._screenSpace = value;
         if (this.component) {
@@ -149,6 +185,11 @@ class ScreenComponentElement extends ComponentElement<ScreenComponent> {
         }
     }
 
+    /**
+     * Gets whether the screen renders its `<pc-element>` descendants in screen space rather than in
+     * the world.
+     * @returns Whether the screen is in screen space.
+     */
     get screenSpace() {
         return this._screenSpace;
     }


### PR DESCRIPTION
## What

Adds JSDoc to every public accessor of `<pc-collision>`, `<pc-rigid-body>` and `<pc-screen>` - 42 setters and getters across the three elements, none of which had a docblock.

| Effect | Count |
| --- | --- |
| Accessors that gained a docblock | 42 |
| Attributes that had no description in the manifest, VS Code, JetBrains or the API reference | 14 |
| Vector attributes that only said "Accepts 3 space-separated numbers" | 7 |
| Attributes in the manifest still without a description | 0 |

The wording follows the engine's own docs for the same properties and states ranges, defaults, and which shape or body types each property applies to. For example `pc-rigid-body[type]` now reads "How the body takes part in the simulation: `static`, `dynamic` or `kinematic`." and `pc-collision[axis]` reads "The local axis along which a `capsule`, `cylinder` or `cone` shape is aligned: 0 for X, 1 for Y and 2 for Z."

## Why

These were the only attributes in the library with blank tooltips. Hovering `mass`, `radius` or `screen-space` in an editor showed nothing, and the API reference pages listed the accessors bare. This came out of the public-surface sweep, as the next item after #453.

## Notes for review

- Comments only; no runtime change. 205 added lines, 3 files.
- The manifest takes the **getter's** first sentence (the getter is the last member the analyzer merges), so the getters carry the informative sentence rather than a bare noun phrase. Setters add the default and the fuller explanation, as elsewhere in the library.
- Against the pre-change manifest, exactly 21 attribute descriptions change. The only other difference is that the newly documented members gain `parameters` and `return` entries, which is how every previously documented member already appears.
- TypeDoc builds with zero warnings; `npm run lint`, `npm run type-check:src`, `npm test` (1219 tests) and prettier on the three files all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
