### PR TITLE
Add area light support: pc-light shape and pc-app area-light-luts

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import type { GraphicsDevice, GraphNode, Entity } from 'playcanvas';
+import type { Asset, GraphicsDevice, GraphNode, Entity } from 'playcanvas';
 import {
     AppBase,
     AppOptions,
@@ -63,6 +63,7 @@ import {
 } from 'playcanvas';
 
 import type { AssetElement } from './asset';
+import { AssetBinding } from './asset-binding';
 import { AsyncElement } from './async-element';
 import { SYNTHESIZED_EVENTS } from './entity-base';
 import type { EntityBaseElement } from './entity-base';
@@ -91,6 +92,14 @@ const ensureBaseStyles = () => {
 };
 
 /**
+ * The number of values in each area light lookup table, a 64x64 RGBA texture. The engine copies a
+ * table into a texture of exactly that size, so a longer array would throw from inside the asset's
+ * load handler and a shorter one would leave part of the texture unwritten - a file is checked
+ * against this before it reaches the engine.
+ */
+const AREA_LIGHT_LUT_LENGTH = 64 * 64 * 4;
+
+/**
  * The AppElement interface provides properties and methods for manipulating
  * {@link https://developer.playcanvas.com/user-manual/web-components/tags/pc-app/ | `<pc-app>`} elements.
  * The AppElement interface also inherits the properties and methods of the
@@ -104,7 +113,8 @@ const ensureBaseStyles = () => {
  *
  * @elementSummary The `<pc-app>` element creates a PlayCanvas application and the canvas it renders
  * into, and is the root of every scene. It holds the `<pc-asset>`, `<pc-material>`, `<pc-wasm>` and
- * `<pc-scene>` elements, and the page's CSS sizes it, as it would a `<video>`.
+ * `<pc-scene>` elements, loads the area light lookup tables from one of its assets, and the page's
+ * CSS sizes it, as it would a `<video>`.
  *
  * @fires {ProgressEvent} progress - Fired while the application preloads its assets. `loaded` and
  * `total` are asset counts, not bytes, and an asset that fails to load still counts as loaded.
@@ -127,6 +137,8 @@ class AppElement extends AsyncElement {
 
     private _alpha = true;
 
+    private _areaLightLuts = '';
+
     private _backend: 'webgpu' | 'webgl2' | 'null' = 'webgpu';
 
     private _antialias = true;
@@ -147,6 +159,12 @@ class AppElement extends AsyncElement {
     private _optionsLocked = false;
 
     private _bar: LoadingBar | null = null;
+
+    /**
+     * Watches the area light lookup table asset while it loads. Rebinding or disconnecting cancels
+     * it, so a superseded file can never reach the engine.
+     */
+    private _areaLightLutsBinding = new AssetBinding();
 
     /**
      * Whether the application has created its initial entity hierarchy. Read by EntityElement to
@@ -449,6 +467,10 @@ class AppElement extends AsyncElement {
             }
         }
 
+        // The lookup table asset is registered now, so binding it here lets a preloaded one apply
+        // inside app.preload(), before the first frame
+        this._bindAreaLightLuts();
+
         // Get all pc-material elements that are direct children of the pc-app element
         const materialElements = this.querySelectorAll<MaterialElement>(':scope > pc-material');
         Array.from(materialElements).forEach((materialElement) => {
@@ -533,6 +555,10 @@ class AppElement extends AsyncElement {
         this._optionsLocked = false;
         this._pointer.disconnect();
 
+        // A lookup table still loading must not be handed to the application destroyed below, nor
+        // to the one a re-inserted element boots - that boot binds afresh from the attribute
+        this._areaLightLutsBinding.cancel();
+
         // Clean up the application. Destroying it destroys every entity, whose destroy hooks
         // unregister them - clear() covers any entity the engine no longer reached.
         if (this._app) {
@@ -611,6 +637,68 @@ class AppElement extends AsyncElement {
     }
 
     /**
+     * Binds the lookup table asset named by `area-light-luts`, applying it once it has loaded, or
+     * switches area lights off when the attribute is empty.
+     */
+    private _bindAreaLightLuts() {
+        this._areaLightLutsBinding.cancel();
+
+        const id = this._areaLightLuts;
+        if (!id) {
+            this._setAreaLightsEnabled(false);
+            return;
+        }
+
+        const asset = this._areaLightLutsBinding.bind(id, {
+            load: (asset) => this._applyAreaLightLuts(asset, id)
+        });
+        if (!asset) {
+            console.warn(`pc-app could not find asset '${id}' - area light lookup tables not applied`);
+        }
+    }
+
+    /**
+     * Hands a loaded lookup table asset to the engine and switches area lights on in clustered
+     * lighting. A file that is not a lookup table is refused and switches them off instead.
+     *
+     * @param asset - The loaded `json` asset.
+     * @param id - The asset's `pc-asset` id, for the warning.
+     */
+    private _applyAreaLightLuts(asset: Asset, id: string) {
+        const app = this._app;
+        if (!app) {
+            return;
+        }
+
+        const isTable = (value: unknown): value is number[] =>
+            Array.isArray(value) && value.length === AREA_LIGHT_LUT_LENGTH;
+        const file = asset.resource as { LTC_MAT_1?: unknown; LTC_MAT_2?: unknown } | null;
+
+        if (!file || !isTable(file.LTC_MAT_1) || !isTable(file.LTC_MAT_2)) {
+            console.warn(
+                `pc-asset '${id}' is not an area light lookup table - expected LTC_MAT_1 and LTC_MAT_2 arrays of ${AREA_LIGHT_LUT_LENGTH} numbers - not applied`
+            );
+            this._setAreaLightsEnabled(false);
+            return;
+        }
+
+        app.setAreaLightLuts(file.LTC_MAT_1, file.LTC_MAT_2);
+        this._setAreaLightsEnabled(true);
+    }
+
+    /**
+     * Switches area lights on or off in clustered lighting, which the engine ignores on devices
+     * that cannot render them.
+     *
+     * @param value - Whether area lights are enabled.
+     */
+    private _setAreaLightsEnabled(value: boolean) {
+        if (this._app) {
+            this._app.scene.lighting.areaLightsEnabled = value;
+        }
+    }
+
+    /**
      * Warns that a graphics option was written too late to have any effect. These options are read
      * once, when the element connects and creates its graphics device, so a later write updates
      * only the element's own property - silently, without this.
@@ -658,6 +746,34 @@ class AppElement extends AsyncElement {
      */
     get antialias() {
         return this._antialias;
+    }
+
+    /**
+     * Sets the id of the `<pc-asset>` holding the area light lookup tables, whose loading also
+     * enables area lights for the application, so `<pc-light>` elements with a `rect`, `disk` or
+     * `sphere` shape render as intended. The asset is a JSON file with `LTC_MAT_1` and `LTC_MAT_2`
+     * arrays, like the PlayCanvas Engine examples' `area-light-luts.json`. The tables apply to the
+     * whole application and, when set before the application boots, load along with the other
+     * assets. Unlike the frame buffer options this applies immediately: clearing it switches area
+     * lights off again, though tables already handed to the engine stay in place. Devices that
+     * cannot render area lights ignore the switch, and `omni` and `spot` area lights stay punctual
+     * there.
+     * @param value - The asset ID.
+     */
+    set areaLightLuts(value: string) {
+        this._areaLightLuts = value;
+        if (this._app) {
+            this._bindAreaLightLuts();
+        }
+    }
+
+    /**
+     * Gets the id of the `<pc-asset>` holding the area light lookup tables, whose loading also
+     * enables area lights for the application.
+     * @returns The asset ID.
+     */
+    get areaLightLuts() {
+        return this._areaLightLuts;
     }
 
     /**
@@ -764,7 +880,16 @@ class AppElement extends AsyncElement {
     }
 
     static get observedAttributes() {
-        return ['alpha', 'antialias', 'backend', 'depth-buffer', 'loading-bar', 'max-pixel-ratio', 'stencil-buffer'];
+        return [
+            'alpha',
+            'antialias',
+            'area-light-luts',
+            'backend',
+            'depth-buffer',
+            'loading-bar',
+            'max-pixel-ratio',
+            'stencil-buffer'
+        ];
     }
 
     attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
@@ -774,6 +899,9 @@ class AppElement extends AsyncElement {
                 break;
             case 'antialias':
                 this.antialias = parseBool(newValue, true);
+                break;
+            case 'area-light-luts':
+                this.areaLightLuts = newValue ?? '';
                 break;
             case 'backend':
                 this.backend = parseEnum(newValue, ['webgpu', 'webgl2', 'null'], 'webgpu', name);

--- a/src/app.ts
+++ b/src/app.ts
@@ -637,8 +637,10 @@ class AppElement extends AsyncElement {
     }
 
     /**
-     * Binds the lookup table asset named by `area-light-luts`, applying it once it has loaded, or
-     * switches area lights off when the attribute is empty.
+     * Binds the lookup table asset named by `area-light-luts`, applying it once it has loaded. An
+     * empty attribute, or one naming an asset that does not exist, switches area lights off. A
+     * change from one asset to another keeps the previous tables lit until the new file applies or
+     * is refused - the engine keeps them either way.
      */
     private _bindAreaLightLuts() {
         this._areaLightLutsBinding.cancel();
@@ -654,6 +656,7 @@ class AppElement extends AsyncElement {
         });
         if (!asset) {
             console.warn(`pc-app could not find asset '${id}' - area light lookup tables not applied`);
+            this._setAreaLightsEnabled(false);
         }
     }
 
