### PR TITLE
Align component attribute defaults with the engine

### DIFF
--- a/examples/2d-screen.html
+++ b/examples/2d-screen.html
@@ -30,13 +30,13 @@
                 <pc-entity name="screen">
                     <pc-screen screen-space></pc-screen>
                     <pc-entity name="text" position="0 40 0">
-                        <pc-element type="text" font-asset="arial" anchor="0.5 0.5 0.5 0.5" text="This is Arial"></pc-element>
+                        <pc-element type="text" font-asset="arial" anchor="0.5 0.5 0.5 0.5" pivot="0.5 0.5" text="This is Arial"></pc-element>
                     </pc-entity>
                     <pc-entity name="text2">
-                        <pc-element type="text" font-asset="courier" anchor="0.5 0.5 0.5 0.5" text="This is Courier"></pc-element>
+                        <pc-element type="text" font-asset="courier" anchor="0.5 0.5 0.5 0.5" pivot="0.5 0.5" text="This is Courier"></pc-element>
                     </pc-entity>
                     <pc-entity name="text3" position="0 -40 0">
-                        <pc-element type="text" font-asset="arial" anchor="0.5 0.5 0.5 0.5" enable-markup text='[color="#ff0000"]Red[/color] [color="#00ff00"]Green[/color] [color="#0088ff"]Blue[/color]'></pc-element>
+                        <pc-element type="text" font-asset="arial" anchor="0.5 0.5 0.5 0.5" pivot="0.5 0.5" enable-markup text='[color="#ff0000"]Red[/color] [color="#00ff00"]Green[/color] [color="#0088ff"]Blue[/color]'></pc-element>
                     </pc-entity>
                 </pc-entity>
             </pc-scene>

--- a/examples/2d-screen.html
+++ b/examples/2d-screen.html
@@ -30,13 +30,13 @@
                 <pc-entity name="screen">
                     <pc-screen screen-space></pc-screen>
                     <pc-entity name="text" position="0 40 0">
-                        <pc-element type="text" font-asset="arial" text="This is Arial"></pc-element>
+                        <pc-element type="text" font-asset="arial" anchor="0.5 0.5 0.5 0.5" text="This is Arial"></pc-element>
                     </pc-entity>
                     <pc-entity name="text2">
-                        <pc-element type="text" font-asset="courier" text="This is Courier"></pc-element>
+                        <pc-element type="text" font-asset="courier" anchor="0.5 0.5 0.5 0.5" text="This is Courier"></pc-element>
                     </pc-entity>
                     <pc-entity name="text3" position="0 -40 0">
-                        <pc-element type="text" font-asset="arial" enable-markup text='[color="#ff0000"]Red[/color] [color="#00ff00"]Green[/color] [color="#0088ff"]Blue[/color]'></pc-element>
+                        <pc-element type="text" font-asset="arial" anchor="0.5 0.5 0.5 0.5" enable-markup text='[color="#ff0000"]Red[/color] [color="#00ff00"]Green[/color] [color="#0088ff"]Blue[/color]'></pc-element>
                     </pc-entity>
                 </pc-entity>
             </pc-scene>

--- a/examples/basic-sound.html
+++ b/examples/basic-sound.html
@@ -38,7 +38,7 @@
                 <pc-model asset="nyan-cat"></pc-model>
                 <!-- Music -->
                 <pc-entity name="music">
-                    <pc-sound>
+                    <pc-sound positional="false">
                         <pc-sound-slot asset="music" auto-play loop></pc-sound-slot>
                     </pc-sound>
                 </pc-entity>

--- a/examples/falling-blocks.html
+++ b/examples/falling-blocks.html
@@ -398,7 +398,7 @@
                                             flash-duration="0.25"></pc-script-instance>
                         <pc-script-instance name="touchControls" drag-cell="24" drag-row="28"></pc-script-instance>
                     </pc-script>
-                    <pc-sound>
+                    <pc-sound positional="false">
                         <pc-sound-slot name="rotate" asset="rotate-sound" overlap volume="0.6"></pc-sound-slot>
                         <pc-sound-slot name="drop" asset="drop-sound" overlap></pc-sound-slot>
                         <!-- The lock tick reuses the drop sample, pitched down and quieter -->

--- a/examples/falling-blocks.html
+++ b/examples/falling-blocks.html
@@ -375,7 +375,7 @@
 
                 <!-- World-space marquee above the well -->
                 <pc-entity name="marquee" position="0 22.2 -0.2">
-                    <pc-element type="text" font-asset="orbitron" text="FALLING BLOCKS" color="#ff3df0" font-size="1.1"></pc-element>
+                    <pc-element type="text" font-asset="orbitron" pivot="0.5 0.5" text="FALLING BLOCKS" color="#ff3df0" font-size="1.1"></pc-element>
                 </pc-entity>
 
                 <!-- The game. Dynamic block entities are spawned under this entity by

--- a/examples/text.html
+++ b/examples/text.html
@@ -28,7 +28,7 @@
                 </pc-entity>
                 <!-- Text -->
                 <pc-entity name="crawl-text" position="0 -2 0" rotation="-72 0 0">
