### PR TITLE
Update PWC for Engine 2.22 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,32 @@ Explore the [PlayCanvas Web Components examples gallery](https://playcanvas.gith
 
 Please see the [Getting Started Guide](https://developer.playcanvas.com/user-manual/web-components/getting-started/) for installation and usage instructions.
 
+## PlayCanvas Engine Compatibility
+
+This version of PlayCanvas Web Components requires PlayCanvas Engine 2.22.0 or later.
+
+When upgrading an existing application to Engine 2.22:
+
+- Gaussian splat LOD is now controlled by a scene-wide budget. Replace the removed
+  `lod-base-distance` and `lod-multiplier` attributes with `lod-falloff` on `<pc-gsplat>`, and set
+  `gsplat-splat-budget` or `gsplat-lod-mode` on `<pc-scene>` when the defaults are not appropriate.
+- The corrected parallax calculation makes `height-map-factor` approximately four times stronger.
+  Divide an existing value by four to preserve its previous appearance.
+- A glTF triangle primitive without a `NORMAL` attribute is now flat shaded. The Engine appends
+  `-flatShaded` to the runtime material clone's name, and `<pc-node material-overrides>` name
+  selectors match that runtime name. Prefer an `index:` selector when the authored material name
+  must remain stable across Engine processing.
+
+For example:
+
+```html
+<pc-scene gsplat-splat-budget="1000000" gsplat-lod-mode="error">
+    <pc-entity>
+        <pc-gsplat asset="capture" lod-falloff="1"></pc-gsplat>
+    </pc-entity>
+</pc-scene>
+```
+
 ## Editor Support
 
 The package ships a [Custom Elements Manifest](https://github.com/webcomponents/custom-elements-manifest), which editors use to offer tag and attribute completions, valid attribute values and hover documentation when authoring HTML.

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "node": ">=18.3.0"
       },
       "peerDependencies": {
-        "playcanvas": "^2.20.1"
+        "playcanvas": "^2.22.0"
       }
     },
     "node_modules/@altano/repository-tools": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "watch": "rollup -c -w"
   },
   "peerDependencies": {
-    "playcanvas": "^2.20.1"
+    "playcanvas": "^2.22.0"
   },
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "0.11.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -299,7 +299,7 @@ class AppElement extends AsyncElement {
         let device: GraphicsDevice;
         try {
             device = await createGraphicsDevice(this._canvas, {
-                // @ts-ignore - alpha needs to be documented
+                // @ts-expect-error PlayCanvas does not declare the graphics-device alpha option.
                 alpha: this._alpha,
                 antialias: this._antialias,
                 depth: this._depthBuffer,

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -327,21 +327,20 @@ class AssetElement extends AsyncElement {
         // Optional inline asset data, used by data-driven assets such as texture atlases (frame
         // definitions) and sprites (atlas reference, frame keys, etc.).
         const data = this._buildData(type);
+        const assetType = type as ConstructorParameters<typeof Asset>[1];
 
-        if (type === 'container') {
-            this.asset = new Asset(id, type, { url: src }, undefined, {
-                // @ts-ignore TODO no definition in pc
+        if (assetType === 'container') {
+            this.asset = new Asset(id, assetType, { url: src }, undefined, {
+                // @ts-expect-error PlayCanvas does not declare the container bufferView hook.
                 bufferView: {
                     processAsync: processBufferView.bind(this)
                 }
             });
-        } else if (type === 'sprite') {
+        } else if (assetType === 'sprite') {
             // Sprite assets have no file of their own; their data references a texture atlas asset.
-            // @ts-ignore
-            this.asset = new Asset(id, type, null, data);
+            this.asset = new Asset(id, assetType, undefined, data);
         } else {
-            // @ts-ignore
-            this.asset = new Asset(id, type, src ? { url: src } : null, data);
+            this.asset = new Asset(id, assetType, src ? { url: src } : undefined, data);
         }
 
         this.asset.preload = !this._lazy;

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -286,7 +286,7 @@ class ButtonComponentElement extends ComponentElement<ButtonComponent> {
         this._hoverSpriteAsset = value;
         const asset = useAsset(value);
         if (this.component && asset) {
-            this.component.hoverSpriteAsset = asset;
+            this.component.hoverSpriteAsset = asset.id as any;
         }
     }
 
@@ -326,7 +326,7 @@ class ButtonComponentElement extends ComponentElement<ButtonComponent> {
         this._pressedSpriteAsset = value;
         const asset = useAsset(value);
         if (this.component && asset) {
-            this.component.pressedSpriteAsset = asset;
+            this.component.pressedSpriteAsset = asset.id as any;
         }
     }
 
@@ -366,7 +366,7 @@ class ButtonComponentElement extends ComponentElement<ButtonComponent> {
         this._inactiveSpriteAsset = value;
         const asset = useAsset(value);
         if (this.component && asset) {
-            this.component.inactiveSpriteAsset = asset;
+            this.component.inactiveSpriteAsset = asset.id as any;
         }
     }
 

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -286,7 +286,7 @@ class ButtonComponentElement extends ComponentElement<ButtonComponent> {
         this._hoverSpriteAsset = value;
         const asset = useAsset(value);
         if (this.component && asset) {
-            this.component.hoverSpriteAsset = asset.id as any;
+            this.component.hoverSpriteAsset = asset;
         }
     }
 
@@ -326,7 +326,7 @@ class ButtonComponentElement extends ComponentElement<ButtonComponent> {
         this._pressedSpriteAsset = value;
         const asset = useAsset(value);
         if (this.component && asset) {
-            this.component.pressedSpriteAsset = asset.id as any;
+            this.component.pressedSpriteAsset = asset;
         }
     }
 
@@ -366,7 +366,7 @@ class ButtonComponentElement extends ComponentElement<ButtonComponent> {
         this._inactiveSpriteAsset = value;
         const asset = useAsset(value);
         if (this.component && asset) {
-            this.component.inactiveSpriteAsset = asset.id as any;
+            this.component.inactiveSpriteAsset = asset;
         }
     }
 

--- a/src/components/gsplat-component.ts
+++ b/src/components/gsplat-component.ts
@@ -24,9 +24,7 @@ class GSplatComponentElement extends ComponentElement<GSplatComponent> {
 
     private _castShadows = false;
 
-    private _lodBaseDistance = 5;
-
-    private _lodMultiplier = 3;
+    private _lodFalloff = 1;
 
     private _lodRangeMin = 0;
 
@@ -41,8 +39,7 @@ class GSplatComponentElement extends ComponentElement<GSplatComponent> {
         return {
             asset: useAsset(this._asset),
             castShadows: this._castShadows,
-            lodBaseDistance: this._lodBaseDistance,
-            lodMultiplier: this._lodMultiplier,
+            lodFalloff: this._lodFalloff,
             lodRangeMin: this._lodRangeMin,
             lodRangeMax: this._lodRangeMax
         };
@@ -97,48 +94,25 @@ class GSplatComponentElement extends ComponentElement<GSplatComponent> {
     }
 
     /**
-     * Sets the base distance for the first LOD transition (LOD 0 to LOD 1). Splats closer than
-     * this distance use the highest quality LOD. Each subsequent LOD level transitions at a
-     * progressively larger distance, controlled by {@link lodMultiplier}. Clamped to a minimum of
-     * 0.1. Defaults to 5. Only affects assets that contain LOD levels (e.g. `.lod-meta.json`).
-     * @param value - The LOD base distance.
+     * Sets how quickly this splat's quality falls off away from the camera. Higher values
+     * concentrate more of the scene-wide splat budget near the camera, while lower values spread
+     * detail more evenly. Clamped to the range 0 to 8. Defaults to 1. Only affects assets that
+     * contain LOD levels (e.g. `.lod-meta.json`).
+     * @param value - The LOD falloff exponent.
      */
-    set lodBaseDistance(value: number) {
-        this._lodBaseDistance = value;
+    set lodFalloff(value: number) {
+        this._lodFalloff = value;
         if (this.component) {
-            this.component.lodBaseDistance = value;
+            this.component.lodFalloff = value;
         }
     }
 
     /**
-     * Gets the base distance for the first LOD transition.
-     * @returns The LOD base distance.
+     * Gets how quickly this splat's quality falls off away from the camera.
+     * @returns The LOD falloff exponent.
      */
-    get lodBaseDistance() {
-        return this._lodBaseDistance;
-    }
-
-    /**
-     * Sets the multiplier between successive LOD distance thresholds. Each LOD level transitions
-     * at this factor times the previous level's distance, creating a geometric progression. Lower
-     * values keep higher quality at distance; higher values switch to coarser LODs sooner. Clamped
-     * to a minimum of 1.2. Defaults to 3. Only affects assets that contain LOD levels (e.g.
-     * `.lod-meta.json`).
-     * @param value - The LOD multiplier.
-     */
-    set lodMultiplier(value: number) {
-        this._lodMultiplier = value;
-        if (this.component) {
-            this.component.lodMultiplier = value;
-        }
-    }
-
-    /**
-     * Gets the multiplier between successive LOD distance thresholds.
-     * @returns The LOD multiplier.
-     */
-    get lodMultiplier() {
-        return this._lodMultiplier;
+    get lodFalloff() {
+        return this._lodFalloff;
     }
 
     /**
@@ -185,15 +159,7 @@ class GSplatComponentElement extends ComponentElement<GSplatComponent> {
     }
 
     static get observedAttributes() {
-        return [
-            ...super.observedAttributes,
-            'asset',
-            'cast-shadows',
-            'lod-base-distance',
-            'lod-multiplier',
-            'lod-range-min',
-            'lod-range-max'
-        ];
+        return [...super.observedAttributes, 'asset', 'cast-shadows', 'lod-falloff', 'lod-range-min', 'lod-range-max'];
     }
 
     attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
@@ -206,11 +172,8 @@ class GSplatComponentElement extends ComponentElement<GSplatComponent> {
             case 'cast-shadows':
                 this.castShadows = parseBool(newValue, false);
                 break;
-            case 'lod-base-distance':
-                this.lodBaseDistance = parseNumber(newValue, 5, name);
-                break;
-            case 'lod-multiplier':
-                this.lodMultiplier = parseNumber(newValue, 3, name);
+            case 'lod-falloff':
+                this.lodFalloff = parseNumber(newValue, 1, name);
                 break;
             case 'lod-range-min':
                 this.lodRangeMin = parseNumber(newValue, 0, name);

--- a/src/material.ts
+++ b/src/material.ts
@@ -451,8 +451,6 @@ class MaterialElement extends HTMLElement {
         material.normalMapRotation = this._normalMapRotation;
         material.normalMapTiling = this._normalMapTiling;
         material.normalMapUv = this._normalMapUv;
-        // @ts-ignore the engine's generated .d.ts types occludeDirect as a number, but its own
-        // JSDoc documents it as a boolean and its runtime default is `false`
         material.occludeDirect = this._occludeDirect;
         material.occludeSpecular = occludeSpeculars.get(this._occludeSpecular) ?? SPECOCC_AO;
         material.opacity = this._opacity;
@@ -1781,7 +1779,6 @@ class MaterialElement extends HTMLElement {
     set occludeDirect(value: boolean) {
         this._occludeDirect = value;
         if (this.material) {
-            // @ts-ignore see _createMaterial() - the engine mistypes occludeDirect as a number
             this.material.occludeDirect = value;
             this._scheduleUpdate();
         }

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -11,8 +11,8 @@ import { parseColor, parseEnum, parseNumber, parseVec3 } from './parse';
  * {@link HTMLElement} interface.
  *
  * @elementSummary The `<pc-scene>` element holds the entity hierarchy the application renders,
- * along with the scene-wide fog, exposure and gravity settings. Must be a direct child of
- * `<pc-app>`.
+ * along with scene-wide fog, exposure, Gaussian splat LOD and gravity settings. Must be a direct
+ * child of `<pc-app>`.
  *
  * @category Application
  */
@@ -46,6 +46,16 @@ class SceneElement extends AsyncElement {
      * The end distance of the fog.
      */
     private _fogEnd = 1000;
+
+    /**
+     * The Gaussian splat LOD selection mode.
+     */
+    private _gsplatLodMode: 'error' | 'distance' = 'error';
+
+    /**
+     * The target number of Gaussian splats rendered across the scene.
+     */
+    private _gsplatSplatBudget = 1_000_000;
 
     /**
      * The gravity of the scene.
@@ -111,6 +121,9 @@ class SceneElement extends AsyncElement {
             this._scene.fog.density = this._fogDensity;
             this._scene.fog.start = this._fogStart;
             this._scene.fog.end = this._fogEnd;
+
+            this._scene.gsplat.lodMode = this._gsplatLodMode;
+            this._scene.gsplat.splatBudget = this._gsplatSplatBudget;
 
             this._applyGravity(this._gravity);
         }
@@ -244,6 +257,48 @@ class SceneElement extends AsyncElement {
     }
 
     /**
+     * Sets how LOD levels are chosen for streamed Gaussian splats. `error` spends the global splat
+     * budget where it removes the most approximation error; `distance` orders detail by camera
+     * distance alone. Defaults to `error`.
+     * @param value - The Gaussian splat LOD mode.
+     */
+    set gsplatLodMode(value: 'error' | 'distance') {
+        this._gsplatLodMode = value;
+        if (this.scene) {
+            this.scene.gsplat.lodMode = value;
+        }
+    }
+
+    /**
+     * Gets the Gaussian splat LOD selection mode.
+     * @returns The Gaussian splat LOD mode.
+     */
+    get gsplatLodMode() {
+        return this._gsplatLodMode;
+    }
+
+    /**
+     * Sets the target number of splats rendered across all Gaussian splats in the scene. The
+     * Engine distributes this budget globally between streamed splat assets. Defaults to
+     * 1,000,000.
+     * @param value - The scene-wide splat budget.
+     */
+    set gsplatSplatBudget(value: number) {
+        this._gsplatSplatBudget = value;
+        if (this.scene) {
+            this.scene.gsplat.splatBudget = value;
+        }
+    }
+
+    /**
+     * Gets the target number of splats rendered across the scene.
+     * @returns The scene-wide splat budget.
+     */
+    get gsplatSplatBudget() {
+        return this._gsplatSplatBudget;
+    }
+
+    /**
      * Sets the gravity of the scene.
      * @param value - The gravity.
      */
@@ -263,7 +318,17 @@ class SceneElement extends AsyncElement {
     }
 
     static get observedAttributes() {
-        return ['exposure', 'fog', 'fog-color', 'fog-density', 'fog-start', 'fog-end', 'gravity'];
+        return [
+            'exposure',
+            'fog',
+            'fog-color',
+            'fog-density',
+            'fog-start',
+            'fog-end',
+            'gsplat-lod-mode',
+            'gsplat-splat-budget',
+            'gravity'
+        ];
     }
 
     attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
@@ -285,6 +350,12 @@ class SceneElement extends AsyncElement {
                 break;
             case 'fog-end':
                 this.fogEnd = parseNumber(newValue, 1000, name);
+                break;
+            case 'gsplat-lod-mode':
+                this.gsplatLodMode = parseEnum(newValue, ['error', 'distance'], 'error', name);
+                break;
+            case 'gsplat-splat-budget':
+                this.gsplatSplatBudget = parseNumber(newValue, 1_000_000, name);
                 break;
             case 'gravity':
                 this.gravity = parseVec3(newValue, new Vec3(0, -9.81, 0), name);

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -146,10 +146,8 @@ class SkyElement extends AsyncElement {
         if (!this._appElement?.app) return;
 
         scene.skybox?.destroy();
-        // @ts-ignore
         scene.skybox = null;
         scene.envAtlas?.destroy();
-        // @ts-ignore
         scene.envAtlas = null;
     }
 

--- a/test/integration/components/gsplat-component.test.ts
+++ b/test/integration/components/gsplat-component.test.ts
@@ -1,0 +1,79 @@
+import type { GSplatComponent } from 'playcanvas';
+import { Entity } from 'playcanvas';
+import { describe, expect, it } from 'vitest';
+
+import { GSplatComponentElement } from '../../../src/components/gsplat-component';
+import { bootApp } from '../../helpers/app';
+import { useGuard } from '../../helpers/guard';
+
+const scene = (attributes = '') => `<pc-entity><pc-gsplat ${attributes}></pc-gsplat></pc-entity>`;
+
+const cases: [attribute: string, property: keyof GSplatComponent, value: string, expected: number][] = [
+    ['lod-falloff', 'lodFalloff', '2.5', 2.5],
+    ['lod-range-min', 'lodRangeMin', '2', 2],
+    ['lod-range-max', 'lodRangeMax', '5', 5]
+];
+
+describe('<pc-gsplat>', () => {
+    const { warnings } = useGuard();
+
+    describe('#component', () => {
+        it('matches the LOD defaults of a component the engine built itself', async () => {
+            const { app, get } = await bootApp(scene());
+            const element = get<GSplatComponentElement>('pc-gsplat').component!;
+
+            const bare = new Entity('bare', app);
+            app.root.addChild(bare);
+            const engine = bare.addComponent('gsplat') as GSplatComponent;
+
+            for (const [, property] of cases) {
+                expect.soft(element[property], property).toBe(engine[property]);
+            }
+        });
+    });
+
+    describe('LOD attributes', () => {
+        it('applies initial values to the engine component', async () => {
+            const markup = cases.map(([attribute, , value]) => `${attribute}="${value}"`).join(' ');
+            const { get } = await bootApp(scene(markup));
+            const gsplat = get<GSplatComponentElement>('pc-gsplat');
+
+            for (const [attribute, property, , expected] of cases) {
+                expect.soft(gsplat.component![property], attribute).toBe(expected);
+            }
+        });
+
+        it('writes changes through and restores the engine defaults on removal', async () => {
+            const { get } = await bootApp(scene());
+            const gsplat = get<GSplatComponentElement>('pc-gsplat');
+
+            for (const [attribute, property, value, expected] of cases) {
+                const initial = gsplat.component![property];
+                gsplat.setAttribute(attribute, value);
+                expect.soft(gsplat.component![property], `${attribute} set`).toBe(expected);
+                gsplat.removeAttribute(attribute);
+                expect.soft(gsplat.component![property], `${attribute} removed`).toBe(initial);
+            }
+        });
+
+        it('falls back to defaults and warns for invalid numbers', async () => {
+            const { get } = await bootApp(scene('lod-falloff="fast" lod-range-min="fine"'));
+            const component = get<GSplatComponentElement>('pc-gsplat').component!;
+
+            warnings.expect("Invalid value 'fast' for attribute 'lod-falloff'. Expected a finite number. Using '1'.");
+            warnings.expect("Invalid value 'fine' for attribute 'lod-range-min'. Expected a finite number. Using '0'.");
+            expect(component.lodFalloff).toBe(1);
+            expect(component.lodRangeMin).toBe(0);
+        });
+
+        it('does not expose the removed distance controls', async () => {
+            expect(GSplatComponentElement.observedAttributes).not.toContain('lod-base-distance');
+            expect(GSplatComponentElement.observedAttributes).not.toContain('lod-multiplier');
+
+            const { get } = await bootApp(scene('lod-base-distance="20" lod-multiplier="6"'));
+            const component = get<GSplatComponentElement>('pc-gsplat').component!;
+
+            expect(component.lodFalloff).toBe(1);
+        });
+    });
+});

--- a/test/integration/material-overrides.test.ts
+++ b/test/integration/material-overrides.test.ts
@@ -60,6 +60,29 @@ const BODY_SRC = `data:application/json,${encodeURIComponent(
 )}`;
 
 /**
+ * A single material on a triangle with no NORMAL attribute. Engine 2.22 clones the material for
+ * flat shading and appends `-flatShaded` to its runtime name.
+ */
+const NO_NORMAL_SRC = `data:application/json,${encodeURIComponent(
+    JSON.stringify({
+        asset: { version: '2.0' },
+        scene: 0,
+        scenes: [{ nodes: [0] }],
+        nodes: [{ name: 'Flat', mesh: 0 }],
+        materials: [{ name: 'Glass' }],
+        meshes: [{ primitives: [{ attributes: { POSITION: 0 }, material: 0 }] }],
+        accessors: [{ bufferView: 0, componentType: 5126, count: 3, type: 'VEC3', min: [0, 0, 0], max: [1, 1, 0] }],
+        bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: positions.byteLength }],
+        buffers: [
+            {
+                uri: `data:application/octet-stream;base64,${positionsBase64}`,
+                byteLength: positions.byteLength
+            }
+        ]
+    })
+)}`;
+
+/**
  * A minimally skinned glTF: one bone, identity bind matrix, every vertex weighted to it. The
  * mesh instance carries a skin instance, which a material swap must leave in place.
  */
@@ -107,6 +130,7 @@ const PRELUDE = `
     <pc-material id="candy-red" name="Candy Red"></pc-material>
     <pc-material id="smoked-glass"></pc-material>
     <pc-asset id="body" type="container" src="${BODY_SRC}"></pc-asset>
+    <pc-asset id="flat" type="container" src="${NO_NORMAL_SRC}"></pc-asset>
     <pc-asset id="skinned" type="container" src="${SKINNED_SRC}"></pc-asset>
 `;
 
@@ -135,6 +159,23 @@ describe('<pc-node> material-overrides', () => {
     };
 
     describe('selection', () => {
+        it('matches the runtime flat-shaded name for a primitive without normals', async () => {
+            const { get } = await bootApp(
+                `${PRELUDE}<pc-model asset="flat"><pc-node name="Flat"></pc-node></pc-model>`
+            );
+            const model = get<ModelElement>('pc-model');
+            const node = get<NodeElement>('pc-node');
+            const replacement = get<MaterialElement>('pc-material[id="smoked-glass"]').material!;
+            const meshInstance = model.contentEntity!.render!.meshInstances[0];
+
+            expect(meshInstance.material.name).toBe('Glass-flatShaded');
+
+            node.materialOverrides = { 'name:Glass-flatShaded': 'smoked-glass' };
+
+            expect(meshInstance.material).toBe(replacement);
+            expect(uncaught.seen).toEqual([]);
+        });
+
         it('replaces sparsely by name and index, leaving unmatched assignments untouched', async () => {
             const { authored, meshInstances, node, replacements } = await bootAuthored();
 

--- a/test/integration/scene.test.ts
+++ b/test/integration/scene.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import type { SceneElement } from '../../src/scene';
+import { bootApp } from '../helpers/app';
+import { useGuard } from '../helpers/guard';
+
+describe('<pc-scene>', () => {
+    const { warnings } = useGuard();
+
+    describe('GSplat LOD attributes', () => {
+        it('uses the Engine 2.22 defaults when omitted', async () => {
+            const { app, get } = await bootApp('<pc-scene></pc-scene>');
+            const scene = get<SceneElement>('pc-scene');
+
+            expect(scene.gsplatLodMode).toBe('error');
+            expect(scene.gsplatSplatBudget).toBe(1_000_000);
+            expect(app.scene.gsplat.lodMode).toBe('error');
+            expect(app.scene.gsplat.splatBudget).toBe(1_000_000);
+        });
+
+        it('applies initial values and subsequent changes to the Engine scene', async () => {
+            const { app, get } = await bootApp(
+                '<pc-scene gsplat-lod-mode="distance" gsplat-splat-budget="250000"></pc-scene>'
+            );
+            const scene = get<SceneElement>('pc-scene');
+
+            expect(app.scene.gsplat.lodMode).toBe('distance');
+            expect(app.scene.gsplat.splatBudget).toBe(250_000);
+
+            scene.setAttribute('gsplat-lod-mode', 'error');
+            scene.setAttribute('gsplat-splat-budget', '500000');
+            expect(app.scene.gsplat.lodMode).toBe('error');
+            expect(app.scene.gsplat.splatBudget).toBe(500_000);
+        });
+
+        it('restores the Engine defaults when removed', async () => {
+            const { app, get } = await bootApp(
+                '<pc-scene gsplat-lod-mode="distance" gsplat-splat-budget="250000"></pc-scene>'
+            );
+            const scene = get<SceneElement>('pc-scene');
+
+            scene.removeAttribute('gsplat-lod-mode');
+            scene.removeAttribute('gsplat-splat-budget');
+
+            expect(app.scene.gsplat.lodMode).toBe('error');
+            expect(app.scene.gsplat.splatBudget).toBe(1_000_000);
+        });
+
+        it('falls back to defaults and warns for invalid values', async () => {
+            const { app } = await bootApp('<pc-scene gsplat-lod-mode="nearest" gsplat-splat-budget="many"></pc-scene>');
+
+            warnings.expect(
+                "Invalid value 'nearest' for attribute 'gsplat-lod-mode'. Valid values: error, distance. Using 'error'."
+            );
+            warnings.expect(
+                "Invalid value 'many' for attribute 'gsplat-splat-budget'. Expected a finite number. Using '1000000'."
+            );
+            expect(app.scene.gsplat.lodMode).toBe('error');
+            expect(app.scene.gsplat.splatBudget).toBe(1_000_000);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- replace the removed GSplat `lod-base-distance` / `lod-multiplier` surface with per-component `lod-falloff`
- expose Engine 2.22's scene-wide `gsplat-lod-mode` and `gsplat-splat-budget` controls
- raise the PlayCanvas peer dependency floor to 2.22.0
- remove stale TypeScript suppressions and convert the two remaining upstream declaration gaps to `@ts-expect-error`
- document Engine 2.22 migration behavior for GSplat LOD, height maps, and missing-normal glTF primitives
- cover GSplat defaults/mutations and flat-shaded runtime material selectors with integration tests

## Validation

- `npm test` (55 files, 1,229 tests)
- `npm run type-check`
- `npm run lint`
- `npm run build`
- `npm run publint`