### PR TITLE
Use camera-frame string enums in examples

### DIFF
--- a/examples/product-viewer.html
+++ b/examples/product-viewer.html
@@ -60,16 +60,14 @@
                                             focus-point="0 0.045 0"
                                             pitch-range="-85 85"
                                             zoom-range="0.3 1.8"></pc-script-instance>
-                        <!-- Post-processing. toneMapping 5 is TONEMAP_NEUTRAL and renderFormat
-                             12/18/7 are pixel-format constants: this script's enums are numeric,
-                             so they have to be written as numbers here.
-                             ssao.radius is in WORLD UNITS, so it has to be scaled to the subject:
-                             this drone is only 0.375 m across, and the usual scene-sized radius of
-                             0.5 samples a hemisphere wider than the whole model, which returns an
-                             almost blank occlusion buffer. 0.035 is the scale of the actual
-                             crevices here - shell seams, motor rings, arm roots. -->
+                        <!-- Post-processing. ssao.radius is in WORLD UNITS, so it has to be scaled
+                             to the subject: this drone is only 0.375 m across, and the usual
+                             scene-sized radius of 0.5 samples a hemisphere wider than the whole
+                             model, which returns an almost blank occlusion buffer. 0.035 is the
+                             scale of the actual crevices here - shell seams, motor rings, arm
+                             roots. -->
                         <pc-script-instance name="cameraFrame" attributes='{
-                            "rendering": { "toneMapping": 5, "samples": 4, "renderFormat": 12, "renderFormatFallback0": 18, "renderFormatFallback1": 7 },
+                            "rendering": { "toneMapping": "neutral", "samples": 4, "renderFormat": "rgba16", "renderFormatFallback0": "rg11b10", "renderFormatFallback1": "rgba8" },
                             "ssao": { "type": "combine", "blurEnabled": true, "intensity": 0.6, "radius": 0.035, "samples": 16, "power": 3, "minAngle": 20, "scale": 1 },
                             "bloom": { "enabled": true, "intensity": 0.04, "blurLevel": 4 },
                             "grading": { "enabled": true, "brightness": 1, "contrast": 1.06, "saturation": 1.05 },

--- a/examples/ragdoll.html
+++ b/examples/ragdoll.html
@@ -52,14 +52,14 @@
                         <!-- Bloom is what makes the visor and the reactor read as lit rather than
                              just brightly painted, and it is the reason those two materials carry a
                              high emissive strength. It blooms out of a half-float buffer:
-                             renderFormat 12 is RGBA16F, which gives those panels the headroom to
-                             bleed from, and it degrades to RG11B10 then RGBA8 where that is not
-                             available. cameraFrame owns tone mapping once it is attached, so it is
-                             set here rather than on pc-camera - 5 is neutral. Worth knowing if you
-                             retune it: the ACES curves (3 and 4) desaturate the orange accents to
-                             cream and wash the cyan panels towards white. -->
+                             renderFormat rgba16 gives those panels the headroom to bleed from, and
+                             it degrades to rg11b10 then rgba8 where that is not available.
+                             cameraFrame owns tone mapping once it is attached, so it is set here
+                             rather than on pc-camera. Worth knowing if you retune it: the ACES
+                             curves ('aces' and 'aces2') desaturate the orange accents to cream and
+                             wash the cyan panels towards white. -->
                         <pc-script-instance name="cameraFrame" attributes='{
-                            "rendering": { "toneMapping": 5, "samples": 4, "renderFormat": 12, "renderFormatFallback0": 18, "renderFormatFallback1": 7 },
+                            "rendering": { "toneMapping": "neutral", "samples": 4, "renderFormat": "rgba16", "renderFormatFallback0": "rg11b10", "renderFormatFallback1": "rgba8" },
                             "bloom": { "enabled": true, "intensity": 0.04, "blurLevel": 4 },
                             "ssao": { "type": "combine", "blurEnabled": true, "intensity": 0.35, "radius": 0.6, "samples": 16, "power": 3, "minAngle": 20, "scale": 1 },
                             "vignette": { "enabled": true, "inner": 0.6, "outer": 1.4, "curvature": 0.7, "intensity": 0.4 }