@@ -670,8 +673,19 @@ class AppElement extends AsyncElement {
             return;
         }
 
-        const isTable = (value: unknown): value is number[] =>
-            Array.isArray(value) && value.length === AREA_LIGHT_LUT_LENGTH;
+        // Every entry is checked, not just the length: the engine converts each value to half float
+        // as it is, so a hole or a non-number would upload as garbage
+        const isTable = (value: unknown): value is number[] => {
+            if (!Array.isArray(value) || value.length !== AREA_LIGHT_LUT_LENGTH) {
+                return false;
+            }
+            for (let i = 0; i < value.length; i++) {
+                if (!Number.isFinite(value[i])) {
+                    return false;
+                }
+            }
+            return true;
+        };
         const file = asset.resource as { LTC_MAT_1?: unknown; LTC_MAT_2?: unknown } | null;
 
         if (!file || !isTable(file.LTC_MAT_1) || !isTable(file.LTC_MAT_2)) {

--- a/src/asset-binding.ts
+++ b/src/asset-binding.ts
@@ -20,7 +20,12 @@ import type { AssetElement } from './asset';
  * @returns The asset, or `undefined`.
  * @internal
  */
-export const findAsset = (id: string) => document.querySelector<AssetElement>(`pc-asset[id="${id}"]`)?.asset;
+export const findAsset = (id: string) => {
+    // getElementById rather than a selector built from the id: an id containing a quote or a
+    // backslash would make the selector throw, whereas here it simply matches nothing
+    const element = document.getElementById(id);
+    return element?.localName === 'pc-asset' ? (element as AssetElement).asset : undefined;
+};
 
 /**
  * Resolves an asset reference for use: {@link findAsset}, plus starting the load of a registered

--- a/src/asset-binding.ts
+++ b/src/asset-binding.ts
@@ -1,10 +1,47 @@
 import type { Asset, EventHandle } from 'playcanvas';
 
-import { useAsset } from './asset';
+import type { AssetElement } from './asset';
 
 // Keep `export` on these declarations. TypeScript removes the declaration and its inline export
 // when `stripInternal` is enabled. A separate `export { ... }` statement would remain in the
 // generated .d.ts file and refer to a declaration that had been removed.
+
+// This module imports asset.ts for its types only. pc-app imports this module, and pc-app has to
+// be defined before pc-asset: defining an element upgrades every instance already in the document
+// and runs its connectedCallback, which awaits the application through `closestApp` - an
+// un-upgraded <pc-app> has no `ready()` to await. A value import here would define pc-asset
+// first, so the lookup lives here and AssetElement.get delegates to it.
+
+/**
+ * Looks up the {@link Asset} created by the `<pc-asset>` element with the given `id`, or
+ * `undefined` if there is no such element or its asset has not been created yet.
+ *
+ * @param id - The `id` of the `<pc-asset>` element.
+ * @returns The asset, or `undefined`.
+ * @internal
+ */
+export const findAsset = (id: string) => document.querySelector<AssetElement>(`pc-asset[id="${id}"]`)?.asset;
+
+/**
+ * Resolves an asset reference for use: {@link findAsset}, plus starting the load of a registered
+ * asset that has not begun one - a `lazy` asset. Every element that consumes assets resolves its
+ * references here, which is what makes `lazy` mean load on first use without any consumer having
+ * to remember the load. The load is asynchronous - callers observe the asset's `load` event for
+ * the resource.
+ *
+ * @param id - The `id` of the `<pc-asset>` element.
+ * @returns The asset, or `undefined`.
+ * @internal
+ */
+export const useAsset = (id: string) => {
+    const asset = findAsset(id);
+    // load() ignores an asset that is already loaded or loading, so repeated resolution
+    // costs nothing.
+    if (asset) {
+        asset.registry?.load(asset);
+    }
+    return asset;
+};
 
 /**
  * Functions called when an {@link AssetBinding} finishes loading an asset or encounters an

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -791,8 +791,4 @@ class AssetElement extends AsyncElement {
 
 customElements.define('pc-asset', AssetElement);
 
-// useAsset is defined in asset-binding.ts (see the note there on why the resolution lives outside
-// this module) and re-exported from here, its home for every element that consumes assets.
-export { useAsset } from './asset-binding';
-
 export { AssetElement };

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -17,6 +17,7 @@ import type { Texture, TextureAtlas } from 'playcanvas';
 
 import { MeshoptDecoder } from '../lib/meshopt_decoder.module.js';
 
+import { findAsset } from './asset-binding';
 import { AsyncElement } from './async-element';
 import { parseBool, parseEnum, parseNumber } from './parse';
 
@@ -702,8 +703,7 @@ class AssetElement extends AsyncElement {
      * @returns The asset, or `undefined`.
      */
     static get(id: string) {
-        const assetElement = document.querySelector<AssetElement>(`pc-asset[id="${id}"]`);
-        return assetElement?.asset;
+        return findAsset(id);
     }
 
     static get observedAttributes() {
@@ -791,25 +791,8 @@ class AssetElement extends AsyncElement {
 
 customElements.define('pc-asset', AssetElement);
 
-/**
- * Resolves an asset reference for use: {@link AssetElement.get}, plus starting the load of a
- * registered asset that has not begun one - a `lazy` asset. Every element that consumes assets
- * resolves its references here, which is what makes `lazy` mean load on first use without any
- * consumer having to remember the load. The load is asynchronous - callers observe the asset's
- * `load` event for the resource.
- *
- * @param id - The `id` of the `<pc-asset>` element.
- * @returns The asset, or `undefined`.
- * @internal
- */
-export const useAsset = (id: string) => {
-    const asset = AssetElement.get(id);
-    // load() ignores an asset that is already loaded or loading, so repeated resolution
-    // costs nothing.
-    if (asset) {
-        asset.registry?.load(asset);
-    }
-    return asset;
-};
+// useAsset is defined in asset-binding.ts (see the note there on why the resolution lives outside
+// this module) and re-exported from here, its home for every element that consumes assets.
+export { useAsset } from './asset-binding';
 
 export { AssetElement };

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -1,7 +1,7 @@
 import type { ButtonComponent } from 'playcanvas';
 import { BUTTON_TRANSITION_MODE_SPRITE_CHANGE, BUTTON_TRANSITION_MODE_TINT, Color, Vec4 } from 'playcanvas';
 
-import { useAsset } from '../asset';
+import { useAsset } from '../asset-binding';
 import { resolveEntity } from '../entity-reference';
 import { parseBool, parseColor, parseEnum, parseNumber, parseVec4 } from '../parse';
 

--- a/src/components/element-component.ts
+++ b/src/components/element-component.ts
@@ -1,7 +1,7 @@
 import type { ElementComponent } from 'playcanvas';
 import { Color, Vec2, Vec4 } from 'playcanvas';
 
-import { useAsset } from '../asset';
+import { useAsset } from '../asset-binding';
 import { parseBool, parseColor, parseEnum, parseNumber, parseVec2, parseVec4 } from '../parse';
 
 import { ComponentElement } from './component';

--- a/src/components/gsplat-component.ts
+++ b/src/components/gsplat-component.ts
@@ -1,6 +1,6 @@
 import type { GSplatComponent } from 'playcanvas';
 
-import { useAsset } from '../asset';
+import { useAsset } from '../asset-binding';
 import { parseBool, parseNumber } from '../parse';
 
 import { ComponentElement } from './component';

--- a/src/components/light-component.ts
+++ b/src/components/light-component.ts
@@ -1,6 +1,10 @@
 import type { LightComponent } from 'playcanvas';
 import {
     Color,
+    LIGHTSHAPE_DISK,
+    LIGHTSHAPE_PUNCTUAL,
+    LIGHTSHAPE_RECT,
+    LIGHTSHAPE_SPHERE,
     SHADOW_PCF1_16F,
     SHADOW_PCF1_32F,
     SHADOW_PCF3_16F,
@@ -32,6 +36,21 @@ const shadowTypes = new Map<
 ]);
 
 /**
+ * The light source shapes supported by the `<pc-light>` element: a `punctual` point, or an area
+ * light shaped as a `rect`, `disk` or `sphere`.
+ *
+ * @category Types
+ */
+export type LightShape = 'punctual' | 'rect' | 'disk' | 'sphere';
+
+const lightShapes = new Map<LightShape, number>([
+    ['punctual', LIGHTSHAPE_PUNCTUAL],
+    ['rect', LIGHTSHAPE_RECT],
+    ['disk', LIGHTSHAPE_DISK],
+    ['sphere', LIGHTSHAPE_SPHERE]
+]);
+
+/**
  * The LightComponentElement interface provides properties and methods for manipulating
  * {@link https://developer.playcanvas.com/user-manual/web-components/tags/pc-light/ | `<pc-light>`} elements.
  * The LightComponentElement interface also inherits the properties and methods of the
@@ -40,8 +59,8 @@ const shadowTypes = new Map<
  * Engine component: {@link LightComponent} (`light`).
  *
  * @elementSummary The `<pc-light>` element lights the scene from its entity — as a directional,
- * omni or spot light — with attributes for color, intensity, range and shadows. Must be a child of
- * a `<pc-entity>`, `<pc-model>` or `<pc-node>`.
+ * omni or spot light, from a point or from a rectangle, disk or sphere — with attributes for color,
+ * intensity, range and shadows. Must be a child of a `<pc-entity>`, `<pc-model>` or `<pc-node>`.
  *
  * @category Components
  */
@@ -85,6 +104,8 @@ class LightComponentElement extends ComponentElement<LightComponent> {
         | 'vsm-32f'
         | 'pcss-32f' = 'pcf3-32f';
 
+    private _shape: LightShape = 'punctual';
+
     private _type: 'directional' | 'omni' | 'spot' = 'directional';
 
     private _vsmBias = 0.0025;
@@ -125,6 +146,7 @@ class LightComponentElement extends ComponentElement<LightComponent> {
             shadowResolution: this._shadowResolution,
             shadowSamples: this._shadowSamples,
             shadowType: shadowTypes.get(this._shadowType) ?? SHADOW_PCF3_32F,
+            shape: lightShapes.get(this._shape) ?? LIGHTSHAPE_PUNCTUAL,
             type: this._type,
             vsmBias: this._vsmBias,
             vsmBlurSize: this._vsmBlurSize
@@ -456,6 +478,36 @@ class LightComponentElement extends ComponentElement<LightComponent> {
     }
 
     /**
+     * Sets the shape of the light source: `punctual` for a point, or an area light shaped as a
+     * `rect`, `disk` or `sphere` that takes its size from the entity's scale and needs the lookup
+     * tables loaded by `area-light-luts` on `<pc-app>`. Defaults to `punctual`.
+     * @param value - The light shape. Can be:
+     *
+     * - `punctual` - An infinitesimally small point.
+     * - `rect` - A rectangle in the entity's local XZ plane, 1 by 1 at unit scale.
+     * - `disk` - A disk in the entity's local XZ plane, 1 across at unit scale.
+     * - `sphere` - A sphere, 1 across at unit scale.
+     *
+     * Area shapes fall off with their size and distance, so `range` is only a cutoff for them.
+     */
+    set shape(value: LightShape) {
+        this._shape = value;
+        if (this.component) {
+            this.component.shape = lightShapes.get(value) ?? LIGHTSHAPE_PUNCTUAL;
+        }
+    }
+
+    /**
+     * Gets the shape of the light source: `punctual`, or an area light shaped as a `rect`, `disk`
+     * or `sphere` that takes its size from the entity's scale and needs the lookup tables loaded by
+     * `area-light-luts` on `<pc-app>`.
+     * @returns The light shape.
+     */
+    get shape() {
+        return this._shape;
+    }
+
+    /**
      * Sets the type of the light. Can be `directional`, `omni` or `spot`. Defaults to
      * `directional`.
      * @param value - The type.
@@ -611,6 +663,7 @@ class LightComponentElement extends ComponentElement<LightComponent> {
             'shadow-resolution',
             'shadow-samples',
             'shadow-type',
+            'shape',
             'type',
             'vsm-bias',
             'vsm-blur-size'
@@ -677,6 +730,9 @@ class LightComponentElement extends ComponentElement<LightComponent> {
                 break;
             case 'shadow-type':
                 this.shadowType = parseEnum(newValue, shadowTypes, 'pcf3-32f', name);
+                break;
+            case 'shape':
+                this.shape = parseEnum(newValue, lightShapes, 'punctual', name);
                 break;
             case 'type':
                 this.type = parseEnum(newValue, ['directional', 'omni', 'spot'], 'directional', name);

--- a/src/components/particle-system-component.ts
+++ b/src/components/particle-system-component.ts
@@ -1,7 +1,6 @@
 import type { Asset, ParticleSystemComponent } from 'playcanvas';
 
-import { useAsset } from '../asset';
-import { AssetBinding } from '../asset-binding';
+import { AssetBinding, useAsset } from '../asset-binding';
 
 import { ComponentElement } from './component';
 

--- a/src/components/script-component.ts
+++ b/src/components/script-component.ts
@@ -1,7 +1,7 @@
 import type { ScriptComponent, Script } from 'playcanvas';
 import { Color, Quat, Vec2, Vec3, Vec4 } from 'playcanvas';
 
-import { useAsset } from '../asset';
+import { useAsset } from '../asset-binding';
 import { findEntityElement, getEntity, idHint, unresolvedCause } from '../entity-reference';
 import {
     parseBool,

--- a/src/components/sound-slot.ts
+++ b/src/components/sound-slot.ts
@@ -1,6 +1,6 @@
 import type { SoundSlot } from 'playcanvas';
 
-import { useAsset } from '../asset';
+import { useAsset } from '../asset-binding';
 import { AsyncElement } from '../async-element';
 import { parseBool, parseNumber } from '../parse';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,6 +169,7 @@ export {
 export type { AddressMode, MagFilterMode, MinFilterMode } from './asset';
 export type { AsyncElementTagName } from './async-element';
 export type { JointType, MotionMode } from './components/joint-component';
+export type { LightShape } from './components/light-component';
 export type {
     BlendType,
     ColorChannel,

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -2,8 +2,7 @@ import type { Asset, Scene, Texture } from 'playcanvas';
 import { EnvLighting, LAYERID_SKYBOX, Quat, Vec3 } from 'playcanvas';
 
 import type { AppElement } from './app';
-import { useAsset } from './asset';
-import { AssetBinding } from './asset-binding';
+import { AssetBinding, useAsset } from './asset-binding';
 import { AsyncElement } from './async-element';
 import { parseBool, parseEnum, parseNumber, parseVec3 } from './parse';
 

--- a/test/elements/attribute-removal.test.ts
+++ b/test/elements/attribute-removal.test.ts
@@ -24,6 +24,7 @@ describe('attribute removal', () => {
         ['pc-anim', 'clip', 'clip', ''],
         ['pc-anim-clip', 'asset', 'asset', ''],
         ['pc-anim-clip', 'name', 'name', ''],
+        ['pc-app', 'area-light-luts', 'areaLightLuts', ''],
         ['pc-button', 'image', 'image', ''],
         ['pc-button', 'hover-sprite-asset', 'hoverSpriteAsset', ''],
         ['pc-button', 'pressed-sprite-asset', 'pressedSpriteAsset', ''],
@@ -71,6 +72,6 @@ describe('attribute removal', () => {
     it('covers every unparsed string attribute in the library', () => {
         // If a new `this.x = newValue ?? ''` branch is added without a case above, this fails.
         // Counted rather than enumerated, so it stays a one-line update rather than a second table.
-        expect(cases).toHaveLength(27);
+        expect(cases).toHaveLength(28);
     });
 });

--- a/test/integration/app-area-lights.test.ts
+++ b/test/integration/app-area-lights.test.ts
@@ -178,10 +178,49 @@ describe('<pc-app> area lights', () => {
             expect(uncaught.seen).toEqual([]);
         });
 
+        it('refuses a table whose entries are not all finite numbers', async () => {
+            const { app, appElement } = await bootApp(LAZY_ASSETS);
+            const parked = parkLoads(app);
+            const placeholder = lutTexture(app, 1);
+
+            appElement.setAttribute('area-light-luts', 'luts-a');
+            const file = tables();
+            (file.LTC_MAT_2 as unknown[])[100] = 'nan';
+            parked.get('luts-a.json')!(null, file);
+
+            warnings.expect("pc-asset 'luts-a' is not an area light lookup table");
+            expect(lutTexture(app, 1)).toBe(placeholder);
+            expect(app.scene.lighting.areaLightsEnabled).toBe(false);
+        });
+
         it('warns when the asset id resolves to nothing', async () => {
             const { app } = await bootApp('', { appAttributes: 'area-light-luts="missing"' });
 
             warnings.expect("pc-app could not find asset 'missing' - area light lookup tables not applied");
+            expect(app.scene.lighting.areaLightsEnabled).toBe(false);
+        });
+
+        it('switches area lights off when changed to an asset that does not exist', async () => {
+            const { app, appElement } = await bootApp(LAZY_ASSETS);
+            const parked = parkLoads(app);
+
+            appElement.setAttribute('area-light-luts', 'luts-a');
+            parked.get('luts-a.json')!(null, tables());
+            expect(app.scene.lighting.areaLightsEnabled).toBe(true);
+
+            appElement.setAttribute('area-light-luts', 'missing');
+
+            warnings.expect("pc-app could not find asset 'missing' - area light lookup tables not applied");
+            expect(app.scene.lighting.areaLightsEnabled, 'nothing valid is bound any more').toBe(false);
+        });
+
+        it('treats an id that would not survive a selector as missing rather than throwing', async () => {
+            const { app, appElement } = await bootApp();
+            const id = 'lu"ts';
+
+            expect(() => appElement.setAttribute('area-light-luts', id)).not.toThrow();
+
+            warnings.expect(`pc-app could not find asset '${id}' - area light lookup tables not applied`);
             expect(app.scene.lighting.areaLightsEnabled).toBe(false);
         });
 

--- a/test/integration/app-area-lights.test.ts
+++ b/test/integration/app-area-lights.test.ts
@@ -1,0 +1,222 @@
+import type { AppBase, Texture } from 'playcanvas';
+import { describe, expect, it } from 'vitest';
+
+import type { AssetElement } from '../../src/asset';
+import { bootApp, settle } from '../helpers/app';
+import { useGuard } from '../helpers/guard';
+import { parkLoads } from '../helpers/loader';
+import { readyWithin } from '../helpers/ready';
+
+/**
+ * `<pc-app area-light-luts>` is the one switch behind area lights: it binds the lookup table
+ * asset, hands the tables to `AppBase#setAreaLightLuts` and enables area lights in clustered
+ * lighting - two engine settings that are only ever useful together. The engine installs a shared
+ * 2x2 placeholder for both tables at init and offers no way back to it, which is why the tests
+ * watch the bound textures rather than a spy.
+ */
+
+/** The number of values in each table - a 64x64 RGBA texture. */
+const LUT_LENGTH = 64 * 64 * 4;
+
+/**
+ * A lookup table file of the shape the engine examples ship, filled with `value`.
+ *
+ * @param value - The value to fill both tables with.
+ * @returns The parsed file.
+ */
+const tables = (value = 0) => ({
+    LTC_MAT_1: new Array<number>(LUT_LENGTH).fill(value),
+    LTC_MAT_2: new Array<number>(LUT_LENGTH).fill(value)
+});
+
+/**
+ * A JSON asset as a `data:` URI, so it preloads without I/O.
+ *
+ * @param data - The object to serialize.
+ * @returns The data: URI.
+ */
+const jsonSrc = (data: unknown) => `data:application/json,${encodeURIComponent(JSON.stringify(data))}`;
+
+/** Two lazy lookup table assets whose loads the tests park and settle in a chosen order. */
+const LAZY_ASSETS = `
+    <pc-asset id="luts-a" type="json" src="luts-a.json" lazy></pc-asset>
+    <pc-asset id="luts-b" type="json" src="luts-b.json" lazy></pc-asset>
+`;
+
+/**
+ * The texture the engine currently samples one of the lookup tables from.
+ *
+ * @param app - The booted application.
+ * @param index - Which of the two tables to read.
+ * @returns The bound texture.
+ */
+const lutTexture = (app: AppBase, index: 1 | 2) =>
+    app.graphicsDevice.scope.resolve(`areaLightsLutTex${index}`).getValue() as Texture;
+
+describe('<pc-app> area lights', () => {
+    const { warnings, uncaught } = useGuard();
+
+    describe('[area-light-luts]', () => {
+        it('leaves the engine placeholder tables and area lights disabled when omitted', async () => {
+            const { app, appElement } = await bootApp();
+
+            expect(appElement.areaLightLuts).toBe('');
+            expect(app.scene.lighting.areaLightsEnabled).toBe(false);
+
+            const placeholder = lutTexture(app, 1);
+            expect(placeholder.width).toBe(2);
+            expect(lutTexture(app, 2), 'the placeholder is shared by both tables').toBe(placeholder);
+        });
+
+        it('preloads the tables named at boot and enables area lights before the first frame', async () => {
+            const { app } = await bootApp(`<pc-asset id="luts" type="json" src="${jsonSrc(tables())}"></pc-asset>`, {
+                appAttributes: 'area-light-luts="luts"'
+            });
+
+            // bootApp resolves from the preload callback, so both are proven to be in place before
+            // app.start() rather than some time after
+            expect(app.scene.lighting.areaLightsEnabled).toBe(true);
+            expect(lutTexture(app, 1).width).toBe(64);
+            expect(lutTexture(app, 2), 'the two tables are separate textures').not.toBe(lutTexture(app, 1));
+        });
+
+        it('applies a lazily loaded asset when it arrives and only then enables area lights', async () => {
+            const { app, appElement } = await bootApp(LAZY_ASSETS);
+            const parked = parkLoads(app);
+            const placeholder = lutTexture(app, 1);
+
+            appElement.setAttribute('area-light-luts', 'luts-a');
+            expect(parked.has('luts-a.json'), 'binding the lazy asset started its load').toBe(true);
+            expect(app.scene.lighting.areaLightsEnabled, 'nothing to enable until the tables exist').toBe(false);
+            expect(lutTexture(app, 1)).toBe(placeholder);
+
+            parked.get('luts-a.json')!(null, tables());
+
+            expect(app.scene.lighting.areaLightsEnabled).toBe(true);
+            expect(lutTexture(app, 1)).not.toBe(placeholder);
+            expect(lutTexture(app, 1).width).toBe(64);
+        });
+
+        it('applies an asset that has already loaded as soon as it is bound', async () => {
+            const { app, appElement, get } = await bootApp(LAZY_ASSETS);
+            const parked = parkLoads(app);
+
+            const asset = get<AssetElement>('pc-asset[id="luts-a"]').asset!;
+            app.assets.load(asset);
+            parked.get('luts-a.json')!(null, tables());
+            expect(app.scene.lighting.areaLightsEnabled, 'loading alone changes nothing').toBe(false);
+
+            appElement.setAttribute('area-light-luts', 'luts-a');
+
+            expect(app.scene.lighting.areaLightsEnabled).toBe(true);
+            expect(lutTexture(app, 1).width).toBe(64);
+        });
+
+        it('applies only the newest asset when a superseded load settles later', async () => {
+            const { app, appElement } = await bootApp(LAZY_ASSETS);
+            const parked = parkLoads(app);
+
+            appElement.setAttribute('area-light-luts', 'luts-a');
+            appElement.setAttribute('area-light-luts', 'luts-b');
+            expect(parked.has('luts-b.json')).toBe(true);
+
+            // B settles first, then A - the superseded tables must not overwrite their replacement
+            parked.get('luts-b.json')!(null, tables());
+            const current = lutTexture(app, 1);
+            expect(current.width).toBe(64);
+
+            parked.get('luts-a.json')!(null, tables(1));
+
+            expect(lutTexture(app, 1), 'the superseded tables did not apply').toBe(current);
+            expect(app.scene.lighting.areaLightsEnabled).toBe(true);
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('never applies a load that was cleared while it was pending', async () => {
+            const { app, appElement } = await bootApp(LAZY_ASSETS);
+            const parked = parkLoads(app);
+            const placeholder = lutTexture(app, 1);
+
+            appElement.setAttribute('area-light-luts', 'luts-a');
+            appElement.removeAttribute('area-light-luts');
+            parked.get('luts-a.json')!(null, tables());
+
+            expect(appElement.areaLightLuts).toBe('');
+            expect(lutTexture(app, 1)).toBe(placeholder);
+            expect(app.scene.lighting.areaLightsEnabled).toBe(false);
+        });
+
+        it('disables area lights again when removed, leaving the applied tables in place', async () => {
+            const { app, appElement } = await bootApp(LAZY_ASSETS);
+            const parked = parkLoads(app);
+
+            appElement.setAttribute('area-light-luts', 'luts-a');
+            parked.get('luts-a.json')!(null, tables());
+            const applied = lutTexture(app, 1);
+            expect(app.scene.lighting.areaLightsEnabled).toBe(true);
+
+            appElement.removeAttribute('area-light-luts');
+
+            // The engine offers no way back to its placeholder, so only the switch can be undone
+            expect(app.scene.lighting.areaLightsEnabled).toBe(false);
+            expect(lutTexture(app, 1)).toBe(applied);
+        });
+
+        it('refuses a file that is not a lookup table', async () => {
+            const { app, appElement } = await bootApp(LAZY_ASSETS);
+            const parked = parkLoads(app);
+            const placeholder = lutTexture(app, 1);
+
+            appElement.setAttribute('area-light-luts', 'luts-a');
+            parked.get('luts-a.json')!(null, { LTC_MAT_1: [1, 2, 3] });
+
+            warnings.expect(
+                "pc-asset 'luts-a' is not an area light lookup table - expected LTC_MAT_1 and LTC_MAT_2 arrays of 16384 numbers - not applied"
+            );
+            expect(lutTexture(app, 1)).toBe(placeholder);
+            expect(app.scene.lighting.areaLightsEnabled).toBe(false);
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('warns when the asset id resolves to nothing', async () => {
+            const { app } = await bootApp('', { appAttributes: 'area-light-luts="missing"' });
+
+            warnings.expect("pc-app could not find asset 'missing' - area light lookup tables not applied");
+            expect(app.scene.lighting.areaLightsEnabled).toBe(false);
+        });
+
+        it('cancels a pending load when the element is removed', async () => {
+            const { app, appElement } = await bootApp(LAZY_ASSETS);
+            const parked = parkLoads(app);
+
+            appElement.setAttribute('area-light-luts', 'luts-a');
+            const settleLoad = parked.get('luts-a.json')!;
+
+            appElement.remove();
+
+            // The application is gone, so a load settling now has nothing to apply to. The registry
+            // still completes the asset against the destroyed loader, which warns that it has no
+            // handler left - the engine's teardown, not the element's.
+            expect(() => settleLoad(null, tables())).not.toThrow();
+            warnings.allow('No resource handler found for: json');
+            expect(uncaught.seen).toEqual([]);
+        });
+
+        it('binds again when a removed element is re-inserted', async () => {
+            const { appElement, container } = await bootApp(
+                `<pc-asset id="luts" type="json" src="${jsonSrc(tables())}"></pc-asset>`,
+                { appAttributes: 'area-light-luts="luts"' }
+            );
+
+            appElement.remove();
+            container.appendChild(appElement);
+            await readyWithin(appElement);
+            await settle(container);
+
+            const app = appElement.app!;
+            app.autoRender = false;
+            expect(app.scene.lighting.areaLightsEnabled).toBe(true);
+            expect(lutTexture(app, 1).width).toBe(64);
+        });
+    });
+});

--- a/test/integration/components/light-component.test.ts
+++ b/test/integration/components/light-component.test.ts
@@ -1,5 +1,15 @@
 import type { LightComponent } from 'playcanvas';
-import { Color, Entity, SHADOW_PCF1_32F, SHADOW_PCF3_32F, SHADOW_VSM_16F } from 'playcanvas';
+import {
+    Color,
+    Entity,
+    LIGHTSHAPE_DISK,
+    LIGHTSHAPE_PUNCTUAL,
+    LIGHTSHAPE_RECT,
+    LIGHTSHAPE_SPHERE,
+    SHADOW_PCF1_32F,
+    SHADOW_PCF3_32F,
+    SHADOW_VSM_16F
+} from 'playcanvas';
 import { describe, expect, it } from 'vitest';
 
 import type { LightComponentElement } from '../../../src/components/light-component';
@@ -40,6 +50,7 @@ const cases: [attribute: string, property: string, value: string, expected: unkn
     ['shadow-resolution', 'shadowResolution', '2048', 2048, 1024],
     ['shadow-samples', 'shadowSamples', '8', 8, 16],
     ['shadow-type', 'shadowType', 'pcf1-32f', SHADOW_PCF1_32F, SHADOW_PCF3_32F],
+    ['shape', 'shape', 'rect', LIGHTSHAPE_RECT, LIGHTSHAPE_PUNCTUAL],
     ['type', 'type', 'omni', 'omni', 'directional'],
     ['vsm-bias', 'vsmBias', '0.01', 0.01, 0.0025],
     ['vsm-blur-size', 'vsmBlurSize', '5', 5, 11]
@@ -116,7 +127,7 @@ describe('<pc-light>', () => {
 
         it('falls back to the default and warns once per invalid value', async () => {
             const { get } = await bootApp(
-                scene('type="area" shadow-type="pcf7-32f" intensity="bright" shadow-bias="soft"')
+                scene('type="area" shadow-type="pcf7-32f" shape="cube" intensity="bright" shadow-bias="soft"')
             );
             const component = get<LightComponentElement>('pc-light').component!;
 
@@ -126,6 +137,9 @@ describe('<pc-light>', () => {
             warnings.expect(
                 "Invalid value 'pcf7-32f' for attribute 'shadow-type'. Valid values: pcf1-16f, pcf1-32f, pcf3-16f, pcf3-32f, pcf5-16f, pcf5-32f, vsm-16f, vsm-32f, pcss-32f. Using 'pcf3-32f'."
             );
+            warnings.expect(
+                "Invalid value 'cube' for attribute 'shape'. Valid values: punctual, rect, disk, sphere. Using 'punctual'."
+            );
             warnings.expect("Invalid value 'bright' for attribute 'intensity'. Expected a finite number. Using '1'.");
             warnings.expect(
                 "Invalid value 'soft' for attribute 'shadow-bias'. Expected a finite number. Using '0.05'."
@@ -133,8 +147,26 @@ describe('<pc-light>', () => {
 
             expect(component.type).toBe('directional');
             expect(component.shadowType).toBe(SHADOW_PCF3_32F);
+            expect(component.shape).toBe(LIGHTSHAPE_PUNCTUAL);
             expect(component.intensity).toBe(1);
             expect(component.shadowBias).toBe(0.05);
+        });
+
+        it('maps each light shape name to its own engine constant', async () => {
+            const { get } = await bootApp(scene());
+            const light = get<LightComponentElement>('pc-light');
+
+            const shapes = [
+                ['punctual', LIGHTSHAPE_PUNCTUAL],
+                ['rect', LIGHTSHAPE_RECT],
+                ['disk', LIGHTSHAPE_DISK],
+                ['sphere', LIGHTSHAPE_SPHERE]
+            ] as const;
+
+            for (const [name, constant] of shapes) {
+                light.setAttribute('shape', name);
+                expect.soft(light.component!.shape, name).toBe(constant);
+            }
         });
 
         it('maps each PCF shadow type name to its own engine constant', async () => {

--- a/test/integration/lazy.test.ts
+++ b/test/integration/lazy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { AssetElement, useAsset } from '../../src/asset';
+import { AssetElement } from '../../src/asset';
+import { useAsset } from '../../src/asset-binding';
 import { bootApp } from '../helpers/app';
 import { useGuard } from '../helpers/guard';
 

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -173,7 +173,13 @@ if (manifest) {
     expectEnum('pc-light', 'type', 3, 'directional');
     expectEnum('pc-camera', 'tonemap', 7, 'none');
     expectEnum('pc-light', 'shadow-type', 9, 'pcf3-32f');
+    expectEnum('pc-light', 'shape', 4, 'punctual');
     expectEnum('pc-scroll-view', 'horizontal-scrollbar-visibility', 2, 'when-required');
+
+    // An area light shape renders wrong until <pc-app> has loaded the lookup tables, so its tooltip
+    // has to point at the attribute that does that
+    check((attribute('pc-light', 'shape')?.description ?? '').includes('area-light-luts'),
+        `pc-light[shape] does not mention 'area-light-luts': ${JSON.stringify(attribute('pc-light', 'shape')?.description)}`);
 
     // Two-value enums that replaced booleans. Both are named for the engine property they drive, so
     // the description has to survive as well - the old names ('blend', 'orthographic') are what made
@@ -207,6 +213,13 @@ if (manifest) {
     // "no cap" / "unbreakable", which renderDefault has a dedicated branch for.
     expectAttribute('pc-app', 'max-pixel-ratio', { type: 'number', default: 'Infinity', fieldName: 'maxPixelRatio' });
     expectAttribute('pc-joint', 'break-impulse', { type: 'number', default: 'Infinity', fieldName: 'breakImpulse' });
+
+    // The lookup table attribute names a pc-asset, so it publishes no default - and loading that
+    // asset is also what switches area lights on, which the tooltip has to say
+    check(attribute('pc-app', 'area-light-luts')?.default === undefined,
+        'pc-app[area-light-luts] should have no default');
+    check(/area lights/.test(attribute('pc-app', 'area-light-luts')?.description ?? ''),
+        `pc-app[area-light-luts] lost its descriptive tooltip: ${JSON.stringify(attribute('pc-app', 'area-light-luts')?.description)}`);
 
     // pc-joint's remaining shapes: enums from inline arrays, a Vec2 default with negative
     // components, and string entity references


### PR DESCRIPTION
## What

Declarative area lights, mirroring the engine's two knobs with one switch:

- `<pc-light shape="punctual|rect|disk|sphere">` maps to `LightComponent.shape` through a `Map` to the `LIGHTSHAPE_*` constants (the `shadowTypes` pattern). Default `punctual`, matching the engine. A `LightShape` type is exported.
- `<pc-app area-light-luts="asset-id">` binds a `json` `<pc-asset>` holding the LTC lookup tables in the format of the engine examples' `area-light-luts.json` (`LTC_MAT_1` and `LTC_MAT_2`, 16384 numbers each), hands it to `app.setAreaLightLuts` and then sets `app.scene.lighting.areaLightsEnabled = true`. Removing the attribute disables area lights again; a file that is not a lookup table is refused with a warning.

```html
<pc-app area-light-luts="luts">
    <pc-asset id="luts" src="assets/json/area-light-luts.json"></pc-asset>
    <pc-scene>
        <!-- A 3 x 1.5 m softbox: the light's size is the entity's scale -->
        <pc-entity name="softbox" position="-3 4 1" rotation="-35 -45 0" scale="3 1 1.5">
            <pc-light type="spot" shape="rect" intensity="4" range="40"
                      inner-cone-angle="80" outer-cone-angle="85"></pc-light>
        </pc-entity>
    </pc-scene>
</pc-app>
```

## Why this shape

- The engine installs an all-zero placeholder for the tables at init. With it, rect and sphere lights are diffuse-only, **disk lights emit nothing**, and no shape has specular. Enabling `areaLightsEnabled` without tables is therefore never useful, and loading tables without enabling it leaves omni/spot area lights punctual under clustered lighting (the default, and mandatory on WebGPU). One attribute makes half-configured markup impossible.
- The tables are device textures set through an `AppBase` method, so they are app-wide and belong on `pc-app`, not `pc-scene` - a future `pc-app` holding several `pc-scene` levels must not reload them per level. The flag it sets lives on the engine's single `Scene`, which `pc-scene` never writes to, so it survives a scene switch.
- The flag is set only after a valid apply and cleared on removal. Tables already handed to the engine stay, because `AreaLightLuts.createPlaceholder` is not public.
- Directional area lights never needed the clustered flag, so a page with only those pays the clustered area-light shader path with no opt-out. Accepted.

## Reviewer notes

- **Define order.** Importing `AssetBinding` into `app.ts` pulled `asset.ts` in first, which defined `pc-asset` before `pc-app` and made every example page throw `appElement.ready is not a function` once per asset - while tests, lint, type-check and the manifest validation all stayed green (tests define the whole library before mounting markup). The asset resolution (`findAsset`/`useAsset`) now lives in `asset-binding.ts` behind a type-only import of `AssetElement`; `asset.ts` re-exports `useAsset`, so no importer changed, and `AssetElement.get` delegates to `findAsset`. `dist/pwc.mjs` defines `pc-wasm, pc-app, pc-entity, ...` again.
- `utils/cem/validate.mjs` pins the new enum, requires the `pc-light[shape]` tooltip to name `area-light-luts`, and pins `pc-app[area-light-luts]` as a no-default attribute with a description.
- The new `test/integration/app-area-lights.test.ts` asserts on the real device textures (the shared 2x2 placeholder becomes two distinct 64x64 tables) rather than a spy, and covers preload ordering, lazy loads, supersede, clear, malformed files, missing ids and remove/re-insert. The attribute-removal table grows to 28.

## Verification

- `npm run build` (manifest analyzed and validated), `npm run lint`, `npm run type-check`, `npm test`: 1249 tests green.
- Runtime on WebGPU with the engine's `area-light-luts.json`: both tables bound as distinct 64x64 textures, `areaLightsEnabled` true, all three shapes reaching the engine, soft rect/disk/sphere reflections on screen, hard highlights after switching the lights to `punctual`, and the flag toggling false/true on removing and re-adding the attribute. No console errors on this or the existing examples.

## Not in this PR

- A showcase example (dark studio with a softbox, beauty dish and bulb over a glossy floor) is deferred to a follow-up PR.
- User Manual pages for `pc-light` and `pc-app` in developer-site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