-                    <pc-element type="text" font-asset="trade-gothic" color="#ffe81f" auto-width="false" font-size="0.2" line-height="0.25" width="2.65" wrap-lines text="It is a period of civil war.
+                    <pc-element type="text" font-asset="trade-gothic" pivot="0.5 0.5" color="#ffe81f" auto-width="false" font-size="0.2" line-height="0.25" width="2.65" wrap-lines text="It is a period of civil war.
 Rebel spaceships, striking
 from a hidden base, have won
 their first victory against

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -200,7 +200,7 @@ class ButtonComponentElement extends ComponentElement<ButtonComponent> {
 
     /**
      * Sets the tint color applied to the image entity when the button is hovered (tint transition
-     * mode). Defaults to the engine's `0.75 0.75 0.75 1`.
+     * mode). Defaults to `0.75 0.75 0.75 1`.
      * @param value - The hover tint.
      */
     set hoverTint(value: Color) {
@@ -220,7 +220,7 @@ class ButtonComponentElement extends ComponentElement<ButtonComponent> {
 
     /**
      * Sets the tint color applied to the image entity when the button is pressed (tint transition
-     * mode). Defaults to the engine's `0.5 0.5 0.5 1`.
+     * mode). Defaults to `0.5 0.5 0.5 1`.
      * @param value - The pressed tint.
      */
     set pressedTint(value: Color) {
@@ -240,7 +240,7 @@ class ButtonComponentElement extends ComponentElement<ButtonComponent> {
 
     /**
      * Sets the tint color applied to the image entity when the button is inactive (tint transition
-     * mode). Defaults to the engine's `0.25 0.25 0.25 1`.
+     * mode). Defaults to `0.25 0.25 0.25 1`.
      * @param value - The inactive tint.
      */
     set inactiveTint(value: Color) {

--- a/src/components/button-component.ts
+++ b/src/components/button-component.ts
@@ -36,11 +36,11 @@ class ButtonComponentElement extends ComponentElement<ButtonComponent> {
 
     private _transitionMode: 'tint' | 'sprite' = 'tint';
 
-    private _hoverTint = new Color(1, 1, 1, 1);
+    private _hoverTint = new Color(0.75, 0.75, 0.75, 1);
 
-    private _pressedTint = new Color(1, 1, 1, 1);
+    private _pressedTint = new Color(0.5, 0.5, 0.5, 1);
 
-    private _inactiveTint = new Color(1, 1, 1, 1);
+    private _inactiveTint = new Color(0.25, 0.25, 0.25, 1);
 
     private _fadeDuration = 0;
 
@@ -200,7 +200,7 @@ class ButtonComponentElement extends ComponentElement<ButtonComponent> {
 
     /**
      * Sets the tint color applied to the image entity when the button is hovered (tint transition
-     * mode).
+     * mode). Defaults to the engine's `0.75 0.75 0.75 1`.
      * @param value - The hover tint.
      */
     set hoverTint(value: Color) {
@@ -220,7 +220,7 @@ class ButtonComponentElement extends ComponentElement<ButtonComponent> {
 
     /**
      * Sets the tint color applied to the image entity when the button is pressed (tint transition
-     * mode).
+     * mode). Defaults to the engine's `0.5 0.5 0.5 1`.
      * @param value - The pressed tint.
      */
     set pressedTint(value: Color) {
@@ -240,7 +240,7 @@ class ButtonComponentElement extends ComponentElement<ButtonComponent> {
 
     /**
      * Sets the tint color applied to the image entity when the button is inactive (tint transition
-     * mode).
+     * mode). Defaults to the engine's `0.25 0.25 0.25 1`.
      * @param value - The inactive tint.
      */
     set inactiveTint(value: Color) {
@@ -434,13 +434,13 @@ class ButtonComponentElement extends ComponentElement<ButtonComponent> {
                 this.transitionMode = parseEnum(newValue, transitionModes, 'tint', name);
                 break;
             case 'hover-tint':
-                this.hoverTint = parseColor(newValue, Color.WHITE, name);
+                this.hoverTint = parseColor(newValue, new Color(0.75, 0.75, 0.75, 1), name);
                 break;
             case 'pressed-tint':
-                this.pressedTint = parseColor(newValue, Color.WHITE, name);
+                this.pressedTint = parseColor(newValue, new Color(0.5, 0.5, 0.5, 1), name);
                 break;
             case 'inactive-tint':
-                this.inactiveTint = parseColor(newValue, Color.WHITE, name);
+                this.inactiveTint = parseColor(newValue, new Color(0.25, 0.25, 0.25, 1), name);
                 break;
             case 'fade-duration':
                 this.fadeDuration = parseNumber(newValue, 0, name);

--- a/src/components/camera-component.ts
+++ b/src/components/camera-component.ts
@@ -87,7 +87,7 @@ class CameraComponentElement extends ComponentElement<CameraComponent> {
 
     private _scissorRect = new Vec4(0, 0, 1, 1);
 
-    private _tonemap: 'none' | 'linear' | 'filmic' | 'hejl' | 'aces' | 'aces2' | 'neutral' = 'none';
+    private _tonemap: 'none' | 'linear' | 'filmic' | 'hejl' | 'aces' | 'aces2' | 'neutral' = 'linear';
 
     /** @ignore */
     constructor() {
@@ -114,7 +114,7 @@ class CameraComponentElement extends ComponentElement<CameraComponent> {
             priority: this._priority,
             rect: this._rect,
             scissorRect: this._scissorRect,
-            toneMapping: tonemaps.get(this._tonemap) ?? TONEMAP_NONE
+            toneMapping: tonemaps.get(this._tonemap) ?? TONEMAP_LINEAR
         };
     }
 
@@ -529,13 +529,15 @@ class CameraComponentElement extends ComponentElement<CameraComponent> {
     }
 
     /**
-     * Sets the tone mapping of the camera.
+     * Sets the tone mapping of the camera. Can be `none`, `linear`, `filmic`, `hejl`, `aces`,
+     * `aces2` or `neutral`. Defaults to `linear`, which applies the scene exposure and nothing
+     * else; `none` skips the exposure too.
      * @param value - The tone mapping.
      */
     set tonemap(value: 'none' | 'linear' | 'filmic' | 'hejl' | 'aces' | 'aces2' | 'neutral') {
         this._tonemap = value;
         if (this.component) {
-            this.component.toneMapping = tonemaps.get(value) ?? TONEMAP_NONE;
+            this.component.toneMapping = tonemaps.get(value) ?? TONEMAP_LINEAR;
         }
     }
 
@@ -631,7 +633,7 @@ class CameraComponentElement extends ComponentElement<CameraComponent> {
                 this.scissorRect = parseVec4(newValue, new Vec4(0, 0, 1, 1), name);
                 break;
             case 'tonemap':
-                this.tonemap = parseEnum(newValue, tonemaps, 'none', name);
+                this.tonemap = parseEnum(newValue, tonemaps, 'linear', name);
                 break;
         }
     }

--- a/src/components/element-component.ts
+++ b/src/components/element-component.ts
@@ -26,7 +26,7 @@ import { ComponentElement } from './component';
  * @category Components
  */
 class ElementComponentElement extends ComponentElement<ElementComponent> {
-    private _anchor: Vec4 = new Vec4(0.5, 0.5, 0.5, 0.5);
+    private _anchor: Vec4 = new Vec4(0, 0, 0, 0);
 
     private _autoWidth = true;
 
@@ -167,7 +167,9 @@ class ElementComponentElement extends ComponentElement<ElementComponent> {
     }
 
     /**
-     * Sets the anchor of the element component.
+     * Sets the anchor of the element component: the left, bottom, right and top edges as fractions
+     * of the parent's size, in that order. Defaults to the engine's `0 0 0 0`, the parent's
+     * bottom-left corner; `0.5 0.5 0.5 0.5` centers the element.
      * @param value - The anchor.
      */
     set anchor(value: Vec4) {
@@ -705,7 +707,7 @@ class ElementComponentElement extends ComponentElement<ElementComponent> {
 
         switch (name) {
             case 'anchor':
-                this.anchor = parseVec4(newValue, new Vec4(0.5, 0.5, 0.5, 0.5), name);
+                this.anchor = parseVec4(newValue, new Vec4(0, 0, 0, 0), name);
                 break;
             case 'auto-width':
                 this.autoWidth = parseBool(newValue, true);

--- a/src/components/element-component.ts
+++ b/src/components/element-component.ts
@@ -48,7 +48,7 @@ class ElementComponentElement extends ComponentElement<ElementComponent> {
 
     private _minFontSize = 8;
 
-    private _height = 0;
+    private _height = 32;
 
     private _lineHeight = 32;
 
@@ -58,7 +58,7 @@ class ElementComponentElement extends ComponentElement<ElementComponent> {
 
     private _opacity = 1;
 
-    private _pivot: Vec2 = new Vec2(0.5, 0.5);
+    private _pivot: Vec2 = new Vec2(0, 0);
 
     private _pixelsPerUnit: number | null = null;
 
@@ -74,7 +74,7 @@ class ElementComponentElement extends ComponentElement<ElementComponent> {
 
     private _useInput = false;
 
-    private _width = 0;
+    private _width = 32;
 
     private _wrapLines = false;
 
@@ -305,7 +305,7 @@ class ElementComponentElement extends ComponentElement<ElementComponent> {
     }
 
     /**
-     * Sets the height of the element component.
+     * Sets the height of the element component. Defaults to the engine's 32.
      * @param value - The height.
      */
     set height(value: number) {
@@ -401,7 +401,9 @@ class ElementComponentElement extends ComponentElement<ElementComponent> {
     }
 
     /**
-     * Sets the pivot of the element component.
+     * Sets the pivot of the element component: the point within its rectangle, as fractions of
+     * its width and height, that sits on its position and that it rotates and scales about.
+     * Defaults to the engine's `0 0`, the bottom-left corner; `0.5 0.5` centers it.
      * @param value - The pivot.
      */
     set pivot(value: Vec2) {
@@ -555,7 +557,7 @@ class ElementComponentElement extends ComponentElement<ElementComponent> {
     }
 
     /**
-     * Sets the width of the element component.
+     * Sets the width of the element component. Defaults to the engine's 32.
      * @param value - The width.
      */
     set width(value: number) {
@@ -740,7 +742,7 @@ class ElementComponentElement extends ComponentElement<ElementComponent> {
                 this.minFontSize = parseNumber(newValue, 8, name);
                 break;
             case 'height':
-                this.height = parseNumber(newValue, 0, name);
+                this.height = parseNumber(newValue, 32, name);
                 break;
             case 'line-height':
                 this.lineHeight = parseNumber(newValue, 32, name);
@@ -755,7 +757,7 @@ class ElementComponentElement extends ComponentElement<ElementComponent> {
                 this.opacity = parseNumber(newValue, 1, name);
                 break;
             case 'pivot':
-                this.pivot = parseVec2(newValue, new Vec2(0.5, 0.5), name);
+                this.pivot = parseVec2(newValue, new Vec2(0, 0), name);
                 break;
             case 'pixels-per-unit':
                 this.pixelsPerUnit = parseNumber(newValue, null, name);
@@ -779,7 +781,7 @@ class ElementComponentElement extends ComponentElement<ElementComponent> {
                 this.useInput = parseBool(newValue, false);
                 break;
             case 'width':
-                this.width = parseNumber(newValue, 0, name);
+                this.width = parseNumber(newValue, 32, name);
                 break;
             case 'wrap-lines':
                 this.wrapLines = parseBool(newValue, false);

--- a/src/components/element-component.ts
+++ b/src/components/element-component.ts
@@ -168,7 +168,7 @@ class ElementComponentElement extends ComponentElement<ElementComponent> {
 
     /**
      * Sets the anchor of the element component: the left, bottom, right and top edges as fractions
-     * of the parent's size, in that order. Defaults to the engine's `0 0 0 0`, the parent's
+     * of the parent's size, in that order. Defaults to `0 0 0 0`, the parent's
      * bottom-left corner; `0.5 0.5 0.5 0.5` centers the element.
      * @param value - The anchor.
      */
@@ -305,7 +305,7 @@ class ElementComponentElement extends ComponentElement<ElementComponent> {
     }
 
     /**
-     * Sets the height of the element component. Defaults to the engine's 32.
+     * Sets the height of the element component. Defaults to 32.
      * @param value - The height.
      */
     set height(value: number) {
@@ -403,7 +403,7 @@ class ElementComponentElement extends ComponentElement<ElementComponent> {
     /**
      * Sets the pivot of the element component: the point within its rectangle, as fractions of
      * its width and height, that sits on its position and that it rotates and scales about.
-     * Defaults to the engine's `0 0`, the bottom-left corner; `0.5 0.5` centers it.
+     * Defaults to `0 0`, the bottom-left corner; `0.5 0.5` centers it.
      * @param value - The pivot.
      */
     set pivot(value: Vec2) {
@@ -557,7 +557,7 @@ class ElementComponentElement extends ComponentElement<ElementComponent> {
     }
 
     /**
-     * Sets the width of the element component. Defaults to the engine's 32.
+     * Sets the width of the element component. Defaults to 32.
      * @param value - The width.
      */
     set width(value: number) {

--- a/src/components/layout-group-component.ts
+++ b/src/components/layout-group-component.ts
@@ -45,7 +45,7 @@ class LayoutGroupComponentElement extends ComponentElement<LayoutGroupComponent>
 
     private _reverseX = false;
 
-    private _reverseY = false;
+    private _reverseY = true;
 
     private _alignment = new Vec2(0, 1);
 
@@ -127,7 +127,8 @@ class LayoutGroupComponentElement extends ComponentElement<LayoutGroupComponent>
     }
 
     /**
-     * Sets whether the order of children is reversed along the vertical axis.
+     * Sets whether the order of children is reversed along the vertical axis. Defaults to true, so
+     * a vertical group lays its children out from the top down.
      * @param value - Whether to reverse the vertical order.
      */
     set reverseY(value: boolean) {
@@ -287,7 +288,7 @@ class LayoutGroupComponentElement extends ComponentElement<LayoutGroupComponent>
                 this.reverseX = parseBool(newValue, false);
                 break;
             case 'reverse-y':
-                this.reverseY = parseBool(newValue, false);
+                this.reverseY = parseBool(newValue, true);
                 break;
             case 'alignment':
                 this.alignment = parseVec2(newValue, new Vec2(0, 1), name);

--- a/src/components/render-component.ts
+++ b/src/components/render-component.ts
@@ -39,12 +39,20 @@ class RenderComponentElement extends ComponentElement<RenderComponent> {
     }
 
     protected getInitialComponentData() {
-        return {
+        const data: Record<string, unknown> = {
             type: this._type,
             castShadows: this._castShadows,
-            material: MaterialElement.get(this._material),
             receiveShadows: this._receiveShadows
         };
+
+        // Only a resolved material is passed on: an undefined one would replace the engine's
+        // default material with nothing at the component level
+        const material = MaterialElement.get(this._material);
+        if (material) {
+            data.material = material;
+        }
+
+        return data;
     }
 
     /**

--- a/src/components/scroll-view-component.ts
+++ b/src/components/scroll-view-component.ts
@@ -53,9 +53,9 @@ class ScrollViewComponentElement extends ComponentElement<ScrollViewComponent> {
 
     private _mouseWheelSensitivity = new Vec2(1, 1);
 
-    private _horizontalScrollbarVisibility: 'always' | 'when-required' = 'when-required';
+    private _horizontalScrollbarVisibility: 'always' | 'when-required' = 'always';
 
-    private _verticalScrollbarVisibility: 'always' | 'when-required' = 'when-required';
+    private _verticalScrollbarVisibility: 'always' | 'when-required' = 'always';
 
     private _viewport = '';
 
@@ -255,7 +255,7 @@ class ScrollViewComponentElement extends ComponentElement<ScrollViewComponent> {
 
     /**
      * Sets the visibility of the horizontal scrollbar. Can be `always` or `when-required`.
-     * Defaults to `when-required`.
+     * Defaults to `always`.
      * @param value - The horizontal scrollbar visibility.
      */
     set horizontalScrollbarVisibility(value: 'always' | 'when-required') {
@@ -276,7 +276,7 @@ class ScrollViewComponentElement extends ComponentElement<ScrollViewComponent> {
 
     /**
      * Sets the visibility of the vertical scrollbar. Can be `always` or `when-required`.
-     * Defaults to `when-required`.
+     * Defaults to `always`.
      * @param value - The vertical scrollbar visibility.
      */
     set verticalScrollbarVisibility(value: 'always' | 'when-required') {
@@ -444,10 +444,10 @@ class ScrollViewComponentElement extends ComponentElement<ScrollViewComponent> {
                 this.mouseWheelSensitivity = parseVec2(newValue, Vec2.ONE, name);
                 break;
             case 'horizontal-scrollbar-visibility':
-                this.horizontalScrollbarVisibility = parseEnum(newValue, visibilities, 'when-required', name);
+                this.horizontalScrollbarVisibility = parseEnum(newValue, visibilities, 'always', name);
                 break;
             case 'vertical-scrollbar-visibility':
-                this.verticalScrollbarVisibility = parseEnum(newValue, visibilities, 'when-required', name);
+                this.verticalScrollbarVisibility = parseEnum(newValue, visibilities, 'always', name);
                 break;
             case 'viewport':
                 this.viewport = newValue ?? '';

--- a/src/components/scrollbar-component.ts
+++ b/src/components/scrollbar-component.ts
@@ -30,7 +30,7 @@ class ScrollbarComponentElement extends ComponentElement<ScrollbarComponent> {
 
     private _value = 0;
 
-    private _handleSize = 0.5;
+    private _handleSize = 0;
 
     private _handle = '';
 
@@ -104,6 +104,7 @@ class ScrollbarComponentElement extends ComponentElement<ScrollbarComponent> {
 
     /**
      * Sets the size of the handle relative to the size of the track, in the range 0 to 1.
+     * Defaults to 0.
      * @param value - The handle size.
      */
     set handleSize(value: number) {
@@ -162,7 +163,7 @@ class ScrollbarComponentElement extends ComponentElement<ScrollbarComponent> {
                 this.value = parseNumber(newValue, 0, name);
                 break;
             case 'handle-size':
-                this.handleSize = parseNumber(newValue, 0.5, name);
+                this.handleSize = parseNumber(newValue, 0, name);
                 break;
             case 'handle':
                 this.handle = newValue ?? '';

--- a/src/components/sound-component.ts
+++ b/src/components/sound-component.ts
@@ -25,7 +25,7 @@ class SoundComponentElement extends ComponentElement<SoundComponent> {
 
     private _pitch = 1;
 
-    private _positional = false;
+    private _positional = true;
 
     private _refDistance = 1;
 
@@ -117,7 +117,8 @@ class SoundComponentElement extends ComponentElement<SoundComponent> {
     }
 
     /**
-     * Sets the positional flag of the sound.
+     * Sets whether the sounds play positionally, attenuated by their distance from the audio
+     * listener. Defaults to true.
      * @param value - The positional flag.
      */
     set positional(value: boolean) {
@@ -128,7 +129,7 @@ class SoundComponentElement extends ComponentElement<SoundComponent> {
     }
 
     /**
-     * Gets the positional flag of the sound.
+     * Gets whether the sounds play positionally.
      * @returns The positional flag.
      */
     get positional() {
@@ -219,7 +220,7 @@ class SoundComponentElement extends ComponentElement<SoundComponent> {
                 this.pitch = parseNumber(newValue, 1, name);
                 break;
             case 'positional':
-                this.positional = parseBool(newValue, false);
+                this.positional = parseBool(newValue, true);
                 break;
             case 'ref-distance':
                 this.refDistance = parseNumber(newValue, 1, name);

--- a/test/integration/components/button-component.test.ts
+++ b/test/integration/components/button-component.test.ts
@@ -1,20 +1,116 @@
+import type { ButtonComponent } from 'playcanvas';
+import { BUTTON_TRANSITION_MODE_SPRITE_CHANGE, BUTTON_TRANSITION_MODE_TINT, Color, Entity, Vec4 } from 'playcanvas';
 import { describe, expect, it } from 'vitest';
 
 import type { ButtonComponentElement } from '../../../src/components/button-component';
 import { bootApp } from '../../helpers/app';
 import { useGuard } from '../../helpers/guard';
 
+const scene = (buttonAttributes = '') =>
+    `<pc-entity name="btn"><pc-button ${buttonAttributes}></pc-button></pc-entity>`;
+
+/** Reads an engine component property named by a table row. */
+const engineValue = (component: ButtonComponent, property: string) =>
+    (component as unknown as Record<string, unknown>)[property];
+
 /**
- * Only the [image] entity reference is covered here. The resolution and reporting contract is
- * shared with every reference-resolving element and pinned once in entity-reference.test.ts; these
- * tests pin this element's wiring - which attribute resolves, the own-entity default, and what
- * an unresolved reference leaves behind.
+ * One row per plain-valued attribute: the attribute, the engine property behind it, a non-default
+ * value, what the engine must report for it, and the default that removal must restore. Ordered
+ * by `observedAttributes`. The asset references ([hover-sprite-asset] and friends) and the [image]
+ * entity reference are covered below and in entity-reference.test.ts.
+ *
+ * Every `restored` value is the engine's own default. The three tints used to be white - a
+ * button with no tint attributes gave no feedback at all - which is what `matches a button the
+ * engine built itself` now holds them to.
+ */
+const cases: [attribute: string, property: string, value: string, expected: unknown, restored: unknown][] = [
+    ['active', 'active', 'false', false, true],
+    ['fade-duration', 'fadeDuration', '150', 150, 0],
+    ['hit-padding', 'hitPadding', '1 2 3 4', new Vec4(1, 2, 3, 4), new Vec4(0, 0, 0, 0)],
+    ['hover-sprite-frame', 'hoverSpriteFrame', '2', 2, 0],
+    ['hover-tint', 'hoverTint', '1 0 0', new Color(1, 0, 0), new Color(0.75, 0.75, 0.75, 1)],
+    ['inactive-sprite-frame', 'inactiveSpriteFrame', '3', 3, 0],
+    ['inactive-tint', 'inactiveTint', '0 0 1', new Color(0, 0, 1), new Color(0.25, 0.25, 0.25, 1)],
+    ['pressed-sprite-frame', 'pressedSpriteFrame', '4', 4, 0],
+    ['pressed-tint', 'pressedTint', '0 1 0', new Color(0, 1, 0), new Color(0.5, 0.5, 0.5, 1)],
+    ['transition-mode', 'transitionMode', 'sprite', BUTTON_TRANSITION_MODE_SPRITE_CHANGE, BUTTON_TRANSITION_MODE_TINT]
+];
+
+/**
+ * The [image] entity reference is covered under its own heading. The resolution and reporting
+ * contract is shared with every reference-resolving element and pinned once in
+ * entity-reference.test.ts; those tests pin this element's wiring - which attribute resolves, the
+ * own-entity default, and what an unresolved reference leaves behind.
  */
 describe('<pc-button>', () => {
     const { warnings } = useGuard();
 
+    describe('#component', () => {
+        it('creates the button component with the engine defaults', async () => {
+            const { get } = await bootApp(scene());
+            const component = get<ButtonComponentElement>('pc-button').component!;
+
+            expect(component).toBeDefined();
+            expect(component.enabled).toBe(true);
+
+            for (const [attribute, property, , , restored] of cases) {
+                expect.soft(engineValue(component, property), attribute).toEqual(restored);
+            }
+        });
+
+        it('matches a button the engine built itself', async () => {
+            const { app, get } = await bootApp(scene());
+            const element = get<ButtonComponentElement>('pc-button').component!;
+
+            // Every plain property the element writes, compared against a component built from
+            // no data at all, so a default drifting on either side shows up here.
+            const bare = new Entity('bare', app);
+            app.root.addChild(bare);
+            const engine = bare.addComponent('button') as ButtonComponent;
+
+            for (const [attribute, property] of cases) {
+                expect
+                    .soft(engineValue(element, property), `${attribute} vs a bare engine button`)
+                    .toEqual(engineValue(engine, property));
+            }
+        });
+    });
+
+    describe('attributes', () => {
+        it('applies every declarative attribute through the initial component data', async () => {
+            const markup = cases.map(([attribute, , value]) => `${attribute}="${value}"`).join(' ');
+            const { get } = await bootApp(scene(markup));
+            const component = get<ButtonComponentElement>('pc-button').component!;
+
+            for (const [attribute, property, , expected] of cases) {
+                expect.soft(engineValue(component, property), attribute).toEqual(expected);
+            }
+        });
+
+        it('writes attribute changes through to the component', async () => {
+            const { get } = await bootApp(scene());
+            const button = get<ButtonComponentElement>('pc-button');
+
+            for (const [attribute, property, value, expected] of cases) {
+                button.setAttribute(attribute, value);
+                expect.soft(engineValue(button.component!, property), attribute).toEqual(expected);
+            }
+        });
+
+        it('restores the engine default when an attribute is removed', async () => {
+            const { get } = await bootApp(scene());
+            const button = get<ButtonComponentElement>('pc-button');
+
+            for (const [attribute, property, value, , restored] of cases) {
+                button.setAttribute(attribute, value);
+                button.removeAttribute(attribute);
+                expect.soft(engineValue(button.component!, property), attribute).toEqual(restored);
+            }
+        });
+    });
+
     describe('[image]', () => {
-        it('defaults the image entity to the button\'s own entity', async () => {
+        it("defaults the image entity to the button's own entity", async () => {
             const { app, get } = await bootApp('<pc-entity name="btn"><pc-button></pc-button></pc-entity>');
             const button = get<ButtonComponentElement>('pc-button');
 
@@ -35,7 +131,9 @@ describe('<pc-button>', () => {
             const { get } = await bootApp('<pc-entity name="btn"><pc-button image="#nope"></pc-button></pc-entity>');
             const button = get<ButtonComponentElement>('pc-button');
 
-            warnings.expect("pc-button could not resolve image '#nope' - nothing in the document matches it - reference ignored");
+            warnings.expect(
+                "pc-button could not resolve image '#nope' - nothing in the document matches it - reference ignored"
+            );
             expect(button.component!.imageEntity).toBeNull();
         });
 

--- a/test/integration/components/camera-component.test.ts
+++ b/test/integration/components/camera-component.test.ts
@@ -7,7 +7,7 @@ import {
     PROJECTION_ORTHOGRAPHIC,
     PROJECTION_PERSPECTIVE,
     TONEMAP_ACES,
-    TONEMAP_NONE,
+    TONEMAP_LINEAR,
     XRTYPE_AR,
     XRTYPE_VR
 } from 'playcanvas';
@@ -76,10 +76,10 @@ const cases: [attribute: string, property: string, value: string, expected: unkn
     ['projection', 'projection', 'orthographic', PROJECTION_ORTHOGRAPHIC, PROJECTION_PERSPECTIVE],
     ['rect', 'rect', '0 0 0.5 1', new Vec4(0, 0, 0.5, 1), new Vec4(0, 0, 1, 1)],
     ['scissor-rect', 'scissorRect', '0 0 0.5 0.5', new Vec4(0, 0, 0.5, 0.5), new Vec4(0, 0, 1, 1)],
-    // The one exception: the engine defaults toneMapping to TONEMAP_LINEAR and this element writes
-    // TONEMAP_NONE. The two diverge only once Scene#exposure moves off 1, which no attribute
-    // reaches, so the deviation is pinned here rather than changed under existing apps.
-    ['tonemap', 'toneMapping', 'aces', TONEMAP_ACES, TONEMAP_NONE]
+    // Used to be the one exception, writing TONEMAP_NONE: the two only differ once the scene
+    // exposure leaves 1, which no attribute could reach at the time. pc-scene[exposure] can now,
+    // and TONEMAP_NONE would ignore it, so the engine default holds here too.
+    ['tonemap', 'toneMapping', 'aces', TONEMAP_ACES, TONEMAP_LINEAR]
 ];
 
 describe('<pc-camera>', () => {
@@ -144,7 +144,7 @@ describe('<pc-camera>', () => {
                 "Invalid value 'isometric' for attribute 'projection'. Valid values: perspective, orthographic. Using 'perspective'."
             );
             warnings.expect(
-                "Invalid value 'reinhard' for attribute 'tonemap'. Valid values: none, linear, filmic, hejl, aces, aces2, neutral. Using 'none'."
+                "Invalid value 'reinhard' for attribute 'tonemap'. Valid values: none, linear, filmic, hejl, aces, aces2, neutral. Using 'linear'."
             );
             warnings.expect(
                 "Invalid value '0 0' for attribute 'rect'. Expected 4 space-separated numbers. Using '[0, 0, 1, 1]'."
@@ -153,7 +153,7 @@ describe('<pc-camera>', () => {
 
             expect(component.fov).toBe(45);
             expect(component.projection).toBe(PROJECTION_PERSPECTIVE);
-            expect(component.toneMapping).toBe(TONEMAP_NONE);
+            expect(component.toneMapping).toBe(TONEMAP_LINEAR);
             expect(component.rect).toEqual(new Vec4(0, 0, 1, 1));
             expect(component.clearDepth).toBe(1);
         });

--- a/test/integration/components/element-component.test.ts
+++ b/test/integration/components/element-component.test.ts
@@ -1,0 +1,159 @@
+import type { ElementComponent } from 'playcanvas';
+import { Color, Entity, Vec2, Vec4 } from 'playcanvas';
+import { describe, expect, it } from 'vitest';
+
+import type { ElementComponentElement } from '../../../src/components/element-component';
+import { bootApp } from '../../helpers/app';
+import { useGuard } from '../../helpers/guard';
+
+/**
+ * An image element: the engine only reports color, opacity, mask and sprite frame through an
+ * image or text element, and a text element needs a font before it exists. Text-only attributes
+ * (auto-width, font-size, wrap-lines, ...) are therefore not in the table.
+ */
+const scene = (elementAttributes = '') =>
+    `<pc-entity name="el"><pc-element type="image" ${elementAttributes}></pc-element></pc-entity>`;
+
+/** Reads an engine component property named by a table row. */
+const engineValue = (component: ElementComponent, property: string) =>
+    (component as unknown as Record<string, unknown>)[property];
+
+/**
+ * One row per attribute an image element reports: the attribute, the engine property behind it,
+ * a non-default value, what the engine must report for it, and the default that removal must
+ * restore. Ordered by `observedAttributes`.
+ *
+ * The anchor used to default to the center, which is the Editor's convention; it is the engine's
+ * bottom-left corner now, and `matches an element the engine built itself` below holds it there.
+ */
+const cases: [attribute: string, property: string, value: string, expected: unknown, restored: unknown][] = [
+    // A point anchor rather than a split one: split anchors size the element from the parent, which
+    // would override the width and height rows when every attribute is applied at once
+    ['anchor', 'anchor', '1 1 1 1', new Vec4(1, 1, 1, 1), new Vec4(0, 0, 0, 0)],
+    ['color', 'color', '1 0 0', new Color(1, 0, 0), new Color(1, 1, 1, 1)],
+    ['height', 'height', '50', 50, 0],
+    ['mask', 'mask', '', true, false],
+    // [opacity] is covered on its own below: the engine reports it as the color's alpha, so a row
+    // here would change what the color row reads back
+    ['pivot', 'pivot', '0 1', new Vec2(0, 1), new Vec2(0.5, 0.5)],
+    ['sprite-frame', 'spriteFrame', '2', 2, 0],
+    ['use-input', 'useInput', '', true, false],
+    ['width', 'width', '80', 80, 0]
+];
+
+/**
+ * Defaults that still differ from a bare engine element - the Editor's conventions rather than
+ * the engine's: a centered pivot, and a zero size, where the engine gives an element 32 units a
+ * side. Whether they stay is a release decision; until it is made they are listed here, so the
+ * divergence is visible rather than hidden in a filtered comparison.
+ */
+const editorDefaults = new Set(['pivot', 'width', 'height']);
+
+describe('<pc-element>', () => {
+    useGuard();
+
+    describe('#component', () => {
+        it('creates the element component with the expected defaults', async () => {
+            const { get } = await bootApp(scene());
+            const component = get<ElementComponentElement>('pc-element').component!;
+
+            expect(component).toBeDefined();
+            expect(component.enabled).toBe(true);
+            expect(component.type).toBe('image');
+
+            for (const [attribute, property, , , restored] of cases) {
+                expect.soft(engineValue(component, property), attribute).toEqual(restored);
+            }
+        });
+
+        it('matches an element the engine built itself', async () => {
+            const { app, get } = await bootApp(scene());
+            const element = get<ElementComponentElement>('pc-element').component!;
+
+            // Every property the element writes, compared against a component built from nothing
+            // but its type, so a default drifting on either side shows up here.
+            const bare = new Entity('bare', app);
+            app.root.addChild(bare);
+            const engine = bare.addComponent('element', { type: 'image' }) as ElementComponent;
+
+            for (const [attribute, property] of cases) {
+                if (editorDefaults.has(property)) {
+                    continue;
+                }
+                expect
+                    .soft(engineValue(element, property), `${attribute} vs a bare engine element`)
+                    .toEqual(engineValue(engine, property));
+            }
+        });
+
+        it('keeps the listed Editor-convention defaults, and only those', async () => {
+            const { app, get } = await bootApp(scene());
+            const element = get<ElementComponentElement>('pc-element').component!;
+
+            const bare = new Entity('bare', app);
+            app.root.addChild(bare);
+            const engine = bare.addComponent('element', { type: 'image' }) as ElementComponent;
+
+            // Pinned both ways: a default aligned with the engine must leave this set, and a new
+            // divergence must be added to it deliberately.
+            for (const [attribute, property] of cases) {
+                const differs =
+                    JSON.stringify(engineValue(element, property)) !== JSON.stringify(engineValue(engine, property));
+                expect.soft(differs, `${attribute} differs from the engine`).toBe(editorDefaults.has(property));
+            }
+        });
+
+        it('defaults to a group element', async () => {
+            const { get } = await bootApp('<pc-entity name="el"><pc-element></pc-element></pc-entity>');
+
+            expect(get<ElementComponentElement>('pc-element').component!.type).toBe('group');
+        });
+    });
+
+    describe('attributes', () => {
+        it('applies every declarative attribute through the initial component data', async () => {
+            const markup = cases
+                .map(([attribute, , value]) => (value === '' ? attribute : `${attribute}="${value}"`))
+                .join(' ');
+            const { get } = await bootApp(scene(markup));
+            const component = get<ElementComponentElement>('pc-element').component!;
+
+            for (const [attribute, property, , expected] of cases) {
+                expect.soft(engineValue(component, property), attribute).toEqual(expected);
+            }
+        });
+
+        it('writes attribute changes through to the component', async () => {
+            const { get } = await bootApp(scene());
+            const element = get<ElementComponentElement>('pc-element');
+
+            for (const [attribute, property, value, expected] of cases) {
+                element.setAttribute(attribute, value);
+                expect.soft(engineValue(element.component!, property), attribute).toEqual(expected);
+            }
+        });
+
+        it('restores the default when an attribute is removed', async () => {
+            const { get } = await bootApp(scene());
+            const element = get<ElementComponentElement>('pc-element');
+
+            for (const [attribute, property, value, , restored] of cases) {
+                element.setAttribute(attribute, value);
+                element.removeAttribute(attribute);
+                expect.soft(engineValue(element.component!, property), attribute).toEqual(restored);
+            }
+        });
+
+        it('writes opacity through, which the engine mirrors in the color alpha', async () => {
+            const { get } = await bootApp(scene('opacity="0.5"'));
+            const element = get<ElementComponentElement>('pc-element');
+
+            expect(element.component!.opacity).toBe(0.5);
+            expect(element.component!.color.a, 'the image color carries the opacity').toBe(0.5);
+
+            element.removeAttribute('opacity');
+            expect(element.component!.opacity).toBe(1);
+            expect(element.component!.color).toEqual(new Color(1, 1, 1, 1));
+        });
+    });
+});

--- a/test/integration/components/element-component.test.ts
+++ b/test/integration/components/element-component.test.ts
@@ -23,37 +23,30 @@ const engineValue = (component: ElementComponent, property: string) =>
  * a non-default value, what the engine must report for it, and the default that removal must
  * restore. Ordered by `observedAttributes`.
  *
- * The anchor used to default to the center, which is the Editor's convention; it is the engine's
- * bottom-left corner now, and `matches an element the engine built itself` below holds it there.
+ * Every `restored` value is the engine's own default. The anchor and pivot used to default to the
+ * center and the size to zero - the Editor's conventions - which is what `matches an element the
+ * engine built itself` below now holds them to.
  */
 const cases: [attribute: string, property: string, value: string, expected: unknown, restored: unknown][] = [
     // A point anchor rather than a split one: split anchors size the element from the parent, which
     // would override the width and height rows when every attribute is applied at once
     ['anchor', 'anchor', '1 1 1 1', new Vec4(1, 1, 1, 1), new Vec4(0, 0, 0, 0)],
     ['color', 'color', '1 0 0', new Color(1, 0, 0), new Color(1, 1, 1, 1)],
-    ['height', 'height', '50', 50, 0],
+    ['height', 'height', '50', 50, 32],
     ['mask', 'mask', '', true, false],
     // [opacity] is covered on its own below: the engine reports it as the color's alpha, so a row
     // here would change what the color row reads back
-    ['pivot', 'pivot', '0 1', new Vec2(0, 1), new Vec2(0.5, 0.5)],
+    ['pivot', 'pivot', '0.5 1', new Vec2(0.5, 1), new Vec2(0, 0)],
     ['sprite-frame', 'spriteFrame', '2', 2, 0],
     ['use-input', 'useInput', '', true, false],
-    ['width', 'width', '80', 80, 0]
+    ['width', 'width', '80', 80, 32]
 ];
-
-/**
- * Defaults that still differ from a bare engine element - the Editor's conventions rather than
- * the engine's: a centered pivot, and a zero size, where the engine gives an element 32 units a
- * side. Whether they stay is a release decision; until it is made they are listed here, so the
- * divergence is visible rather than hidden in a filtered comparison.
- */
-const editorDefaults = new Set(['pivot', 'width', 'height']);
 
 describe('<pc-element>', () => {
     useGuard();
 
     describe('#component', () => {
-        it('creates the element component with the expected defaults', async () => {
+        it('creates the element component with the engine defaults', async () => {
             const { get } = await bootApp(scene());
             const component = get<ElementComponentElement>('pc-element').component!;
 
@@ -77,29 +70,9 @@ describe('<pc-element>', () => {
             const engine = bare.addComponent('element', { type: 'image' }) as ElementComponent;
 
             for (const [attribute, property] of cases) {
-                if (editorDefaults.has(property)) {
-                    continue;
-                }
                 expect
                     .soft(engineValue(element, property), `${attribute} vs a bare engine element`)
                     .toEqual(engineValue(engine, property));
-            }
-        });
-
-        it('keeps the listed Editor-convention defaults, and only those', async () => {
-            const { app, get } = await bootApp(scene());
-            const element = get<ElementComponentElement>('pc-element').component!;
-
-            const bare = new Entity('bare', app);
-            app.root.addChild(bare);
-            const engine = bare.addComponent('element', { type: 'image' }) as ElementComponent;
-
-            // Pinned both ways: a default aligned with the engine must leave this set, and a new
-            // divergence must be added to it deliberately.
-            for (const [attribute, property] of cases) {
-                const differs =
-                    JSON.stringify(engineValue(element, property)) !== JSON.stringify(engineValue(engine, property));
-                expect.soft(differs, `${attribute} differs from the engine`).toBe(editorDefaults.has(property));
             }
         });
 

--- a/test/integration/components/layout-group-component.test.ts
+++ b/test/integration/components/layout-group-component.test.ts
@@ -1,0 +1,113 @@
+import type { LayoutGroupComponent } from 'playcanvas';
+import {
+    Entity,
+    FITTING_NONE,
+    FITTING_SHRINK,
+    FITTING_STRETCH,
+    ORIENTATION_HORIZONTAL,
+    ORIENTATION_VERTICAL,
+    Vec2,
+    Vec4
+} from 'playcanvas';
+import { describe, expect, it } from 'vitest';
+
+import type { LayoutGroupComponentElement } from '../../../src/components/layout-group-component';
+import { bootApp } from '../../helpers/app';
+import { useGuard } from '../../helpers/guard';
+
+const scene = (groupAttributes = '') =>
+    `<pc-entity name="group"><pc-layout-group ${groupAttributes}></pc-layout-group></pc-entity>`;
+
+/** Reads an engine component property named by a table row. */
+const engineValue = (component: LayoutGroupComponent, property: string) =>
+    (component as unknown as Record<string, unknown>)[property];
+
+/**
+ * One row per attribute: the attribute, the engine property behind it, a non-default value, what
+ * the engine must report for it, and the default that removal must restore. Ordered by
+ * `observedAttributes`.
+ *
+ * Every `restored` value is the engine's own default. reverse-y used to default to false, which
+ * is what `matches a layout group the engine built itself` below now holds it to.
+ */
+const cases: [attribute: string, property: string, value: string, expected: unknown, restored: unknown][] = [
+    ['orientation', 'orientation', 'vertical', ORIENTATION_VERTICAL, ORIENTATION_HORIZONTAL],
+    ['reverse-x', 'reverseX', '', true, false],
+    ['reverse-y', 'reverseY', 'false', false, true],
+    ['alignment', 'alignment', '0.5 0.5', new Vec2(0.5, 0.5), new Vec2(0, 1)],
+    ['padding', 'padding', '1 2 3 4', new Vec4(1, 2, 3, 4), new Vec4(0, 0, 0, 0)],
+    ['spacing', 'spacing', '5 6', new Vec2(5, 6), new Vec2(0, 0)],
+    ['width-fitting', 'widthFitting', 'stretch', FITTING_STRETCH, FITTING_NONE],
+    ['height-fitting', 'heightFitting', 'shrink', FITTING_SHRINK, FITTING_NONE],
+    ['wrap', 'wrap', '', true, false]
+];
+
+describe('<pc-layout-group>', () => {
+    useGuard();
+
+    describe('#component', () => {
+        it('creates the layout group component with the engine defaults', async () => {
+            const { get } = await bootApp(scene());
+            const component = get<LayoutGroupComponentElement>('pc-layout-group').component!;
+
+            expect(component).toBeDefined();
+            expect(component.enabled).toBe(true);
+
+            for (const [attribute, property, , , restored] of cases) {
+                expect.soft(engineValue(component, property), attribute).toEqual(restored);
+            }
+        });
+
+        it('matches a layout group the engine built itself', async () => {
+            const { app, get } = await bootApp(scene());
+            const element = get<LayoutGroupComponentElement>('pc-layout-group').component!;
+
+            // Every property the element writes, compared against a component built from no data
+            // at all, so a default drifting on either side shows up here.
+            const bare = new Entity('bare', app);
+            app.root.addChild(bare);
+            const engine = bare.addComponent('layoutgroup') as LayoutGroupComponent;
+
+            for (const [attribute, property] of cases) {
+                expect
+                    .soft(engineValue(element, property), `${attribute} vs a bare engine layout group`)
+                    .toEqual(engineValue(engine, property));
+            }
+        });
+    });
+
+    describe('attributes', () => {
+        it('applies every declarative attribute through the initial component data', async () => {
+            const markup = cases
+                .map(([attribute, , value]) => (value === '' ? attribute : `${attribute}="${value}"`))
+                .join(' ');
+            const { get } = await bootApp(scene(markup));
+            const component = get<LayoutGroupComponentElement>('pc-layout-group').component!;
+
+            for (const [attribute, property, , expected] of cases) {
+                expect.soft(engineValue(component, property), attribute).toEqual(expected);
+            }
+        });
+
+        it('writes attribute changes through to the component', async () => {
+            const { get } = await bootApp(scene());
+            const group = get<LayoutGroupComponentElement>('pc-layout-group');
+
+            for (const [attribute, property, value, expected] of cases) {
+                group.setAttribute(attribute, value);
+                expect.soft(engineValue(group.component!, property), attribute).toEqual(expected);
+            }
+        });
+
+        it('restores the engine default when an attribute is removed', async () => {
+            const { get } = await bootApp(scene());
+            const group = get<LayoutGroupComponentElement>('pc-layout-group');
+
+            for (const [attribute, property, value, , restored] of cases) {
+                group.setAttribute(attribute, value);
+                group.removeAttribute(attribute);
+                expect.soft(engineValue(group.component!, property), attribute).toEqual(restored);
+            }
+        });
+    });
+});

--- a/test/integration/components/render-component.test.ts
+++ b/test/integration/components/render-component.test.ts
@@ -1,0 +1,48 @@
+import type { RenderComponent } from 'playcanvas';
+import { Entity } from 'playcanvas';
+import { describe, expect, it } from 'vitest';
+
+import type { RenderComponentElement } from '../../../src/components/render-component';
+import { bootApp } from '../../helpers/app';
+import { useGuard } from '../../helpers/guard';
+
+const scene = (renderAttributes = '') =>
+    `<pc-entity name="shape"><pc-render ${renderAttributes}></pc-render></pc-entity>`;
+
+describe('<pc-render>', () => {
+    useGuard();
+
+    describe('#component', () => {
+        it('defaults to a box, which is the one default that departs from the engine on purpose', async () => {
+            const { app, get } = await bootApp(scene());
+            const component = get<RenderComponentElement>('pc-render').component!;
+
+            // The engine's default type is 'asset', which draws nothing without one. This element
+            // exists to place primitives - assets go through <pc-model> - so a bare <pc-render>
+            // is a box. Every other property it writes matches a bare engine component.
+            const bare = new Entity('bare', app);
+            app.root.addChild(bare);
+            const engine = bare.addComponent('render') as RenderComponent;
+
+            expect(component.type).toBe('box');
+            expect(engine.type).toBe('asset');
+            expect(component.castShadows).toBe(engine.castShadows);
+            expect(component.receiveShadows).toBe(engine.receiveShadows);
+        });
+
+        it('leaves the material at the engine default when none is named', async () => {
+            const { app, get } = await bootApp(scene());
+            const component = get<RenderComponentElement>('pc-render').component!;
+
+            // Passing an unresolved material through the initial data would set the component's
+            // material to undefined; the meshes would still draw with the default material, but
+            // the component would no longer say so
+            const bare = new Entity('bare', app);
+            app.root.addChild(bare);
+            const engine = bare.addComponent('render') as RenderComponent;
+
+            expect(component.material).toBe(engine.material);
+            expect(component.meshInstances[0].material).toBe(engine.material);
+        });
+    });
+});

--- a/test/integration/components/scroll-view-component.test.ts
+++ b/test/integration/components/scroll-view-component.test.ts
@@ -1,3 +1,5 @@
+import type { ScrollViewComponent } from 'playcanvas';
+import { Entity, SCROLLBAR_VISIBILITY_SHOW_ALWAYS, SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED } from 'playcanvas';
 import { describe, expect, it } from 'vitest';
 
 import type { ScrollViewComponentElement } from '../../../src/components/scroll-view-component';
@@ -54,5 +56,44 @@ describe('<pc-scroll-view>', () => {
         // test if anything warns
         expect(scrollView.component!.viewportEntity).toBeNull();
         expect(scrollView.component!.contentEntity).toBeNull();
+    });
+
+    describe('scrollbar visibility', () => {
+        const attributes = ['horizontal-scrollbar-visibility', 'vertical-scrollbar-visibility'] as const;
+        const properties = ['horizontalScrollbarVisibility', 'verticalScrollbarVisibility'] as const;
+
+        it("defaults both to the engine's, showing the scrollbars always", async () => {
+            const { app, get } = await bootApp('<pc-entity name="sv"><pc-scroll-view></pc-scroll-view></pc-entity>');
+            const component = get<ScrollViewComponentElement>('pc-scroll-view').component!;
+
+            // The other scroll settings (horizontal, vertical, scroll-mode, bounce-amount,
+            // friction) have no engine default at all - a bare engine component leaves them
+            // undefined - so these two are the ones a bare component can be held to.
+            const bare = new Entity('bare', app);
+            app.root.addChild(bare);
+            const engine = bare.addComponent('scrollview') as ScrollViewComponent;
+
+            for (const property of properties) {
+                expect.soft(component[property], property).toBe(SCROLLBAR_VISIBILITY_SHOW_ALWAYS);
+                expect.soft(component[property], `${property} vs a bare engine scroll view`).toBe(engine[property]);
+            }
+        });
+
+        it('writes each through and restores the default on removal', async () => {
+            const { get } = await bootApp('<pc-entity name="sv"><pc-scroll-view></pc-scroll-view></pc-entity>');
+            const scrollView = get<ScrollViewComponentElement>('pc-scroll-view');
+
+            attributes.forEach((attribute, i) => {
+                scrollView.setAttribute(attribute, 'when-required');
+                expect
+                    .soft(scrollView.component![properties[i]], attribute)
+                    .toBe(SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED);
+
+                scrollView.removeAttribute(attribute);
+                expect
+                    .soft(scrollView.component![properties[i]], `${attribute} restored`)
+                    .toBe(SCROLLBAR_VISIBILITY_SHOW_ALWAYS);
+            });
+        });
     });
 });

--- a/test/integration/components/scrollbar-component.test.ts
+++ b/test/integration/components/scrollbar-component.test.ts
@@ -1,3 +1,5 @@
+import type { ScrollbarComponent } from 'playcanvas';
+import { Entity } from 'playcanvas';
 import { describe, expect, it } from 'vitest';
 
 import type { ScrollbarComponentElement } from '../../../src/components/scrollbar-component';
@@ -26,10 +28,14 @@ describe('<pc-scrollbar>', () => {
         });
 
         it('warns when the reference does not resolve, leaving the handle unset', async () => {
-            const { get } = await bootApp('<pc-entity name="track"><pc-scrollbar handle="#nope"></pc-scrollbar></pc-entity>');
+            const { get } = await bootApp(
+                '<pc-entity name="track"><pc-scrollbar handle="#nope"></pc-scrollbar></pc-entity>'
+            );
             const scrollbar = get<ScrollbarComponentElement>('pc-scrollbar');
 
-            warnings.expect("pc-scrollbar could not resolve handle '#nope' - nothing in the document matches it - reference ignored");
+            warnings.expect(
+                "pc-scrollbar could not resolve handle '#nope' - nothing in the document matches it - reference ignored"
+            );
             expect(scrollbar.component!.handleEntity).toBeNull();
         });
 
@@ -46,6 +52,33 @@ describe('<pc-scrollbar>', () => {
 
             warnings.expect("pc-scrollbar could not resolve handle '#still-nope'");
             expect(scrollbar.component!.handleEntity).toBe(app.root.findByName('handle'));
+        });
+    });
+
+    describe('[handle-size]', () => {
+        it("defaults to the engine's zero-length handle", async () => {
+            const { app, get } = await bootApp('<pc-entity name="sb"><pc-scrollbar></pc-scrollbar></pc-entity>');
+            const component = get<ScrollbarComponentElement>('pc-scrollbar').component!;
+
+            // The engine's default is degenerate - no handle until the page sizes one - but it is
+            // the engine's; it used to be 0.5 here.
+            const bare = new Entity('bare', app);
+            app.root.addChild(bare);
+            const engine = bare.addComponent('scrollbar') as ScrollbarComponent;
+
+            expect(component.handleSize).toBe(0);
+            expect(component.handleSize).toBe(engine.handleSize);
+        });
+
+        it('writes through and restores the default on removal', async () => {
+            const { get } = await bootApp('<pc-entity name="sb"><pc-scrollbar></pc-scrollbar></pc-entity>');
+            const scrollbar = get<ScrollbarComponentElement>('pc-scrollbar');
+
+            scrollbar.setAttribute('handle-size', '0.5');
+            expect(scrollbar.component!.handleSize).toBe(0.5);
+
+            scrollbar.removeAttribute('handle-size');
+            expect(scrollbar.component!.handleSize).toBe(0);
         });
     });
 });

--- a/test/integration/components/sound-component.test.ts
+++ b/test/integration/components/sound-component.test.ts
@@ -1,0 +1,99 @@
+import type { SoundComponent } from 'playcanvas';
+import { DISTANCE_INVERSE, DISTANCE_LINEAR, Entity } from 'playcanvas';
+import { describe, expect, it } from 'vitest';
+
+import type { SoundComponentElement } from '../../../src/components/sound-component';
+import { bootApp } from '../../helpers/app';
+import { useGuard } from '../../helpers/guard';
+
+const scene = (soundAttributes = '') => `<pc-entity name="sound"><pc-sound ${soundAttributes}></pc-sound></pc-entity>`;
+
+/** Reads an engine component property named by a table row. */
+const engineValue = (component: SoundComponent, property: string) =>
+    (component as unknown as Record<string, unknown>)[property];
+
+/**
+ * One row per attribute: the attribute, the engine property behind it, a non-default value, what
+ * the engine must report for it, and the default that removal must restore. Ordered by
+ * `observedAttributes`. The slots are `<pc-sound-slot>` children and covered in their own suite.
+ *
+ * Every `restored` value is the engine's own default. positional used to default to false, which
+ * is what `matches a sound component the engine built itself` below now holds it to.
+ */
+const cases: [attribute: string, property: string, value: string, expected: unknown, restored: unknown][] = [
+    ['distance-model', 'distanceModel', 'inverse', DISTANCE_INVERSE, DISTANCE_LINEAR],
+    ['max-distance', 'maxDistance', '50', 50, 10000],
+    ['pitch', 'pitch', '1.5', 1.5, 1],
+    ['positional', 'positional', 'false', false, true],
+    ['ref-distance', 'refDistance', '2', 2, 1],
+    ['roll-off-factor', 'rollOffFactor', '0.5', 0.5, 1],
+    ['volume', 'volume', '0.25', 0.25, 1]
+];
+
+describe('<pc-sound>', () => {
+    useGuard();
+
+    describe('#component', () => {
+        it('creates the sound component with the engine defaults', async () => {
+            const { get } = await bootApp(scene());
+            const component = get<SoundComponentElement>('pc-sound').component!;
+
+            expect(component).toBeDefined();
+            expect(component.enabled).toBe(true);
+
+            for (const [attribute, property, , , restored] of cases) {
+                expect.soft(engineValue(component, property), attribute).toEqual(restored);
+            }
+        });
+
+        it('matches a sound component the engine built itself', async () => {
+            const { app, get } = await bootApp(scene());
+            const element = get<SoundComponentElement>('pc-sound').component!;
+
+            // Every property the element writes, compared against a component built from no data
+            // at all, so a default drifting on either side shows up here.
+            const bare = new Entity('bare', app);
+            app.root.addChild(bare);
+            const engine = bare.addComponent('sound') as SoundComponent;
+
+            for (const [attribute, property] of cases) {
+                expect
+                    .soft(engineValue(element, property), `${attribute} vs a bare engine sound component`)
+                    .toEqual(engineValue(engine, property));
+            }
+        });
+    });
+
+    describe('attributes', () => {
+        it('applies every declarative attribute through the initial component data', async () => {
+            const markup = cases.map(([attribute, , value]) => `${attribute}="${value}"`).join(' ');
+            const { get } = await bootApp(scene(markup));
+            const component = get<SoundComponentElement>('pc-sound').component!;
+
+            for (const [attribute, property, , expected] of cases) {
+                expect.soft(engineValue(component, property), attribute).toEqual(expected);
+            }
+        });
+
+        it('writes attribute changes through to the component', async () => {
+            const { get } = await bootApp(scene());
+            const sound = get<SoundComponentElement>('pc-sound');
+
+            for (const [attribute, property, value, expected] of cases) {
+                sound.setAttribute(attribute, value);
+                expect.soft(engineValue(sound.component!, property), attribute).toEqual(expected);
+            }
+        });
+
+        it('restores the engine default when an attribute is removed', async () => {
+            const { get } = await bootApp(scene());
+            const sound = get<SoundComponentElement>('pc-sound');
+
+            for (const [attribute, property, value, , restored] of cases) {
+                sound.setAttribute(attribute, value);
+                sound.removeAttribute(attribute);
+                expect.soft(engineValue(sound.component!, property), attribute).toEqual(restored);
+            }
+        });
+    });
+});

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -111,7 +111,10 @@ if (manifest) {
     check(Boolean(attribute('pc-entity', 'position')?.description), 'pc-entity[position] has no description');
     check(Boolean(attribute('pc-model', 'position')?.description), 'pc-model[position] has no description');
     expectAttribute('pc-button', 'hit-padding', { default: '0 0 0 0' });
-    expectAttribute('pc-button', 'hover-tint', { default: '1 1 1' });
+    expectAttribute('pc-button', 'hover-tint', { default: '0.75 0.75 0.75 1' });
+    expectAttribute('pc-button', 'pressed-tint', { default: '0.5 0.5 0.5 1' });
+    expectAttribute('pc-button', 'inactive-tint', { default: '0.25 0.25 0.25 1' });
+    expectAttribute('pc-element', 'anchor', { default: '0 0 0 0' });
     expectAttribute('pc-collision', 'angular-offset', { default: '0 0 0' });
 
     // A `null` default means "leave the engine value alone", so it is omitted

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -118,6 +118,9 @@ if (manifest) {
     expectAttribute('pc-element', 'pivot', { default: '0 0' });
     expectAttribute('pc-element', 'width', { type: 'number', default: '32', fieldName: 'width' });
     expectAttribute('pc-element', 'height', { default: '32' });
+    expectAttribute('pc-layout-group', 'reverse-y', { type: 'boolean', default: 'true', fieldName: 'reverseY' });
+    expectAttribute('pc-sound', 'positional', { type: 'boolean', default: 'true', fieldName: 'positional' });
+    expectAttribute('pc-scrollbar', 'handle-size', { type: 'number', default: '0', fieldName: 'handleSize' });
     expectAttribute('pc-collision', 'angular-offset', { default: '0 0 0' });
 
     // A `null` default means "leave the engine value alone", so it is omitted
@@ -177,10 +180,11 @@ if (manifest) {
     // Enums resolved from an inline array, and from a module-scope Map
     expectEnum('pc-render', 'type', 6, 'box');
     expectEnum('pc-light', 'type', 3, 'directional');
-    expectEnum('pc-camera', 'tonemap', 7, 'none');
+    expectEnum('pc-camera', 'tonemap', 7, 'linear');
     expectEnum('pc-light', 'shadow-type', 9, 'pcf3-32f');
     expectEnum('pc-light', 'shape', 4, 'punctual');
-    expectEnum('pc-scroll-view', 'horizontal-scrollbar-visibility', 2, 'when-required');
+    expectEnum('pc-scroll-view', 'horizontal-scrollbar-visibility', 2, 'always');
+    expectEnum('pc-scroll-view', 'vertical-scrollbar-visibility', 2, 'always');
 
     // An area light shape renders wrong until <pc-app> has loaded the lookup tables, so its tooltip
     // has to point at the attribute that does that

--- a/utils/cem/validate.mjs
+++ b/utils/cem/validate.mjs
@@ -115,6 +115,9 @@ if (manifest) {
     expectAttribute('pc-button', 'pressed-tint', { default: '0.5 0.5 0.5 1' });
     expectAttribute('pc-button', 'inactive-tint', { default: '0.25 0.25 0.25 1' });
     expectAttribute('pc-element', 'anchor', { default: '0 0 0 0' });
+    expectAttribute('pc-element', 'pivot', { default: '0 0' });
+    expectAttribute('pc-element', 'width', { type: 'number', default: '32', fieldName: 'width' });
+    expectAttribute('pc-element', 'height', { default: '32' });
     expectAttribute('pc-collision', 'angular-offset', { default: '0 0 0' });
 
     // A `null` default means "leave the engine value alone", so it is omitted


### PR DESCRIPTION
## What

Every component element now writes the engine's own defaults. Thirteen values that were the element's own become the engine's:

| Element | Attribute | Was | Now |
|---|---|---|---|
| `pc-button` | `hover-tint` | `1 1 1 1` | `0.75 0.75 0.75 1` |
| `pc-button` | `pressed-tint` | `1 1 1 1` | `0.5 0.5 0.5 1` |
| `pc-button` | `inactive-tint` | `1 1 1 1` | `0.25 0.25 0.25 1` |
| `pc-element` | `anchor` | `0.5 0.5 0.5 0.5` | `0 0 0 0` |
| `pc-element` | `pivot` | `0.5 0.5` | `0 0` |
| `pc-element` | `width` | `0` | `32` |
| `pc-element` | `height` | `0` | `32` |
| `pc-camera` | `tonemap` | `none` | `linear` |
| `pc-layout-group` | `reverse-y` | `false` | `true` |
| `pc-sound` | `positional` | `false` | `true` |
| `pc-scroll-view` | `horizontal-scrollbar-visibility` | `when-required` | `always` |
| `pc-scroll-view` | `vertical-scrollbar-visibility` | `when-required` | `always` |
| `pc-scrollbar` | `handle-size` | `0.5` | `0` |

The list is complete: a sweep booted each component element with no attributes and compared every property it writes against a component the engine builds from no data. What remains different is deliberate and documented in the tests: `pc-render` defaults to a box (the engine's `asset` draws nothing without one, and this element exists to place primitives), and `pc-button` defaults its `image` to its own entity. `pc-scroll-view`'s horizontal, vertical, scroll-mode, bounce-amount and friction have no engine default at all (undefined on a bare component), so the element's values stay.

## Why

Same call as #411 and #412: no library-side defaults that differ from the engine, expose the attribute and let the page opt in. Pre-1.0 is the free window, and 0.23.0 is meant to be the surface-final release.

Two of these deserve a word:

- **`tonemap`** was kept at `none` deliberately in #411, because `none` and `linear` only differ once the scene exposure leaves 1, which no attribute could reach. #417 then added `pc-scene[exposure]`, and with `none` it was silently inert on a default camera. At exposure 1 the two still render identically, so no existing page changes, and `exposure` now works everywhere.
- **`handle-size`**'s engine default is a zero-length handle, which is degenerate, but it is the engine's, and the Scroll View example already sizes its handle.

## Notes for review

- Removal defaults in `attributeChangedCallback` move with the fields. That is also where the CEM plugin reads manifest defaults from, so `custom-elements.json` now publishes the engine values; `validate.mjs` pins all thirteen and the setter docs state them.
- **Tests.** `pc-button`, `pc-element`, `pc-layout-group`, `pc-sound` and `pc-render` gain suites on the light-component pattern, each ending in a comparison against a component the engine builds from no data; `pc-camera`, `pc-scroll-view` and `pc-scrollbar`'s existing suites take the new defaults. The element suite is image-typed because the engine only reports color, mask and sprite frame through an image or text element; opacity has its own test because the engine reports it as the image color's alpha; its anchor row is a point anchor because a split one would override the width/height rows.
- **Tidy-up.** `pc-render` stops passing an unresolved material through the initial data, which set the component's `material` to `undefined` where the engine's reads the default material. The meshes drew with the default material either way.
- **Examples.** 2D Screen's three texts, Falling Blocks' marquee and Text's crawl relied on the centered anchor/pivot and now say so; Basic Sound and Falling Blocks play 2D sounds and now say `positional="false"`; Scroll View's bare scrollbar-handle `<pc-button>` gains the engine's gray hover/pressed feedback. Nothing else relied on the old values: every other camera sets its tonemap or runs under cameraFrame, both layout groups that need `reverse-y` set it, and Scroll View sets its visibility and handle size. UI Layout's one horizontal group without `reverse-y` lays out identically.
- The developer-site tag pages list the old defaults and need updating once the release is on jsDelivr.

## Verification

`npm run build` (manifest pins), `npm run lint`, `npm run type-check` and `npm test` pass. 2D Screen, Falling Blocks, Text and UI Layout checked in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