--- a/examples/robot-arm.html
+++ b/examples/robot-arm.html
@@ -256,7 +256,7 @@
                         <!-- Bloom is deliberately weak: much above this and the orange shell haloes
                              rather than just the two emissive panels. -->
                         <pc-script-instance name="cameraFrame" attributes='{
-                            "rendering": { "toneMapping": 5, "samples": 4, "renderFormat": 12, "renderFormatFallback0": 18, "renderFormatFallback1": 7 },
+                            "rendering": { "toneMapping": "neutral", "samples": 4, "renderFormat": "rgba16", "renderFormatFallback0": "rg11b10", "renderFormatFallback1": "rgba8" },
                             "bloom": { "enabled": true, "intensity": 0.01, "blurLevel": 3 },
                             "ssao": { "type": "combine", "blurEnabled": true, "intensity": 0.55, "radius": 0.4, "samples": 16, "power": 3, "minAngle": 20, "scale": 1 },
                             "vignette": { "enabled": true, "inner": 0.55, "outer": 1.4, "curvature": 0.7, "intensity": 0.45 }


### PR DESCRIPTION
### What

Switches the three examples that configure `cameraFrame`'s `rendering` group off numeric enum values and onto the string enums:

| Attribute | Before | After |
| --- | --- | --- |
| `toneMapping` | `5` | `"neutral"` |
| `renderFormat` | `12` | `"rgba16"` |
| `renderFormatFallback0` | `18` | `"rg11b10"` |
| `renderFormatFallback1` | `7` | `"rgba8"` |

Affects `examples/product-viewer.html`, `examples/ragdoll.html` and `examples/robot-arm.html`.

Two comments existed purely to decode those numbers for the reader — product-viewer's *"this script's enums are numeric, so they have to be written as numbers here"* paragraph, and ragdoll's *"5 is neutral"* / *"the ACES curves (3 and 4)"* asides. The first is deleted, the second now names `'aces'` and `'aces2'`.

### Why

The engine's `camera-frame.mjs` only exposed numeric enums for `toneMapping` and `renderFormat` because `TONEMAP_*` and `PIXELFORMAT_*` are numeric constants. Expressed as `pc-script-instance` attribute JSON, that meant every example using HDR rendering carried raw magic numbers with no way for a reader to tell `12` from `18`.

Engine 2.22.0 ships `camera-frame.mjs` v1.3, which resolves string values for both (playcanvas/engine#9210), so the examples can now read as intended.

### No rendering change

The script's `resolveToneMapping` / `resolveRenderFormat` map the strings back to the same engine constants. Confirmed by reading the live `engineCameraFrame.rendering` on each page after the change:

```
authored:  toneMapping "neutral", renderFormat "rgba16"/"rg11b10"/"rgba8"
resolved:  toneMapping 5,         renderFormats [12, 18, 7]   <- identical to before
```

This is worth checking rather than eyeballing, because an unrecognized string falls back **silently** to `TONEMAP_LINEAR` / `PIXELFORMAT_111110F` — a typo would have changed the image with no console warning.

`npm run test:examples` passes (329/329), and no numeric enum values remain anywhere under `examples/`.

### Notes for the reviewer

- `physics-cluster.html` and `splat-annotations.html` were already clean — they only set `ssao.type` / `vignette`, which have always been string-valued — so they are untouched.
- The `"samples"` values are genuine counts, not enums, and stay numeric.
- Numbers still pass through `camera-frame.mjs` unchanged for back-compat, so stale magic numbers elsewhere would keep working without warning; grepping is the only way to find them.
- This requires engine >= 2.22.0. `package.json` is already there (#458), but the examples would break if that dependency were rolled back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
